### PR TITLE
Swapping two adjacent regions of an array of any sizes

### DIFF
--- a/lib/steel/Steel.ST.Array.Swap.fst
+++ b/lib/steel/Steel.ST.Array.Swap.fst
@@ -1,0 +1,31 @@
+module Steel.ST.Array.Swap
+open Steel.ST.GenElim
+open Steel.ST.Array // for pts_to
+
+module Gen = Steel.ST.GenArraySwap
+
+[@@__reduce__]
+let array_pts_to (#t: Type) (a: array t) : Tot (Gen.array_pts_to_t t) =
+  fun s -> pts_to a full_perm (Ghost.reveal s)
+
+inline_for_extraction
+let array_index
+  (#t: Type)
+  (a: array t)
+: Tot (Gen.array_index_t (array_pts_to a))
+= fun s n i ->
+    index a i
+
+inline_for_extraction
+let array_upd
+  (#t: Type)
+  (a: array t)
+: Tot (Gen.array_upd_t (array_pts_to a))
+= fun s n i x ->
+    upd a i x;
+    return _
+
+let swap
+  a n l
+= pts_to_length a _;
+  Gen.array_swap_gen (array_index a) (array_upd a) _ n l

--- a/lib/steel/Steel.ST.Array.Swap.fsti
+++ b/lib/steel/Steel.ST.Array.Swap.fsti
@@ -1,0 +1,24 @@
+module Steel.ST.Array.Swap
+open Steel.ST.Util
+include Steel.ST.Array
+
+module SZ = FStar.SizeT
+
+val swap
+  (#t: Type0)
+  (#s0: Ghost.erased (Seq.seq t))
+  (a: array t)
+  (n: SZ.t)
+  (l: SZ.t)
+: ST (Ghost.erased (Seq.seq t))
+    (pts_to a full_perm s0)
+    (fun s -> pts_to a full_perm s)
+    (
+      SZ.v n == length a /\
+      SZ.v l <= SZ.v n
+    )
+    (fun s ->
+      SZ.v n == Seq.length s0 /\
+      SZ.v l <= SZ.v n /\
+      s `Seq.equal` (Seq.slice s0 (SZ.v l) (SZ.v n) `Seq.append` Seq.slice s0 0 (SZ.v l))
+    )

--- a/lib/steel/Steel.ST.GenArraySwap.Proof.fst
+++ b/lib/steel/Steel.ST.GenArraySwap.Proof.fst
@@ -588,7 +588,7 @@ let array_swap_inner_invariant_end
     let s' = Seq.upd s idx (Seq.index s0 i) in
     array_swap_outer_invariant s0 n l bz s' (i + 1)
   ))
-  [SMTPat (array_swap_inner_invariant s0 n l bz s i j idx)]
+//  [SMTPat (array_swap_inner_invariant s0 n l bz s i j idx)]
 = ()
 
 module SZ = FStar.SizeT

--- a/lib/steel/Steel.ST.GenArraySwap.Proof.fst
+++ b/lib/steel/Steel.ST.GenArraySwap.Proof.fst
@@ -529,3 +529,35 @@ let array_as_ring_buffer_swap
   = Seq.index s idx == Seq.index s0 (jump n l idx)
   in
   jump_iter_elim n p l bz
+
+let array_swap_outer_invariant // hoisting necessary because "Let binding is effectful"
+  (#t: Type0) (s0: Seq.seq t) (n: nat) (l: nat) (bz: bezout (n) (l))
+  (s: Seq.seq t) (i: nat)
+: Tot prop
+= 0 < l /\
+  l < n /\
+  i <= bz.d /\
+  n == Seq.length s0 /\
+  n == Seq.length s /\
+  (forall (i': nat_up_to bz.d) .
+     (forall (j: nat_up_to bz.q_n) .
+        let idx = iter_fun #(nat_up_to (n)) (jump (n) (l)) j i' in
+        Seq.index s idx == Seq.index s0 (if i' < i then jump (n) (l) idx else idx)
+  ))
+
+let array_swap_inner_invariant
+  (#t: Type0) (s0: Seq.seq t) (n: nat) (l: nat) (bz: bezout (n) (l))
+  (s: Seq.seq t) (i: nat) (j: nat) (idx: nat)
+: Tot prop
+= 0 < l /\
+  l < n /\
+  n == Seq.length s0 /\
+  i < bz.d /\
+  j < bz.q_n /\
+  idx == iter_fun #(nat_up_to (n)) (jump (n) (l)) (j) (i) /\
+  n == Seq.length s /\
+  (forall (i': nat_up_to bz.d) .
+     (forall (j': nat_up_to bz.q_n) .
+        let idx = iter_fun #(nat_up_to (n)) (jump (n) (l)) j' i' in
+        Seq.index s idx == Seq.index s0 (if i' < i || (i' = i && j' < j) then jump (n) (l) idx else idx)
+  ))

--- a/lib/steel/Steel.ST.GenArraySwap.Proof.fst
+++ b/lib/steel/Steel.ST.GenArraySwap.Proof.fst
@@ -1,0 +1,478 @@
+module Steel.ST.GenArraySwap.Proof
+open FStar.Math.Lemmas
+open FStar.Mul
+open FStar.Tactics.CanonCommSemiring
+
+[@@erasable]
+noeq
+type bezout_t = {
+  d: pos;
+  q_n: nat;
+  q_l: nat;
+  u_n: int;
+  u_l: int;
+}
+
+let bezout_prop
+  (n: nat)
+  (l: nat)
+  (b: bezout_t)
+: Tot prop
+= n == b.d * b.q_n /\
+  l == b.d * b.q_l /\
+  b.d == n * b.u_n + l * b.u_l
+
+#push-options "--z3rlimit 32"
+
+#restart-solver
+let rec mk_bezout
+  (n: pos)
+  (l: nat)
+: Ghost bezout_t
+  (requires (l < n))
+  (ensures (fun b ->
+    bezout_prop n l b 
+  ))
+  (decreases l)
+= if l = 0
+  then {
+    d = n;
+    q_n = 1;
+    q_l = 0;
+    u_n = 1;
+    u_l = 0;
+  }
+  else begin
+    let l' = n % l in
+    let ql = n / l in
+    let n_alt0 = l * ql + l' in
+    euclidean_division_definition n l;
+    assert (n == n_alt0);
+    let b' = mk_bezout l l' in
+    let l_alt = b'.d * b'.q_n in
+    let l'_alt1 = b'.d * b'.q_l in
+    let n_alt1 = l_alt * ql + l'_alt1 in
+    assert (n_alt1 == n);
+    let q_n = b'.q_n * ql + b'.q_l in
+    assert (n_alt1 == b'.d * q_n) by (int_semiring ());
+    let l'_alt2 = n - l * ql in
+    assert (l'_alt2 == l');
+    let d_alt = l * b'.u_n + l'_alt2 * b'.u_l in
+    assert (d_alt == b'.d);
+    let u_l = b'.u_n - ql * b'.u_l in
+    assert (d_alt == n_alt0 * b'.u_l + l * u_l) by (int_semiring ());
+    {
+      d = b'.d;
+      q_n = q_n;
+      q_l = b'.q_n;
+      u_n = b'.u_l;
+      u_l = u_l;
+    }
+  end
+
+#pop-options
+
+let bezout
+  (n: nat)
+  (l: nat)
+: Tot Type
+= (b: bezout_t { bezout_prop n l b })
+
+let rec iter_fun
+  (#t: Type)
+  (f: (t -> GTot t))
+  (n: nat)
+  (x: t)
+: GTot t
+  (decreases n)
+= if n = 0
+  then x
+  else iter_fun f (n - 1) (f x)
+
+let nat_up_to (n: nat) : Tot Type = (i: nat { i < n })
+
+let jump
+  (n: pos)
+  (l: nat)
+  (x: nat_up_to n)
+: GTot (nat_up_to n)
+= (x + l) % n
+
+#push-options "--z3rlimit 64"
+
+#restart-solver
+let jump_mod_d
+  (n: pos)
+  (l: nat)
+  (b: bezout n l)
+  (x: nat_up_to n)
+: Lemma
+  (jump n l x % b.d == x % b.d)
+= let x' = jump n l x in
+  let x'q = (x + l) / n in
+  let l_alt = b.d * b.q_l in
+  assert (l_alt == l);
+  let n_alt = b.d * b.q_n in
+  assert (n_alt == n);
+  let x'_alt = x + l_alt - x'q * n_alt in
+  euclidean_division_definition (x + l) n;
+  assert (x'_alt == x');
+  let qx = b.q_l - x'q * b.q_n in
+  assert (x'_alt == x + qx * b.d) by (int_semiring ());
+  lemma_mod_plus x qx b.d;
+  ()
+
+#pop-options
+
+let rec jump_iter_mod_d
+  (n: pos)
+  (l: nat)
+  (b: bezout n l)
+  (x: nat_up_to n)
+  (k: nat)
+: Lemma
+  (ensures (iter_fun #(nat_up_to n) (jump n l) k x % b.d == x % b.d))
+  (decreases k)
+= if k = 0
+  then ()
+  else begin
+    jump_mod_d n l b x;
+    jump_iter_mod_d n l b (jump n l x) (k - 1)
+  end
+
+(* Coverage *)
+
+let rec jump_iter
+  (n: pos)
+  (l: nat)
+  (x: nat_up_to n)
+  (k: nat)
+: Lemma
+  (ensures (iter_fun (jump n l) k x == (x + k * l) % n))
+  (decreases k)
+= if k = 0
+  then ()
+  else begin
+    let k' = k - 1 in
+    assert (x + k * l == (x + l) + k' * l);
+    jump_iter n l ((x + l) % n) k';
+    lemma_mod_add_distr (k' * l) (x + l) n
+  end
+
+#push-options "--z3rlimit 64"
+
+#restart-solver
+[@@"opaque_to_smt"]
+irreducible
+let jump_coverage
+  (n: pos)
+  (l: nat)
+  (b: bezout n l)
+  (x: nat_up_to n)
+: Ghost nat
+  (requires True)
+  (ensures (fun k ->
+    x == iter_fun (jump n l) k (x % b.d)
+  ))
+= let i = x % b.d in
+  let qx = x / b.d in
+  euclidean_division_definition x b.d;
+  let k1 = qx * b.u_l in
+  let m = qx * b.u_n in
+  assert (x == i + k1 * l + m * n);
+  small_mod x n;
+  lemma_mod_plus (i + k1 * l) m n;
+  assert (x == (i + k1 * l) % n);
+  let k = k1 % n in
+  let qk = k1 / n in
+  euclidean_division_definition k1 n;
+  assert (i + k1 * l == i + k * l + (qk * l) * n);
+  lemma_mod_plus (i + k * l) (qk * l) n;
+  assert (x == (i + k * l) % n);
+  jump_iter n l i k;
+  k
+
+#pop-options
+
+[@@"opaque_to_smt"]
+irreducible
+let rec minimal_exists'
+  (p: (nat -> GTot bool))
+  (n: nat)
+  (i: nat)
+: Ghost nat
+  (requires (
+    p n == true /\
+    i <= n /\
+    (forall (j: nat) . j < i ==> p j == false)
+  ))
+  (ensures (fun k ->
+    p k == true /\
+    (forall (j: nat) . j < k ==> p j == false)
+  ))
+  (decreases (n - i))
+= if p i
+  then i
+  else minimal_exists' p n (i + 1)
+
+[@@"opaque_to_smt"]
+irreducible
+let minimal_exists
+  (p: (nat -> GTot bool))
+  (n: nat)
+: Ghost nat
+  (requires (
+    p n == true
+  ))
+  (ensures (fun k ->
+    p k == true /\
+    (forall (j: nat) . j < k ==> p j == false)
+  ))
+= minimal_exists' p n 0
+
+[@@"opaque_to_smt"]
+irreducible
+let jump_coverage_strong
+  (n: pos)
+  (l: nat)
+  (b: bezout n l)
+  (x: nat_up_to n)
+: Ghost nat
+  (requires True)
+  (ensures (fun k ->
+    x == iter_fun (jump n l) k (x % b.d) /\
+    (forall (k': nat) . k' < k ==> (~ (x == iter_fun (jump n l) k' (x % b.d))))
+  ))
+= let k' = jump_coverage n l b x in
+  minimal_exists (fun k -> x = iter_fun (jump n l) k (x % b.d)) k'
+
+#restart-solver
+let jump_iter_mod_q
+  (n: pos)
+  (l: nat)
+  (b: bezout n l)
+  (x: nat_up_to n)
+  (k: nat)
+: Lemma
+  (ensures (
+    b.q_n > 0 /\
+    iter_fun (jump n l) (k % b.q_n) x == iter_fun (jump n l) k x
+  ))
+= assert (b.q_n > 0);
+  let k' = k % b.q_n in
+  let qk = k / b.q_n in
+  euclidean_division_definition k b.q_n;
+  jump_iter n l x k';
+  jump_iter n l x k;
+  assert (x + (qk * b.q_n + k') * (b.d * b.q_l) == x + k' * (b.d * b.q_l) + (qk * b.q_l) * (b.d * b.q_n)) by (int_semiring ());
+  assert (x + k * l == x + k' * l + (qk * b.q_l) * n);
+  lemma_mod_plus (x + k' * l) (qk * b.q_l) n
+
+let jump_coverage_strong_bound
+  (n: pos)
+  (l: nat)
+  (b: bezout n l)
+  (x: nat_up_to n)
+: Lemma
+  (b.q_n > 0 /\
+    jump_coverage_strong n l b x < b.q_n
+  )
+  [SMTPat (jump_coverage_strong n l b x)]
+= let k = jump_coverage_strong n l b x in
+  jump_iter_mod_q n l b (x % b.d) k
+
+#restart-solver
+
+[@@"opaque_to_smt"]
+irreducible
+let mod_eq_elim
+  (n: pos)
+  (x1 x2: int)
+: Ghost int
+  (requires (x1 % n == x2 % n))
+  (ensures (fun k -> x1 - x2 == k * n))
+= euclidean_division_definition x1 n;
+  euclidean_division_definition x2 n;
+  (x1 / n) - (x2 / n)
+
+let mod_eq_intro
+  (n: pos)
+  (x1 x2: int)
+  (k: int)
+: Lemma
+  (requires (x1 - x2 == k * n))
+  (ensures (x1 % n == x2 % n))
+= lemma_mod_plus x2 k n
+
+#push-options "--z3rlimit 64"
+
+#restart-solver
+[@@"opaque_to_smt"]
+irreducible
+let gauss
+  (n: pos)
+  (l: pos) // necessary here
+  (b: bezout n l)
+  (kl kn: int)
+: Ghost int
+  (requires (
+    kl * l == kn * n
+  ))
+  (ensures (fun k ->
+    kl == k * b.q_n
+  ))
+= assert ((b.d * b.q_n) * b.u_n + (b.d * b.q_l) * b.u_l == b.d * (b.u_n * b.q_n + b.u_l * b.q_l)) by (int_semiring ());
+  assert (b.d * (b.u_n * b.q_n + b.u_l * b.q_l) == b.d * 1);
+  assert (b.u_n * b.q_n + b.u_l * b.q_l == 1);
+  if b.u_l = 0
+  then begin
+    assert (b.q_n == 1);
+    kl
+  end else begin
+    assert (kl * (b.d * b.q_l) == kn * (b.d * b.q_n));
+    assert (kl * (b.d * b.q_l) == b.d * (kl * b.q_l)) by (int_semiring ());
+    assert (kn * (b.d * b.q_n) == b.d * (kn * b.q_n)) by (int_semiring ());
+    assert (b.d * (kl * b.q_l) == b.d * (kn * b.q_n));
+    assert (kl * b.q_l == kn * b.q_n);
+    assert (b.u_l * (kl * b.q_l) == b.u_l * (kn * b.q_n));
+    assert (b.u_l * (kl * b.q_l) == kl * (b.u_l * b.q_l)) by (int_semiring ());
+    assert (b.u_l * (kn * b.q_n) == (kn * b.u_l) * b.q_n) by (int_semiring ());
+    assert (kl * (b.u_l * b.q_l) == (kn * b.u_l) * b.q_n);
+    assert (kl * (1 + - (b.u_n * b.q_n)) == kl + - kl * b.u_n * b.q_n) by (int_semiring ());
+    assert (kl * b.u_n * b.q_n + (kn * b.u_l) * b.q_n == (kn * b.u_l + kl * b.u_n) * b.q_n) by (int_semiring ());
+    kn * b.u_l + kl * b.u_n
+  end
+
+#pop-options
+
+let jump_iter_mod_q_inj_weak
+  (n: pos)
+  (l: pos)
+  (b: bezout n l)
+  (x: nat_up_to n)
+  (k1 k2: nat)
+: Lemma
+  (requires (
+    iter_fun (jump n l) k1 x == iter_fun (jump n l) k2 x
+  ))
+  (ensures (
+    b.q_n > 0 /\
+    k1 % b.q_n == k2 % b.q_n
+  ))
+= jump_iter n l x k1;
+  jump_iter n l x k2;
+  let kn = mod_eq_elim n (x + k1 * l) (x + k2 * l) in
+  let kq = gauss n l b (k1 - k2) kn in
+  mod_eq_intro b.q_n k1 k2 kq
+
+let jump_iter_inj
+  (n: nat)
+  (l: nat)
+  (b: bezout_t)
+  (i1 i2: nat)
+  (k1 k2: nat)
+: Lemma
+  (requires (
+    n > 0 /\
+    l > 0 /\
+    bezout_prop n l b /\
+    i1 < b.d /\
+    i2 < b.d /\
+    k1 < b.q_n /\
+    k2 < b.q_n /\
+    iter_fun (jump n l) k1 i1 == iter_fun (jump n l) k2 i2
+  ))
+  (ensures (
+    i1 == i2 /\
+    k1 == k2
+  ))
+  [SMTPat (iter_fun (jump n l) k1 i1); SMTPat (iter_fun (jump n l) k2 i2); SMTPat (bezout_prop n l b)]
+= jump_iter_mod_d n l b i1 k1;
+  jump_iter_mod_d n l b i2 k2;
+  small_mod i1 b.d;
+  small_mod i2 b.d;
+  jump_iter_mod_q_inj_weak n l b i1 k1 k2;
+  small_mod k1 b.q_n;
+  small_mod k2 b.q_n
+  
+#restart-solver
+let jump_iter_elim
+  (n: pos)
+  (p: nat_up_to n -> prop)
+  (l: nat)
+  (b: bezout n l)
+: Lemma
+  (requires (
+    forall (i: nat_up_to b.d) (k: nat_up_to b.q_n) . p (iter_fun (jump n l) k i)
+  ))
+  (ensures (
+    forall (x: nat_up_to n) . p x
+  ))
+= let prf
+    (x: nat_up_to n)
+  : Lemma
+    (p x)
+  =
+    let i : nat_up_to b.d = x % b.d in
+    let k' = jump_coverage_strong n l b x in
+    jump_coverage_strong_bound n l b x;
+    assert (p (iter_fun (jump n l) k' i))
+  in
+  Classical.forall_intro prf
+
+let jump_if
+  (n: pos)
+  (l: nat)
+  (sq: squash (l < n))
+  (idx: nat_up_to n)
+: Lemma
+  (jump n l idx == (if idx + l >= n then idx - (n - l) else idx + l))
+= let idx' = (if idx + l >= n then idx - (n - l) else idx + l) in
+  small_mod idx n;
+  small_mod idx' n;
+  lemma_mod_plus (idx + l) 1 n
+
+let jump_iter_q
+  (n: pos)
+  (l: nat)
+  (b: bezout n l)
+  (x: nat_up_to n)
+: Lemma
+  (ensures (
+    iter_fun (jump n l) b.q_n x == x
+  ))
+= cancel_mul_mod 1 b.q_n;
+  jump_iter_mod_q n l b x b.q_n
+
+let rec iter_fun_add
+  (#t: Type)
+  (f: (t -> GTot t))
+  (n1 n2: nat)
+  (x: t)
+: Lemma
+  (ensures (iter_fun f n1 (iter_fun f n2 x) == iter_fun f (n1 + n2) x))
+  (decreases n2)
+= if n2 = 0
+  then ()
+  else iter_fun_add f n1 (n2 - 1) (f x)
+
+let iter_succ_l
+  (#t: Type)
+  (f: (t -> GTot t))
+  (n: nat)
+  (x: t)
+: Lemma
+  (f (iter_fun f n x) == iter_fun f (n + 1) x)
+  [SMTPat (f (iter_fun f n x))]
+= iter_fun_add f 1 n x
+
+let jump_jump_iter_pred_q
+  (n: pos)
+  (l: nat)
+  (b: bezout n l)
+  (x: nat_up_to n)
+: Lemma
+  (ensures (
+    jump n l (iter_fun (jump n l) (b.q_n - 1) x) == x
+  ))
+= jump_iter_q n l b x

--- a/lib/steel/Steel.ST.GenArraySwap.Proof.fst
+++ b/lib/steel/Steel.ST.GenArraySwap.Proof.fst
@@ -484,3 +484,48 @@ let jump_jump_iter_pred_q
   ))
   [SMTPat (jump n l (iter_fun (jump n l) (b.q_n - 1) x))]
 = jump_iter_q n l b x
+
+let array_swap_post
+  (#t: Type)
+  (s0: Seq.seq t)
+  (n: nat)
+  (l: nat)
+  (s: Seq.seq t)
+: Tot prop
+=
+    n == Seq.length s0 /\
+    0 <= l /\
+    l <= n /\
+    s `Seq.equal` (Seq.slice s0 l n `Seq.append` Seq.slice s0 0 l)
+
+let array_as_ring_buffer_swap
+  (#t: Type)
+  (n: nat)
+  (l: nat)
+  (bz: bezout n l)
+  (s0: Seq.seq t)
+  (s: Seq.seq t)
+: Lemma
+  (requires (
+    n == Seq.length s0 /\
+    n == Seq.length s /\
+    0 < l /\
+    l < n /\
+    (forall (i': nat_up_to bz.d) .
+      (forall (j: nat_up_to bz.q_n) .
+        (i' < bz.d) ==> (
+        let idx = iter_fun #(nat_up_to n) (jump n l) j i' in
+        Seq.index s idx == Seq.index s0 (jump n l idx)
+    )))
+  ))
+  (ensures (
+    array_swap_post s0 n l s
+  ))
+  [SMTPat (array_swap_post s0 n l s); SMTPat (bezout_prop n l bz)]
+= Classical.forall_intro (jump_if n l ());
+  let p
+    (idx: nat_up_to n)
+  : Tot prop
+  = Seq.index s idx == Seq.index s0 (jump n l idx)
+  in
+  jump_iter_elim n p l bz

--- a/lib/steel/Steel.ST.GenArraySwap.Proof.fst
+++ b/lib/steel/Steel.ST.GenArraySwap.Proof.fst
@@ -34,7 +34,7 @@ let bezout
 let rec mk_bezout
   (n: pos)
   (l: nat)
-: Ghost (bezout n l)
+: Pure (bezout n l)
   (requires (l < n))
   (ensures (fun _ -> True))
   (decreases l)

--- a/lib/steel/Steel.ST.GenArraySwap.fst
+++ b/lib/steel/Steel.ST.GenArraySwap.fst
@@ -1,0 +1,556 @@
+module Steel.ST.GenArraySwap
+open Steel.ST.GenElim
+
+module Prf = Steel.ST.GenArraySwap.Proof
+module R = Steel.ST.Reference
+
+let gcd_inv_prop
+  (n0: nat)
+  (l0: nat)
+  (n: nat)
+  (l: nat)
+  (b: bool)
+: Tot prop
+= l0 < n0 /\
+  l < n /\
+  (Prf.mk_bezout n0 l0).d == (Prf.mk_bezout n l).d /\
+  b == (l > 0)
+
+[@@__reduce__]
+let gcd_inv0
+  (n0: SZ.t)
+  (l0: SZ.t)
+  (pn: R.ref SZ.t)
+  (pl: R.ref SZ.t)
+  (b: bool)
+: Tot vprop
+= exists_ (fun n -> exists_ (fun l ->
+    R.pts_to pn full_perm n `star`
+    R.pts_to pl full_perm l `star`
+    pure (gcd_inv_prop (SZ.v n0) (SZ.v l0) (SZ.v n) (SZ.v l) b)
+  ))
+
+let gcd_inv
+  (n0: SZ.t)
+  (l0: SZ.t)
+  (pn: R.ref SZ.t)
+  (pl: R.ref SZ.t)
+  (b: bool)
+: Tot vprop
+= gcd_inv0 n0 l0 pn pl b
+
+let gcd_post
+  (n0: SZ.t)
+  (l0: SZ.t)
+  (res: SZ.t)
+: Tot prop
+= SZ.v l0 < SZ.v n0 /\
+  SZ.v res == (Prf.mk_bezout (SZ.v n0) (SZ.v l0)).d
+
+#restart-solver
+let gcd
+  (n0: SZ.t)
+  (l0: SZ.t)
+: ST SZ.t
+    emp
+    (fun _ -> emp)
+    (SZ.v l0 < SZ.v n0)
+    (fun res -> gcd_post n0 l0 res)
+= let res =
+    R.with_local n0 (fun pn ->
+      R.with_local l0 (fun pl ->
+        noop ();
+        rewrite (gcd_inv0 n0 l0 pn pl (l0 `SZ.gt` 0sz)) (gcd_inv n0 l0 pn pl (l0 `SZ.gt` 0sz));
+        Steel.ST.Loops.while_loop
+          (gcd_inv n0 l0 pn pl)
+          (fun _ ->
+            let gb = elim_exists () in
+            rewrite (gcd_inv n0 l0 pn pl gb) (gcd_inv0 n0 l0 pn pl gb);
+            let _ = gen_elim () in
+            let l = R.read pl in
+            [@@inline_let]
+            let b = l `SZ.gt` 0sz in
+            noop ();
+            rewrite (gcd_inv0 n0 l0 pn pl b) (gcd_inv n0 l0 pn pl b);
+            return b
+          )
+          (fun _ ->
+            rewrite (gcd_inv n0 l0 pn pl true) (gcd_inv0 n0 l0 pn pl true);
+            let _ = gen_elim () in
+            let n = R.read pn in
+            let l = R.read pl in
+            [@@inline_let]
+            let l' = SZ.rem n l in
+            R.write pn l;
+            R.write pl l';
+            rewrite (gcd_inv0 n0 l0 pn pl (l' `SZ.gt` 0sz)) (gcd_inv n0 l0 pn pl (l' `SZ.gt` 0sz));
+            noop ()
+          );
+        rewrite (gcd_inv n0 l0 pn pl false) (gcd_inv0 n0 l0 pn pl false);
+        let _ = gen_elim () in
+        let res = R.read pn in
+        return res
+      )
+    )
+  in
+  elim_pure (gcd_post n0 l0 res);
+  return res
+
+let array_swap_partial_invariant
+  (#t: Type)
+  (n: nat)
+  (l: nat)
+  (bz: Prf.bezout n l)
+  (s0: Ghost.erased (Seq.seq t))
+  (s: Ghost.erased (Seq.seq t))
+  (i: nat)
+: GTot prop
+= n == Seq.length s0 /\
+  n == Seq.length s /\
+  0 < l /\
+  l < n /\
+  i <= bz.d /\
+  (forall (i': Prf.nat_up_to bz.d) .
+    (forall (j: Prf.nat_up_to bz.q_n) .
+      (i' < i) ==> (
+      let idx = Prf.iter_fun #(Prf.nat_up_to n) (Prf.jump n l) j i' in
+      Seq.index s idx == Seq.index s0 (Prf.jump n l idx)
+  ))) /\
+  (forall (i': Prf.nat_up_to bz.d) .
+    (forall (j: Prf.nat_up_to bz.q_n) .
+      (i' > i) ==> (
+      let idx = Prf.iter_fun #(Prf.nat_up_to n) (Prf.jump n l) j i' in
+      Seq.index s idx == Seq.index s0 idx
+  )))
+
+let array_swap_inner_invariant_prop
+  (#t: Type)
+  (n: nat)
+  (l: nat)
+  (bz: Prf.bezout n l)
+  (s0: Ghost.erased (Seq.seq t))
+  (s: Ghost.erased (Seq.seq t))
+  (i: nat)
+  (j: nat)
+  (idx: nat)
+  (b: bool)
+: GTot prop
+=
+  array_swap_partial_invariant n l bz s0 s i /\
+  i < bz.d /\
+  bz.d < n /\
+  j <= bz.q_n - 1 /\
+  idx == Prf.iter_fun #(Prf.nat_up_to n) (Prf.jump n l) j i /\
+  (forall (j': Prf.nat_up_to bz.q_n) .
+      let idx = Prf.iter_fun #(Prf.nat_up_to n) (Prf.jump n l) j' i in
+      Seq.index s idx == Seq.index s0 (if j' < j then Prf.jump n l idx else idx)
+  ) /\
+  (b == (j < bz.q_n - 1))
+
+let array_swap_outer_invariant_prop
+  (#t: Type)
+  (n: nat)
+  (l: nat)
+  (bz: Prf.bezout n l)
+  (s0: Ghost.erased (Seq.seq t))
+  (s: Ghost.erased (Seq.seq t))
+  (i: nat)
+  (b: bool)
+: GTot prop
+= array_swap_partial_invariant n l bz s0 s i /\
+  bz.d < n /\
+  (forall (j: Prf.nat_up_to bz.q_n) .
+    (i < bz.d) ==> (
+    let idx = Prf.iter_fun #(Prf.nat_up_to n) (Prf.jump n l) j i in
+    Seq.index s idx == Seq.index s0 idx
+  )) /\
+  (b == (i < bz.d))
+
+#restart-solver
+let array_swap_outer_invariant_prop_begin
+  (#t: Type)
+  (n: nat)
+  (l: nat)
+  (bz: Prf.bezout n l)
+  (s0: Ghost.erased (Seq.seq t))
+: Lemma
+  (requires (
+    n == Seq.length s0 /\
+    0 < l /\
+    l < n
+  ))
+  (ensures (
+    array_swap_outer_invariant_prop n l bz s0 s0 0 true
+  ))
+= ()
+
+#restart-solver
+let array_swap_outer_invariant_prop_end
+  (#t: Type)
+  (n: nat)
+  (l: nat)
+  (bz: Prf.bezout n l)
+  (s0: Ghost.erased (Seq.seq t))
+  (s: Ghost.erased (Seq.seq t))
+  (i: nat)
+: Lemma
+  (requires (
+    array_swap_outer_invariant_prop n l bz s0 s i false
+  ))
+  (ensures (
+    Ghost.reveal s `Seq.equal` (Seq.slice s0 l n `Seq.append` Seq.slice s0 0 l)
+  ))
+= Classical.forall_intro (Prf.jump_if n l ());
+  let p
+    (idx: Prf.nat_up_to n)
+  : Tot prop
+  = Seq.index s idx == Seq.index s0 (Prf.jump n l idx)
+  in
+  assert (i == bz.d);
+   assert (forall (i': Prf.nat_up_to bz.d) .
+    (forall (j: Prf.nat_up_to bz.q_n) .
+      (i' < i) ==> (
+      let idx = Prf.iter_fun #(Prf.nat_up_to n) (Prf.jump n l) j i' in
+      Seq.index s idx == Seq.index s0 (Prf.jump n l idx)
+  )));
+  assert (forall (i: Prf.nat_up_to bz.d) (k: Prf.nat_up_to bz.q_n) . p (Prf.iter_fun #(Prf.nat_up_to n) (Prf.jump n l) k i));
+  Prf.jump_iter_elim n p l bz
+
+[@@__reduce__]
+let array_swap_outer_invariant0
+  (#t: Type)
+  (pts_to: array_pts_to_t t)
+  (n: SZ.t)
+  (l: SZ.t)
+  (bz: Prf.bezout (SZ.v n) (SZ.v l))
+  (s0: Ghost.erased (Seq.seq t))
+  (pi: R.ref SZ.t)
+  (b: bool)
+: Tot vprop
+= exists_ (fun i -> exists_ (fun s ->
+    R.pts_to pi full_perm i `star`
+    pts_to s `star`
+    pure (array_swap_outer_invariant_prop (SZ.v n) (SZ.v l) bz s0 s (SZ.v i) b)
+  ))
+
+let array_swap_outer_invariant
+  (#t: Type)
+  (pts_to: array_pts_to_t t)
+  (n: SZ.t)
+  (l: SZ.t)
+  (bz: Prf.bezout (SZ.v n) (SZ.v l))
+  (s0: Ghost.erased (Seq.seq t))
+  (pi: R.ref SZ.t)
+  (b: bool)
+: Tot vprop
+= array_swap_outer_invariant0 pts_to n l bz s0 pi b
+
+[@@erasable]
+noeq
+type array_swap_inner_invariant_t (t: Type)
+= {
+    j: SZ.t;
+    idx: SZ.t;
+    s: Ghost.erased (Seq.seq t)
+  }
+
+[@@__reduce__]
+let array_swap_inner_invariant_body0
+  (#t: Type)
+  (pts_to: array_pts_to_t t)
+  (n: SZ.t)
+  (l: SZ.t)
+  (bz: Prf.bezout (SZ.v n) (SZ.v l))
+  (s0: Ghost.erased (Seq.seq t))
+  (pi: R.ref SZ.t)
+  (i: SZ.t)
+  (pj: R.ref SZ.t)
+  (pidx: R.ref SZ.t)
+  (b: bool)
+  (j: SZ.t)
+  (idx: SZ.t)
+  (s: Ghost.erased (Seq.seq t))
+: Tot vprop
+=   R.pts_to pi full_perm i `star`
+    R.pts_to pj full_perm j `star`
+    R.pts_to pidx full_perm idx `star`
+    pts_to s
+
+[@@__reduce__]
+let array_swap_inner_invariant0
+  (#t: Type)
+  (pts_to: array_pts_to_t t)
+  (n: SZ.t)
+  (l: SZ.t)
+  (bz: Prf.bezout (SZ.v n) (SZ.v l))
+  (s0: Ghost.erased (Seq.seq t))
+  (pi: R.ref SZ.t)
+  (i: SZ.t)
+  (pj: R.ref SZ.t)
+  (pidx: R.ref SZ.t)
+  (b: bool)
+: Tot vprop
+= exists_ (fun w ->
+    array_swap_inner_invariant_body0 pts_to n l bz s0 pi i pj pidx b w.j w.idx w.s `star`
+    pure (array_swap_inner_invariant_prop (SZ.v n) (SZ.v l) bz s0 w.s (SZ.v i) (SZ.v w.j) (SZ.v w.idx) b)
+  )
+
+let array_swap_inner_invariant
+  (#t: Type)
+  (pts_to: array_pts_to_t t)
+  (n: SZ.t)
+  (l: SZ.t)
+  (bz: Prf.bezout (SZ.v n) (SZ.v l))
+  (s0: Ghost.erased (Seq.seq t))
+  (pi: R.ref SZ.t)
+  (i: SZ.t)
+  (pj: R.ref SZ.t)
+  (pidx: R.ref SZ.t)
+  (b: bool)
+: Tot vprop
+= array_swap_inner_invariant0 pts_to n l bz s0 pi i pj pidx b
+
+let intro_array_swap_inner_invariant
+  (#opened: _)
+  (#t: Type)
+  (pts_to: array_pts_to_t t)
+  (n: SZ.t)
+  (l: SZ.t)
+  (bz: Prf.bezout (SZ.v n) (SZ.v l))
+  (s0: Ghost.erased (Seq.seq t))
+  (pi: R.ref SZ.t)
+  (i: SZ.t)
+  (pj: R.ref SZ.t)
+  (pidx: R.ref SZ.t)
+  (b: bool)
+  (j: SZ.t)
+  (idx: SZ.t)
+  (s: Ghost.erased (Seq.seq t))
+: STGhost unit opened
+    (array_swap_inner_invariant_body0 pts_to n l bz s0 pi i pj pidx b j idx s)
+    (fun _ -> array_swap_inner_invariant pts_to n l bz s0 pi i pj pidx b)
+    (array_swap_inner_invariant_prop (SZ.v n) (SZ.v l) bz s0 s (SZ.v i) (SZ.v j) (SZ.v idx) b)
+    (fun _ -> True)
+= let w = {
+    j = j;
+    idx = idx;
+    s = s;
+  }
+  in
+  rewrite
+    (array_swap_inner_invariant_body0 pts_to n l bz s0 pi i pj pidx b j idx s)
+    (array_swap_inner_invariant_body0 pts_to n l bz s0 pi i pj pidx b w.j w.idx w.s);
+  rewrite
+    (array_swap_inner_invariant0 pts_to n l bz s0 pi i pj pidx b)
+    (array_swap_inner_invariant pts_to n l bz s0 pi i pj pidx b)
+
+let elim_array_swap_inner_invariant
+  (#opened: _)
+  (#t: Type)
+  (pts_to: array_pts_to_t t)
+  (n: SZ.t)
+  (l: SZ.t)
+  (bz: Prf.bezout (SZ.v n) (SZ.v l))
+  (s0: Ghost.erased (Seq.seq t))
+  (pi: R.ref SZ.t)
+  (i: SZ.t)
+  (pj: R.ref SZ.t)
+  (pidx: R.ref SZ.t)
+  (b: bool)
+: STGhost (array_swap_inner_invariant_t t) opened
+    (array_swap_inner_invariant pts_to n l bz s0 pi i pj pidx b)
+    (fun w -> array_swap_inner_invariant_body0 pts_to n l bz s0 pi i pj pidx b w.j w.idx w.s)
+    True
+    (fun w -> array_swap_inner_invariant_prop (SZ.v n) (SZ.v l) bz s0 w.s (SZ.v i) (SZ.v w.j) (SZ.v w.idx) b)
+= let w = elim_exists () in
+  elim_pure _;
+  w
+
+inline_for_extraction
+let impl_jump
+  (n: SZ.t)
+  (l: SZ.t)
+  (idx: SZ.t)
+: Pure SZ.t
+    (requires (
+      SZ.v l < SZ.v n /\
+      SZ.v idx < SZ.v n
+    ))
+    (ensures (fun idx' ->
+      SZ.v idx' == Prf.jump (SZ.v n) (SZ.v l) (SZ.v idx)
+    ))
+= Prf.jump_if (SZ.v n) (SZ.v l) () (SZ.v idx);
+  [@@inline_let]
+  let nl = n `SZ.sub` l in
+  if idx `SZ.gte` nl
+  then idx `SZ.sub` nl
+  else idx `SZ.add` l
+
+let array_swap_aux_post
+  (#t: Type)
+  (s0: Ghost.erased (Seq.seq t))
+  (n: SZ.t)
+  (l: SZ.t)
+  (s: Ghost.erased (Seq.seq t))
+: Tot prop
+=
+      SZ.v n == Seq.length s0 /\
+      SZ.v l > 0 /\
+      SZ.v l < SZ.v n /\
+      Ghost.reveal s == Seq.slice s0 (SZ.v l) (SZ.v n) `Seq.append` Seq.slice s0 0 (SZ.v l)
+
+#push-options "--z3rlimit 64"
+
+#restart-solver
+inline_for_extraction
+let array_swap_outer_body
+  (#t: Type)
+  (#pts_to: array_pts_to_t t)
+  (index: array_index_t pts_to)
+  (upd: array_upd_t pts_to)
+  (s0: Ghost.erased (Seq.seq t))
+  (n: SZ.t)
+  (l: SZ.t)
+  (bz: Prf.bezout (SZ.v n) (SZ.v l))
+  (d: SZ.t)
+  (q: SZ.t)
+  (pi: R.ref SZ.t)
+  (sq: squash (
+    SZ.v d == bz.d /\
+    SZ.v q == bz.q_n
+  ))
+  ()
+: STT unit
+    (array_swap_outer_invariant pts_to n l bz s0 pi true)
+    (fun _ -> exists_ (array_swap_outer_invariant pts_to n l bz s0 pi))
+=
+  rewrite (array_swap_outer_invariant pts_to n l bz s0 pi true) (array_swap_outer_invariant0 pts_to n l bz s0 pi true);
+  let _ = gen_elim () in
+  let i = R.read pi in
+  let s = vpattern_replace pts_to in
+  let save = index _ n i in
+  R.with_local 0sz (fun pj ->
+  R.with_local i (fun pidx ->
+    noop ();
+    intro_array_swap_inner_invariant pts_to n l bz s0 pi i pj pidx (0 < bz.q_n - 1) _ _ _;
+    Steel.ST.Loops.while_loop
+      (array_swap_inner_invariant pts_to n l bz s0 pi i pj pidx)
+      (fun _ ->
+        let gb = elim_exists () in
+        let _ = elim_array_swap_inner_invariant pts_to n l bz s0 pi i pj pidx gb in
+        let j = R.read pj in
+        [@@inline_let]
+        let b = j `SZ.lt` (q `SZ.sub` 1sz) in
+        intro_array_swap_inner_invariant pts_to n l bz s0 pi i pj pidx b _ _ _;
+        return b
+      )
+      (fun _ ->
+        let _ = elim_array_swap_inner_invariant pts_to n l bz s0 pi i pj pidx true in
+        let j = R.read pj in
+        let idx = R.read pidx in
+        let j' = j `SZ.add` 1sz in
+        let idx' = impl_jump n l idx in
+        let x = index _ n idx' in
+        let _ = upd _ n idx x in
+        R.write pj j';
+        R.write pidx idx';
+        intro_array_swap_inner_invariant pts_to n l bz s0 pi i pj pidx (SZ.v j' < bz.q_n - 1) _ _ _;
+        noop ()
+      );
+    let _ = elim_array_swap_inner_invariant pts_to n l bz s0 pi i pj pidx false in
+    let idx = R.read pidx in
+    let _ = upd _ n idx save in
+    Prf.jump_jump_iter_pred_q (SZ.v n) (SZ.v l) bz (SZ.v i);
+    [@@inline_let]
+    let i' = i `SZ.add` 1sz in
+    R.write pi i';
+    rewrite (array_swap_outer_invariant0 pts_to n l bz s0 pi (i' `SZ.lt` d)) (array_swap_outer_invariant pts_to n l bz s0 pi (i' `SZ.lt` d));
+    noop ()
+  ))
+
+#restart-solver
+inline_for_extraction
+let array_swap_aux
+  (#t: Type)
+  (#pts_to: array_pts_to_t t)
+  (index: array_index_t pts_to)
+  (upd: array_upd_t pts_to)
+  (s0: Ghost.erased (Seq.seq t))
+  (n: SZ.t)
+  (l: SZ.t)
+: ST (Ghost.erased (Seq.seq t))
+    (pts_to s0)
+    (fun s -> pts_to s)
+    (
+      SZ.v n == Seq.length s0 /\
+      SZ.v l > 0 /\
+      SZ.v l < SZ.v n
+    )
+    (fun s -> array_swap_aux_post s0 n l s)
+= let bz : Prf.bezout (SZ.v n) (SZ.v l) = Prf.mk_bezout (SZ.v n) (SZ.v l) in
+  let d = gcd n l in
+  let q = n `SZ.div` d in
+  assert (SZ.v d == bz.d);
+  FStar.Math.Lemmas.cancel_mul_div bz.q_n bz.d;
+  assert (SZ.v q == bz.q_n);
+  assert (SZ.v q > 0);
+  noop ();
+  let s = R.with_local 0sz (fun pi ->
+    array_swap_outer_invariant_prop_begin (SZ.v n) (SZ.v l) bz s0;
+    noop ();
+    rewrite (array_swap_outer_invariant0 pts_to n l bz s0 pi true) (array_swap_outer_invariant pts_to n l bz s0 pi true);
+    Steel.ST.Loops.while_loop
+      (array_swap_outer_invariant pts_to n l bz s0 pi)
+      (fun _ ->
+        let gb = elim_exists () in
+        rewrite (array_swap_outer_invariant pts_to n l bz s0 pi gb) (array_swap_outer_invariant0 pts_to n l bz s0 pi gb);
+        let _ = gen_elim () in
+        let i = R.read pi in
+        [@@inline_let]
+        let b = i `SZ.lt` d in
+        noop ();
+        rewrite (array_swap_outer_invariant0 pts_to n l bz s0 pi b) (array_swap_outer_invariant pts_to n l bz s0 pi b);
+        return b
+      )
+      (array_swap_outer_body index upd s0 n l bz d q pi ());
+    rewrite (array_swap_outer_invariant pts_to n l bz s0 pi false) (array_swap_outer_invariant0 pts_to n l bz s0 pi false);
+    let _ = gen_elim () in
+    let i = vpattern_erased (R.pts_to pi full_perm) in
+    let s = vpattern_replace pts_to in
+    array_swap_outer_invariant_prop_end (SZ.v n) (SZ.v l) bz s0 s (SZ.v i);
+    noop ();
+    return s
+  )
+  in
+  elim_pure (array_swap_aux_post s0 n l s);
+  return s
+
+#pop-options
+
+inline_for_extraction
+let array_swap_gen
+  (#t: Type)
+  (#pts_to: array_pts_to_t t)
+  (index: array_index_t pts_to)
+  (upd: array_upd_t pts_to)
+  (s0: Ghost.erased (Seq.seq t))
+  (n: SZ.t)
+  (l: SZ.t)
+: ST (Ghost.erased (Seq.seq t))
+    (pts_to s0)
+    (fun s -> pts_to s)
+    (
+      SZ.v n == Seq.length s0 /\
+      SZ.v l <= SZ.v n
+    )
+    (fun s ->
+      SZ.v n == Seq.length s0 /\
+      SZ.v l <= SZ.v n /\
+      s `Seq.equal` (Seq.slice s0 (SZ.v l) (SZ.v n) `Seq.append` Seq.slice s0 0 (SZ.v l))
+    )
+= if l = 0sz || l = n
+  then begin
+    noop ();
+    return s0
+  end
+  else array_swap_aux index upd s0 n l

--- a/lib/steel/Steel.ST.GenArraySwap.fst
+++ b/lib/steel/Steel.ST.GenArraySwap.fst
@@ -139,16 +139,7 @@ let array_swap_inner_invariant_prop
   (idx: nat)
   (b: bool)
 : GTot prop
-=
-  array_swap_partial_invariant n l bz s0 s i /\
-  i < bz.d /\
-  bz.d < n /\
-  j <= bz.q_n - 1 /\
-  idx == Prf.iter_fun #(Prf.nat_up_to n) (Prf.jump n l) j i /\
-  (forall (j': Prf.nat_up_to bz.q_n) .
-      let idx = Prf.iter_fun #(Prf.nat_up_to n) (Prf.jump n l) j' i in
-      Seq.index s idx == Seq.index s0 (if j' < j then Prf.jump n l idx else idx)
-  ) /\
+= Prf.array_swap_inner_invariant s0 n l bz s i j idx /\
   (b == (j < bz.q_n - 1))
 
 let array_swap_outer_invariant_prop
@@ -161,13 +152,7 @@ let array_swap_outer_invariant_prop
   (i: nat)
   (b: bool)
 : GTot prop
-= array_swap_partial_invariant n l bz s0 s i /\
-  bz.d < n /\
-  (forall (j: Prf.nat_up_to bz.q_n) .
-    (i < bz.d) ==> (
-    let idx = Prf.iter_fun #(Prf.nat_up_to n) (Prf.jump n l) j i in
-    Seq.index s idx == Seq.index s0 idx
-  )) /\
+= Prf.array_swap_outer_invariant s0 n l bz s i /\
   (b == (i < bz.d))
 
 [@@__reduce__]
@@ -408,7 +393,7 @@ let impl_jump
   then idx `SZ.sub` nl
   else idx `SZ.add` l
 
-#push-options "--z3rlimit 128"
+#push-options "--z3rlimit 32"
 
 #restart-solver
 inline_for_extraction
@@ -475,10 +460,6 @@ let array_swap_outer_body
     intro_array_swap_outer_invariant pts_to n l bz s0 pi (i' `SZ.lt` d) _ _;
     noop ()
   ))
-
-#pop-options
-
-#push-options "--z3rlimit 256 --split_queries always" // WHY WHY WHY is the pattern on array_as_ring_buffer_swap SO hard to trigger?
 
 #restart-solver
 inline_for_extraction

--- a/lib/steel/Steel.ST.GenArraySwap.fsti
+++ b/lib/steel/Steel.ST.GenArraySwap.fsti
@@ -1,0 +1,75 @@
+module Steel.ST.GenArraySwap
+open Steel.ST.Util
+
+module SZ = FStar.SizeT
+
+let array_pts_to_t
+  (t: Type)
+: Tot Type
+= Ghost.erased (Seq.seq t) -> Tot vprop
+
+inline_for_extraction
+let array_index_t
+  (#t: Type)
+  (pts_to: array_pts_to_t t)
+: Tot Type
+=
+  (s: Ghost.erased (Seq.seq t)) ->
+  (n: SZ.t) ->
+  (i: SZ.t) ->
+  ST t
+    (pts_to s)
+    (fun _ -> pts_to s)
+    (
+      SZ.v i < Seq.length s /\
+      SZ.v n == Seq.length s
+    )
+    (fun x ->
+      SZ.v i < Seq.length s /\
+      x == Seq.index s (SZ.v i)
+    )
+
+inline_for_extraction
+let array_upd_t
+  (#t: Type)
+  (pts_to: array_pts_to_t t)
+: Tot Type
+=
+  (s: Ghost.erased (Seq.seq t)) ->
+  (n: SZ.t) ->
+  (i: SZ.t) ->
+  (x: t) ->
+  ST (Ghost.erased (Seq.seq t))
+    (pts_to s)
+    (fun s' -> pts_to s')
+    (
+      SZ.v n == Seq.length s /\
+      SZ.v i < SZ.v n
+    )
+    (fun s' ->
+      SZ.v n == Seq.length s /\
+      SZ.v i < SZ.v n /\
+      Ghost.reveal s' == Seq.upd s (SZ.v i) x
+    )
+
+inline_for_extraction
+val array_swap_gen
+  (#t: Type0)
+  (#pts_to: array_pts_to_t t)
+  (index: array_index_t pts_to)
+  (upd: array_upd_t pts_to)
+  (s0: Ghost.erased (Seq.seq t))
+  (n: SZ.t)
+  (l: SZ.t)
+: ST (Ghost.erased (Seq.seq t))
+    (pts_to s0)
+    (fun s -> pts_to s)
+    (
+      SZ.v n == Seq.length s0 /\
+      SZ.v l <= SZ.v n
+    )
+    (fun s ->
+      SZ.v n == Seq.length s0 /\
+      SZ.v l <= SZ.v n /\
+      s `Seq.equal` (Seq.slice s0 (SZ.v l) (SZ.v n) `Seq.append` Seq.slice s0 0 (SZ.v l))
+    )

--- a/share/steel/examples/pulse/ArraySwap.fst
+++ b/share/steel/examples/pulse/ArraySwap.fst
@@ -12,7 +12,6 @@ module SZ = FStar.SizeT
 
 #set-options "--ide_id_info_off"
 
-#push-options "--query_stats --z3rlimit 32"
 #restart-solver
 
 ```pulse
@@ -50,8 +49,6 @@ fn gcd (n0: SZ.t) (l0: SZ.t)
 }
 ```
 
-#pop-options
-
 inline_for_extraction
 let impl_jump
   (n: SZ.t)
@@ -72,7 +69,7 @@ let impl_jump
   then idx `SZ.sub` nl
   else idx `SZ.add` l
 
-#push-options "--query_stats --z3rlimit 32 --split_queries always"
+#push-options "--query_stats --z3rlimit 256"
 #restart-solver
 
 ```pulse
@@ -104,6 +101,7 @@ fn array_swap(#t: Type0) (#s0: Ghost.erased (Seq.seq t)) (a: A.array t) (n: SZ.t
     )) {
       let i = !pi;
       let save = a.(i);
+      let save_eq0 = magic () <: squash (save == Seq.index s0 (SZ.v i));
       let mut pj = 0sz;
       let mut pidx = i;
       while (let j = !pj; (j `SZ.lt` (q `SZ.sub` 1sz)))
@@ -120,6 +118,7 @@ fn array_swap(#t: Type0) (#s0: Ghost.erased (Seq.seq t)) (a: A.array t) (n: SZ.t
         let j = !pj;
         let idx = !pidx;
         let idx' = impl_jump n l idx;
+        let idx'_eq = () <: squash (SZ.v idx' == Prf.jump (SZ.v n) (SZ.v l) (SZ.v idx));
         let x = a.(idx');
         let j' = j `SZ.add` 1sz;
         (a.(idx) <- x);
@@ -130,6 +129,7 @@ fn array_swap(#t: Type0) (#s0: Ghost.erased (Seq.seq t)) (a: A.array t) (n: SZ.t
       let idx = !pidx;
       (a.(idx) <- save);
       let i' = i `SZ.add` 1sz;
+      let i'_eq = () <: squash (SZ.v i' == SZ.v i + 1);
       pi := i';
       ()
     };

--- a/share/steel/examples/pulse/ArraySwap.fst
+++ b/share/steel/examples/pulse/ArraySwap.fst
@@ -149,7 +149,6 @@ fn pulse_assert (p: prop)
   }
 ```
 
-#push-options "--query_stats --z3rlimit 64"
 #restart-solver
 
 ```pulse
@@ -214,5 +213,3 @@ fn array_swap(#t: Type0) (#s0: Ghost.erased (Seq.seq t)) (a: A.array t) (n: SZ.t
     ()
 }
 ```
-
-#pop-options

--- a/share/steel/examples/pulse/ArraySwap.fst
+++ b/share/steel/examples/pulse/ArraySwap.fst
@@ -129,6 +129,16 @@ fn get_array_pts_to (#t: Type0) (a: A.array t) (#p: perm) (#s: Ghost.erased (Seq
   }
 ```
 
+```pulse
+fn get_pts_to (#t: Type0) (a: R.ref t) (#p: perm) (#s: Ghost.erased (t))
+  requires (R.pts_to a p s)
+  returns s': Ghost.erased (t)
+  ensures (R.pts_to a p s `star` pure (s' == s))
+  {
+    s
+  }
+```
+
 #push-options "--query_stats --z3rlimit 64"
 #restart-solver
 
@@ -185,12 +195,15 @@ fn array_swap(#t: Type0) (#s0: Ghost.erased (Seq.seq t)) (a: A.array t) (n: SZ.t
         pidx := idx';
         ()
       };
-      ();
+      let gj = get_pts_to pj;
       let s = get_array_pts_to a;
       let idx = !pidx;
+      ();
+      let prf = () <: squash (Prf.array_swap_inner_invariant s0 (SZ.v n) (SZ.v l) bz s (SZ.v i) (SZ.v gj) (SZ.v idx));
+//      Prf.array_swap_inner_invariant_end (SZ.v n) (SZ.v l) bz s0 s (SZ.v i) (SZ.v gj) (SZ.v idx);
+      ();
       (a.(idx) <- save);
       let i' = size_add i 1sz ();
-//      Prf.array_as_ring_buffer_swap (SZ.v n) (SZ.v l) bz s0 s;
       pi := i';
       ()
     };

--- a/share/steel/examples/pulse/ArraySwap.fst
+++ b/share/steel/examples/pulse/ArraySwap.fst
@@ -139,6 +139,16 @@ fn get_pts_to (#t: Type0) (a: R.ref t) (#p: perm) (#s: Ghost.erased (t))
   }
 ```
 
+```pulse
+fn pulse_assert (p: prop)
+  requires (pure p)
+  returns res: squash p
+  ensures emp
+  {
+    ()
+  }
+```
+
 #push-options "--query_stats --z3rlimit 64"
 #restart-solver
 
@@ -171,11 +181,10 @@ fn array_swap(#t: Type0) (#s0: Ghost.erased (Seq.seq t)) (a: A.array t) (n: SZ.t
     )) {
       let i = !pi;
       let save = a.(i);
-      let save_eq0 = magic () <: squash (save == Seq.index s0 (SZ.v i));
       let mut pj = 0sz;
       let mut pidx = i;
       while (let j = !pj; (j `size_lt` (size_sub q 1sz ())))
-      invariant b . exists s i j idx . (
+      invariant b . exists s j idx . (
         A.pts_to a full_perm s `star`
         R.pts_to pi full_perm i `star`
         R.pts_to pj full_perm j `star`
@@ -195,13 +204,8 @@ fn array_swap(#t: Type0) (#s0: Ghost.erased (Seq.seq t)) (a: A.array t) (n: SZ.t
         pidx := idx';
         ()
       };
-      let gj = get_pts_to pj;
-      let s = get_array_pts_to a;
+      ();
       let idx = !pidx;
-      ();
-      let prf = () <: squash (Prf.array_swap_inner_invariant s0 (SZ.v n) (SZ.v l) bz s (SZ.v i) (SZ.v gj) (SZ.v idx));
-//      Prf.array_swap_inner_invariant_end (SZ.v n) (SZ.v l) bz s0 s (SZ.v i) (SZ.v gj) (SZ.v idx);
-      ();
       (a.(idx) <- save);
       let i' = size_add i 1sz ();
       pi := i';

--- a/share/steel/examples/pulse/ArraySwap.fst
+++ b/share/steel/examples/pulse/ArraySwap.fst
@@ -1,0 +1,140 @@
+module ArraySwap
+module T = FStar.Tactics
+module PM = Pulse.Main
+open Steel.ST.Util 
+open Steel.FractionalPermission
+module U32 = FStar.UInt32
+open Pulse.Steel.Wrapper
+module A = Steel.ST.Array
+module R = Steel.ST.Reference
+module Prf = Steel.ST.GenArraySwap.Proof
+module SZ = FStar.SizeT
+
+#set-options "--ide_id_info_off"
+
+#push-options "--query_stats --z3rlimit 32"
+#restart-solver
+
+```pulse
+fn gcd (n0: SZ.t) (l0: SZ.t)
+  requires (emp `star` pure (
+    SZ.v l0 < SZ.v n0
+  ))
+  returns res : SZ.t
+  ensures (emp `star` pure (
+    SZ.v l0 < SZ.v n0 /\
+    SZ.v res == (Prf.mk_bezout (SZ.v n0) (SZ.v l0)).d  
+  ))
+{
+  let mut pn = n0;
+  let mut pl = l0;
+  while (let l = !pl ; (l `SZ.gt` 0sz))
+  invariant b . exists n l . (
+    R.pts_to pn full_perm n `star`
+    R.pts_to pl full_perm l `star`
+    pure (
+      SZ.v l < SZ.v n /\
+      (Prf.mk_bezout (SZ.v n0) (SZ.v l0)).d == (Prf.mk_bezout (SZ.v n) (SZ.v l)).d /\
+      b == (SZ.v l > 0)
+    ))
+  {
+    let n = !pn;
+    let l = !pl;
+    let l' = SZ.rem n l;
+    pn := l;
+    pl := l';
+    ()
+  };
+  let res = !pn;
+  res
+}
+```
+
+#pop-options
+
+inline_for_extraction
+let impl_jump
+  (n: SZ.t)
+  (l: SZ.t)
+  (idx: SZ.t)
+: Pure SZ.t
+    (requires (
+      SZ.v l < SZ.v n /\
+      SZ.v idx < SZ.v n
+    ))
+    (ensures (fun idx' ->
+      SZ.v idx' == Prf.jump (SZ.v n) (SZ.v l) (SZ.v idx)
+    ))
+= Prf.jump_if (SZ.v n) (SZ.v l) () (SZ.v idx);
+  [@@inline_let]
+  let nl = n `SZ.sub` l in
+  if idx `SZ.gte` nl
+  then idx `SZ.sub` nl
+  else idx `SZ.add` l
+
+#push-options "--query_stats --z3rlimit 32 --split_queries always"
+#restart-solver
+
+```pulse
+fn array_swap(#t: Type0) (#s0: Ghost.erased (Seq.seq t)) (a: A.array t) (n: SZ.t) (l: SZ.t) (bz: Prf.bezout (SZ.v n) (SZ.v l)) (d: SZ.t) (q: SZ.t)
+  requires (
+    A.pts_to a full_perm s0 `star`
+    pure (
+      SZ.v n == A.length a /\
+      SZ.v n == Seq.length s0 /\
+      0 < SZ.v l /\
+      SZ.v l < SZ.v n /\
+      SZ.v d == bz.d /\
+      SZ.v q == bz.q_n
+    )
+  )
+  ensures exists s . (
+    A.pts_to a full_perm s `star`
+    pure (Prf.array_swap_post s0 (SZ.v n) (SZ.v l) s) // hoisted out because of the SMT pattern on array_as_ring_buffer_swap
+  )
+{
+    let mut pi = 0sz;
+    while (let i = !pi; (i `SZ.lt` d))
+    invariant b . exists s i . (
+      A.pts_to a full_perm s `star`
+      R.pts_to pi full_perm i `star`
+      pure (
+        Prf.array_swap_outer_invariant s0 (SZ.v n) (SZ.v l) bz s (SZ.v i) /\
+        eq2_prop #bool b (SZ.v i < bz.d)
+    )) {
+      let i = !pi;
+      let save = a.(i);
+      let mut pj = 0sz;
+      let mut pidx = i;
+      while (let j = !pj; (j `SZ.lt` (q `SZ.sub` 1sz)))
+      invariant b . exists s i j idx . (
+        A.pts_to a full_perm s `star`
+        R.pts_to pi full_perm i `star`
+        R.pts_to pj full_perm j `star`
+        R.pts_to pidx full_perm idx `star`
+        pure (
+          Prf.array_swap_inner_invariant s0 (SZ.v n) (SZ.v l) bz s (SZ.v i) (SZ.v j) (SZ.v idx) /\
+          eq2_prop #bool b (SZ.v j < bz.q_n - 1)
+        )
+      ) {
+        let j = !pj;
+        let idx = !pidx;
+        let idx' = impl_jump n l idx;
+        let x = a.(idx');
+        let j' = j `SZ.add` 1sz;
+        (a.(idx) <- x);
+        pj := j';
+        pidx := idx';
+        ()
+      };
+      let idx = !pidx;
+      (a.(idx) <- save);
+      let i' = i `SZ.add` 1sz;
+      pi := i';
+      ()
+    };
+    ()
+}
+```
+
+#pop-options

--- a/share/steel/tests/krml/ArraySwap.fst
+++ b/share/steel/tests/krml/ArraySwap.fst
@@ -1,0 +1,24 @@
+module ArraySwap
+open Steel.ST.Util
+open Steel.ST.Array.Swap
+
+let main () : ST Int32.t emp (fun _ -> emp) True (fun i -> i == 0l) = 
+  let arr = malloc 0l 12sz in
+  pts_to_length arr _;
+  upd arr 1sz 1l;
+  upd arr 2sz 2l;
+  upd arr 3sz 3l;
+  upd arr 4sz 4l;
+  upd arr 5sz 5l;
+  upd arr 6sz 6l;
+  upd arr 7sz 7l;
+  upd arr 8sz 8l;
+  upd arr 9sz 9l;
+  upd arr 10sz 10l;
+  upd arr 11sz 11l;
+  let _ = swap arr 12sz 8sz in
+  let a3 = index arr 3sz in
+  let a7 = index arr 7sz in
+  let b = (a3 = 11l && a7 = 3l) in
+  free arr;
+  return (if b then 0l else 1l)


### PR DESCRIPTION
Let `a` be an array of size `n`, and let `0 < l < n`. How do we swap the regions from `0` to `l-1` and from `l` to `n-1` of `a`?
With @mtzguido , we have been working on a verified implementation performing this task **fully in-place** and in only `n` writes.

To do that, we compute the gcd of `n` and `l`, say `d`, so that any array index `x` can be reached from some `i` such that `0 <= i < n` by repeatedly adding `l` and truncating modulo `n`, and such starting point `i` is unique for a given `x`.
Then, for each such `i`, we save the contents of `a[i]`, then we shift `a[(i+l)%n]`, `a[(i+2l)%n]`, etc. to `l` positions to the left (treating `a` as a "ring buffer"), and we do it `n/d - 1` times, and then we restore the saved contents to the last index of that cycle.

The proof involves:
* [Bézout's identity](https://en.wikipedia.org/wiki/B%C3%A9zout%27s_identity), which we use as a characterization of the gcd (so we do not really exploit the "greatest" aspect of the gcd in terms of integer ordering, rather it's the common divisor that is greatest to work with.) With this identity, we show that every number can be reached from its remainder in its division by `d` with at most `n/d - 1` steps.
* [Euclid's lemma](https://en.wikipedia.org/wiki/Euclid%27s_lemma) (also called Gauß' lemma), to prove that, for a given array index `x`, if `x` can be reached from `i` with `k` steps, where `0 <= i < d` and `0 <= k < n/d`, then such `i` and `k` are unique. A SMT pattern on the latter lemma allows to automatically prove that all array accesses are disjoint.

With those two lemmas, we don't need to reason about periodic sequences or anything, it is enough to reason with integer ring computations.