### PR TITLE
Better extraction for array primitives

### DIFF
--- a/lib/steel/Steel.ST.HigherArray.fsti
+++ b/lib/steel/Steel.ST.HigherArray.fsti
@@ -316,7 +316,8 @@ let upd
 : STT unit
     (pts_to a P.full_perm s)
     (fun res -> pts_to a P.full_perm (Seq.upd s (US.v i) v))
-= let (| pt, len |) = a in
+= [@inline_let]
+  let (| pt, len |) = a in
   rewrite
     (pts_to _ _ _)
     (pts_to (| pt, len |) _ s);

--- a/lib/steel/Steel.ST.HigherArray.fsti
+++ b/lib/steel/Steel.ST.HigherArray.fsti
@@ -281,11 +281,10 @@ let index
     (fun _ -> pts_to a p s)
     (US.v i < length a \/ US.v i < Seq.length s)
     (fun res -> Seq.length s == length a /\ US.v i < Seq.length s /\ res == Seq.index s (US.v i))
-= let (| pt, len |) = a in
-  rewrite
+= rewrite
     (pts_to _ _ _)
-    (pts_to (| pt, len |) p s);
-  let res = index_ptr pt i in
+    (pts_to (| (ptr_of a), (dsnd a) |) p s);
+  let res = index_ptr (ptr_of a) i in
   rewrite
     (pts_to _ _ _)
     (pts_to a p s);

--- a/lib/steel/Steel.ST.HigherArray.fsti
+++ b/lib/steel/Steel.ST.HigherArray.fsti
@@ -315,12 +315,10 @@ let upd
 : STT unit
     (pts_to a P.full_perm s)
     (fun res -> pts_to a P.full_perm (Seq.upd s (US.v i) v))
-= [@inline_let]
-  let (| pt, len |) = a in
-  rewrite
+= rewrite
     (pts_to _ _ _)
-    (pts_to (| pt, len |) _ s);
-  upd_ptr pt i v;
+    (pts_to (| ptr_of a, (dsnd a) |) _ s);
+  upd_ptr (ptr_of a) i v;
   rewrite
     (pts_to _ _ _)
     (pts_to _ _ _)


### PR DESCRIPTION
This PR does minor tweaks to the implementation of the array accesses and updates to improve the quality of extraction.
Concretely, it uses the inlining ptr_of predicate instead of deconstructing the pointer pair inside index and upd. This avoids an extra let-binding of the shape `let pt = a in ...` when extracting memory accesses and updates.

Note, I initially tried adding an inline_let on the previous `let (| ptr, len |) = a in`, but this did not yield the expected behavior.