### PR TITLE
Steel: improve within_bounds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,6 +95,9 @@ export INSTALL
 install-ocaml:
 	cd src/ocaml && dune install --prefix=$(STEEL_INSTALL_PREFIX)
 
+install-src-c:
+	+$(MAKE) -C src/c install
+
 install-lib:
 	+$(MAKE) -C lib/steel install
 
@@ -104,4 +107,4 @@ install-include:
 install-share:
 	+$(MAKE) -C share/steel install
 
-install: install-ocaml install-lib install-include install-share
+install: install-ocaml install-lib install-include install-share install-src-c

--- a/flake.nix
+++ b/flake.nix
@@ -23,6 +23,7 @@
             ocamlPackages.sedlex
             ocamlPackages.process
             ocamlPackages.pprint
+            ocamlPackages.menhir
             ocamlPackages.menhirLib
             ocamlPackages.stdint
             ocamlPackages.batteries

--- a/flake.nix
+++ b/flake.nix
@@ -11,7 +11,7 @@
         pkgs = import nixpkgs { inherit system; };
         fstarPkgs = fstar.packages.${system};
         ocamlPackages = fstarPkgs.ocamlPackages;
-        steel = pkgs.stdenv.mkDerivation {
+        default = pkgs.stdenv.mkDerivation {
           name = "steel";
           src = ./.;
           nativeBuildInputs = [
@@ -29,18 +29,18 @@
             ocamlPackages.batteries
             ocamlPackages.zarith
           ];
-          buildFlags = [ "lib" "verify-steel" ];
           installPhase = ''
             mkdir -p $out
             PREFIX=$out make install
           '';
           enableParallelBuilding = true;
         };
+        steel =
+          default.overrideAttrs (_: { buildFlags = [ "lib" "verify-steel" ]; });
       in {
         packages = {
-          inherit steel;
-          default = steel;
+          inherit default steel;
         };
-        hydraJobs = { inherit steel; };
+        hydraJobs = { inherit default steel; };
       });
 }

--- a/flake.nix
+++ b/flake.nix
@@ -29,6 +29,7 @@
             ocamlPackages.batteries
             ocamlPackages.zarith
           ];
+          buildFlags = [ "lib" "verify-steel" ];
           installPhase = ''
             mkdir -p $out
             PREFIX=$out make install

--- a/include/steel/steel_base.h
+++ b/include/steel/steel_base.h
@@ -5,7 +5,7 @@
 #define __KRML_STEEL_BASE_H
 
 static inline bool within_bounds_ptr(void *left, void *p, void *right) {
-  return (uintptr_t) left <= (uintptr_t) p && (uintptr_t) p <= (uintptr_t) right;
+  return (uintptr_t) left <= (uintptr_t) p && (uintptr_t) p < (uintptr_t) right;
 }
 
 #endif

--- a/lib/steel/Steel.ArrayArith.fsti
+++ b/lib/steel/Steel.ArrayArith.fsti
@@ -84,5 +84,5 @@ val within_bounds_elim (#a: Type)
     same_base_array arr1 p /\
     same_base_array arr2 p /\
     offset (ptr_of p) - offset (ptr_of arr1) >= 0 /\
-    offset (ptr_of arr2) - offset (ptr_of p) >= 0
+    offset (ptr_of arr2) - offset (ptr_of p) > 0
   )

--- a/src/c/Makefile
+++ b/src/c/Makefile
@@ -18,3 +18,12 @@ clean:
 .PHONY: extract
 extract:
 	+$(MAKE) -f extract.Makefile
+
+install: $(addsuffix .install,$(wildcard *.c))
+
+.PHONY: %.install
+
+%.install: %
+	$(INSTALL) -m 644 -D $< $(STEEL_INSTALL_PREFIX)/src/c/$<
+
+.PHONY: install


### PR DESCRIPTION
Depends on  #9 .
The so-far used model and implementation of within_bounds_ptr are not very natural. That is, when checking whether a pointer belongs to an array, which is the main use case of within_bounds_ptr, one wants to have a strict upper check, which otherwise would lead as currently to a possible off-by-one error.
Indeed, given an array arr,  `split_r arr (A.length arr)` is a Steel array of length zero, which cannot be accessed.
This PR is thus a fix for this case.