### PR TITLE
Nix: fix build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,6 +95,9 @@ export INSTALL
 install-ocaml:
 	cd src/ocaml && dune install --prefix=$(STEEL_INSTALL_PREFIX)
 
+install-src-c:
+	+$(MAKE) -C src/c install
+
 install-lib:
 	+$(MAKE) -C lib/steel install
 
@@ -104,4 +107,4 @@ install-include:
 install-share:
 	+$(MAKE) -C share/steel install
 
-install: install-ocaml install-lib install-include install-share
+install: install-ocaml install-lib install-include install-share install-src-c

--- a/flake.nix
+++ b/flake.nix
@@ -23,6 +23,7 @@
             ocamlPackages.sedlex
             ocamlPackages.process
             ocamlPackages.pprint
+            ocamlPackages.menhir
             ocamlPackages.menhirLib
             ocamlPackages.stdint
             ocamlPackages.batteries

--- a/flake.nix
+++ b/flake.nix
@@ -11,7 +11,7 @@
         pkgs = import nixpkgs { inherit system; };
         fstarPkgs = fstar.packages.${system};
         ocamlPackages = fstarPkgs.ocamlPackages;
-        steel = pkgs.stdenv.mkDerivation {
+        default = pkgs.stdenv.mkDerivation {
           name = "steel";
           src = ./.;
           nativeBuildInputs = [
@@ -29,18 +29,18 @@
             ocamlPackages.batteries
             ocamlPackages.zarith
           ];
-          buildFlags = [ "lib" "verify-steel" ];
           installPhase = ''
             mkdir -p $out
             PREFIX=$out make install
           '';
           enableParallelBuilding = true;
         };
+        steel =
+          default.overrideAttrs (_: { buildFlags = [ "lib" "verify-steel" ]; });
       in {
         packages = {
-          inherit steel;
-          default = steel;
+          inherit default steel;
         };
-        hydraJobs = { inherit steel; };
+        hydraJobs = { inherit default steel; };
       });
 }

--- a/flake.nix
+++ b/flake.nix
@@ -29,6 +29,7 @@
             ocamlPackages.batteries
             ocamlPackages.zarith
           ];
+          buildFlags = [ "lib" "verify-steel" ];
           installPhase = ''
             mkdir -p $out
             PREFIX=$out make install

--- a/src/c/Makefile
+++ b/src/c/Makefile
@@ -18,3 +18,12 @@ clean:
 .PHONY: extract
 extract:
 	+$(MAKE) -f extract.Makefile
+
+install: $(addsuffix .install,$(wildcard *.c))
+
+.PHONY: %.install
+
+%.install: %
+	$(INSTALL) -m 644 -D $< $(STEEL_INSTALL_PREFIX)/src/c/$<
+
+.PHONY: install


### PR DESCRIPTION
This PR does three different things:
- first, it adds a new required dependency to build Steel using Nix (menhir) ;
- second, it improves the install target : previously, src/c/*.c files, that is src/c/steel_spinlock.c, were not installed, leading to CI failures ;
- third, it adds a new subderivation that allows to only build Steel when this is all that is required (e.g. for a CI job).
Marking it as WIP while checking for INRIA's CI result.
Supersedes #7 for mergeability reasons.
As pointed out by @tahina-pro, the updated install targets installs src/c/*.c files. The reason is that when working on a Steel project that yields C code through KaRaMeL, it is better to have source .c files, that is, to have a final compilation phase that only require .c files (extracted ones and source ones like steel_spinlock.c). It applies for development (debugging is easier) as well as for a possible audit.