### PR TITLE
ci: shuffle dockerfiles a bit

### DIFF
--- a/src/ci/ci.Dockerfile
+++ b/src/ci/ci.Dockerfile
@@ -3,6 +3,14 @@
 ARG ocaml_version=4.12
 FROM ocaml/opam:ubuntu-22.04-ocaml-$ocaml_version
 
+# CI dependencies for the Wasm11 test: node.js
+# The sed call is a workaround for these upstream issues... sigh.
+# https://github.com/nodesource/distributions/issues/1576
+# https://github.com/nodesource/distributions/issues/1593
+# Remove when they are solved
+RUN curl -fsSL https://deb.nodesource.com/setup_16.x | sed 's,https://deb.nodesource.com,http://deb.nodesource.com,' | sudo -E bash -
+RUN sudo apt-get install -y --no-install-recommends nodejs
+
 ARG opamthreads=24
 
 ADD --chown=opam:opam ./ steel/
@@ -22,14 +30,6 @@ RUN sudo apt-get update && sudo apt-get install --yes --no-install-recommends \
     git clone --branch $(jq -c -r '.RepoVersions.karamel' steel/src/ci/config.json || echo master) https://github.com/FStarLang/karamel $KRML_HOME && \
     eval $(opam env) && $KRML_HOME/.docker/build/install-other-deps.sh && \
     env OTHERFLAGS='--admit_smt_queries true' make -C $KRML_HOME -j $opamthreads
-
-# CI dependencies for the Wasm11 test: node.js
-# The sed call is a workaround for these upstream issues... sigh.
-# https://github.com/nodesource/distributions/issues/1576
-# https://github.com/nodesource/distributions/issues/1593
-# Remove when they are solved
-RUN curl -fsSL https://deb.nodesource.com/setup_16.x | sed 's,https://deb.nodesource.com,http://deb.nodesource.com,' | sudo -E bash -
-RUN sudo apt-get install -y --no-install-recommends nodejs
 
 # Steel CI proper
 ARG STEEL_NIGHTLY_CI

--- a/src/ci/hierarchic.Dockerfile
+++ b/src/ci/hierarchic.Dockerfile
@@ -3,6 +3,14 @@
 ARG FSTAR_BRANCH=master
 FROM fstar:local-branch-$FSTAR_BRANCH
 
+# CI dependencies for the Wasm11 test: node.js
+# The sed call is a workaround for these upstream issues... sigh.
+# https://github.com/nodesource/distributions/issues/1576
+# https://github.com/nodesource/distributions/issues/1593
+# Remove when they are solved
+RUN curl -fsSL https://deb.nodesource.com/setup_16.x | sed 's,https://deb.nodesource.com,http://deb.nodesource.com,' | sudo -E bash -
+RUN sudo apt-get install -y --no-install-recommends nodejs
+
 ADD --chown=opam:opam ./ $HOME/steel
 WORKDIR $HOME/steel
 
@@ -12,14 +20,6 @@ RUN mkdir -p $HOME/steel_tools && \
     git clone --branch $(jq -c -r '.RepoVersions.karamel' $HOME/steel/src/ci/config.json || echo master) https://github.com/FStarLang/karamel $KRML_HOME && \
     eval $(opam env) && $KRML_HOME/.docker/build/install-other-deps.sh && \
     env OTHERFLAGS='--admit_smt_queries true' make -C $KRML_HOME -j $opamthreads
-
-# CI dependencies for the Wasm11 test: node.js
-# The sed call is a workaround for these upstream issues... sigh.
-# https://github.com/nodesource/distributions/issues/1576
-# https://github.com/nodesource/distributions/issues/1593
-# Remove when they are solved
-RUN curl -fsSL https://deb.nodesource.com/setup_16.x | sed 's,https://deb.nodesource.com,http://deb.nodesource.com,' | sudo -E bash -
-RUN sudo apt-get install -y --no-install-recommends nodejs
 
 # Steel CI proper
 ARG STEEL_NIGHTLY_CI

--- a/src/ci/no-fstar-home.Dockerfile
+++ b/src/ci/no-fstar-home.Dockerfile
@@ -5,6 +5,14 @@ FROM ocaml/opam:ubuntu-22.04-ocaml-$ocaml_version
 
 ARG opamthreads=24
 
+# CI dependencies for the Wasm11 test: node.js
+# The sed call is a workaround for these upstream issues... sigh.
+# https://github.com/nodesource/distributions/issues/1576
+# https://github.com/nodesource/distributions/issues/1593
+# Remove when they are solved
+RUN curl -fsSL https://deb.nodesource.com/setup_16.x | sed 's,https://deb.nodesource.com,http://deb.nodesource.com,' | sudo -E bash -
+RUN sudo apt-get install -y --no-install-recommends nodejs
+
 ADD --chown=opam:opam ./ steel/
 
 # Install F* and Karamel from the Karamel CI install script
@@ -23,14 +31,6 @@ RUN sudo apt-get update && sudo apt-get install --yes --no-install-recommends \
     env FSTAR_HOME=$HOME/FStar OTHERFLAGS='--admit_smt_queries true' make -C $KRML_HOME -j $opamthreads
 
 ENV PATH=$HOME/FStar/bin:$PATH
-
-# CI dependencies for the Wasm11 test: node.js
-# The sed call is a workaround for these upstream issues... sigh.
-# https://github.com/nodesource/distributions/issues/1576
-# https://github.com/nodesource/distributions/issues/1593
-# Remove when they are solved
-RUN curl -fsSL https://deb.nodesource.com/setup_16.x | sed 's,https://deb.nodesource.com,http://deb.nodesource.com,' | sudo -E bash -
-RUN sudo apt-get install -y --no-install-recommends nodejs
 
 # Steel CI proper
 ARG STEEL_NIGHTLY_CI


### PR DESCRIPTION
Installing dependencies (some of them, the ones we know a priori) before
the ADD helps with the build being cached up to that point. Since the
ADD adds every file in the repo, including potentially the git history,
any change whatsoever invalidates the cache for every step that follows.
