### PR TITLE
Bootstrap using the current snapshot (no longer from scratch)

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -6,42 +6,48 @@
 all: boot
 .PHONY: all
 
-# Step 1: we build the initial plugin and the Steel and Pulse library
-# as they are now, and then we blast all generated files
-
-.PHONY: initial-build
-initial-build:
+.PHONY: build
+build:
 	+$(MAKE) -C .. all
-	rm -rf ocaml/*/generated ../include/steel/Steel_SpinLock.h
+
+# Extraction rules assume that a snapshot has already been compiled.
 
 .PHONY: extract-ocaml
 extract-ocaml: extract-steel-plugin extract-extraction extract-pulse-plugin
 
 .PHONY: extract-steel-plugin
-extract-steel-plugin: initial-build
+extract-steel-plugin:
 	+$(MAKE) -C ocaml/plugin -f extract-steel.Makefile
 
 .PHONY: extract-pulse-plugin
-extract-pulse-plugin: initial-build
+extract-pulse-plugin:
 	+$(MAKE) -C ocaml/plugin -f extract-pulse.Makefile
 
 .PHONY: extract-extraction
-extract-extraction: initial-build
+extract-extraction:
 	+$(MAKE) -C extraction
 
 .PHONY: extract-c
-extract-c: initial-build
+extract-c:
 	+$(MAKE) -C c extract
 
 .PHONY: extract
 extract: extract-ocaml extract-c
 
 .PHONY: boot
-boot: extract
-	+$(MAKE) -C .. all
+boot:
+	+$(MAKE) extract
+	+$(MAKE) build
+
+.PHONY: clean-snapshot
+clean-snapshot:
+	rm -rf ocaml/*/generated ../include/steel/Steel_SpinLock.h
 
 .PHONY: full-boot
-full-boot: boot
+full-boot:
+	+$(MAKE) build
+	+$(MAKE) clean-snapshot
+	+$(MAKE) boot
 
 .PHONY: proofs
 proofs:

--- a/src/Makefile
+++ b/src/Makefile
@@ -6,41 +6,31 @@
 all: boot
 .PHONY: all
 
+# Step 1: we build the initial plugin and the Steel and Pulse library
+# as they are now, and then we blast all generated files
+
+.PHONY: initial-build
+initial-build:
+	+$(MAKE) -C .. all
+	rm -rf ocaml/*/generated ../include/steel/Steel_SpinLock.h
+
 .PHONY: extract-ocaml
 extract-ocaml: extract-steel-plugin extract-extraction extract-pulse-plugin
 
 .PHONY: extract-steel-plugin
-extract-steel-plugin:
+extract-steel-plugin: initial-build
 	+$(MAKE) -C ocaml/plugin -f extract-steel.Makefile
 
 .PHONY: extract-pulse-plugin
-extract-pulse-plugin: rebuild-and-verify-steel
+extract-pulse-plugin: initial-build
 	+$(MAKE) -C ocaml/plugin -f extract-pulse.Makefile
 
 .PHONY: extract-extraction
-extract-extraction:
+extract-extraction: initial-build
 	+$(MAKE) -C extraction
 
-# NOTE: while verification of Steel does not in itself need extracting
-# the krml extraction rules, the following `rebuild-and-verify-steel`
-# rule also recompiles the Steel plugin, so it is not possible to
-# extract the extraction rules in parallel with this rule. Adding a
-# dependency on `extract-extraction` is one way to solve this
-# problem. This solution also solves 2 more problems:
-#
-# * the Steel plugin is recompiled 2 times instead of 3: once instead
-#   of twice for Steel + extraction with this rule, in addition to the
-#   one time for Pulse with the `boot` rule.
-#
-# * extracting LibSteel may need the krml extraction rules compiled
-#   into the Steel plugin
-
-.PHONY: rebuild-and-verify-steel
-rebuild-and-verify-steel: extract-steel-plugin extract-extraction
-	+$(MAKE) -C .. verify-steel
-
 .PHONY: extract-c
-extract-c: rebuild-and-verify-steel
+extract-c: initial-build
 	+$(MAKE) -C c extract
 
 .PHONY: extract
@@ -51,9 +41,7 @@ boot: extract
 	+$(MAKE) -C .. all
 
 .PHONY: full-boot
-full-boot:
-	rm -rf ocaml/*/generated ../include/steel/Steel_SpinLock.h
-	+$(MAKE) boot
+full-boot: boot
 
 .PHONY: proofs
 proofs:

--- a/src/ocaml/plugin/extract-pulse.Makefile
+++ b/src/ocaml/plugin/extract-pulse.Makefile
@@ -14,7 +14,7 @@ endif
 
 FSTAR_FILES:=$(wildcard $(LIB_PULSE)/*.fst $(LIB_PULSE)/*.fsti)
 
-MY_FSTAR=$(RUNLIM) $(FSTAR) $(SIL) $(OTHERFLAGS) --include $(LIB_STEEL) --include $(LIB_PULSE) --cache_checked_modules --odir $(OUTPUT_DIRECTORY) --warn_error @241 --already_cached '*,-Pulse' --load_cmxs steel
+MY_FSTAR=$(RUNLIM) $(FSTAR) $(SIL) $(OTHERFLAGS) --include $(LIB_STEEL) --include $(LIB_PULSE) --cache_checked_modules --odir $(OUTPUT_DIRECTORY) --warn_error @241 --already_cached '*,' --load_cmxs steel
 EXTRACT_MODULES=--extract '+Pulse,-Pulse.Steel'
 
 COMPAT_INDEXED_EFFECTS=--compat_pre_typed_indexed_effects

--- a/src/ocaml/plugin/extract-steel.Makefile
+++ b/src/ocaml/plugin/extract-steel.Makefile
@@ -13,7 +13,7 @@ endif
 
 FSTAR_FILES:=$(wildcard $(LIB_STEEL)/*.fst $(LIB_STEEL)/*.fsti)
 
-MY_FSTAR=$(RUNLIM) $(FSTAR) $(SIL) $(OTHERFLAGS) --include $(LIB_STEEL) --cache_checked_modules --odir $(OUTPUT_DIRECTORY) --warn_error @241 --already_cached '*,-Steel'
+MY_FSTAR=$(RUNLIM) $(FSTAR) $(SIL) $(OTHERFLAGS) --include $(LIB_STEEL) --cache_checked_modules --odir $(OUTPUT_DIRECTORY) --warn_error @241 --already_cached '*,'
 EXTRACT_MODULES=--extract '+Steel.Effect.Common +Steel.ST.GenElim.Base +Steel.ST.GenElim1.Base'
 
 COMPAT_INDEXED_EFFECTS=--compat_pre_typed_indexed_effects


### PR DESCRIPTION
So far `make -C src full-boot` removes the whole snapshot and rebuilds it from scratch in a staged way: verifying and building the Steel tactic, then verifying Steel, then verifying and building the Pulse checker.
But this model will no longer work as soon as handwritten files depending on other extracted files (say Pulse) are added to `src/ocaml/plugin`, as requested by @nikswamy 
Thus, this PR refactors the bootstrap process by making it more similar to what is done in F*: with this PR, `make -C src full-boot`  will first build the snapshot as it is, and then verify Steel and Pulse with that snapshot, and then re-extract everything.
The CI will still make sure that all files are still consistent in this process.
