### PR TITLE
snap for FStarLang/FStar#3001

### DIFF
--- a/src/ocaml/plugin/generated/Pulse_Main.ml
+++ b/src/ocaml/plugin/generated/Pulse_Main.ml
@@ -532,6 +532,7 @@ let _ =
        fun ncb ->
          fun args ->
            FStar_Tactics_V2_InterpFuns.mk_tactic_interpretation_7
+             "Pulse.Main.check_pulse (plugin)"
              (FStar_Tactics_Native.from_tactic_7 check_pulse)
              (FStar_Syntax_Embeddings.e_list FStar_Syntax_Embeddings.e_string)
              (FStar_Syntax_Embeddings.e_list

--- a/src/ocaml/plugin/generated/Steel_Effect_Common.ml
+++ b/src/ocaml/plugin/generated/Steel_Effect_Common.ml
@@ -568,6 +568,7 @@ let _ =
        fun ncb ->
          fun args ->
            FStar_Tactics_V2_InterpFuns.mk_tactic_interpretation_1
+             "Steel.Effect.Common.frame_vc_norm (plugin)"
              (FStar_Tactics_Native.from_tactic_1 frame_vc_norm)
              FStar_Syntax_Embeddings.e_unit FStar_Syntax_Embeddings.e_unit
              psc ncb args)
@@ -16908,6 +16909,7 @@ let _ =
        fun ncb ->
          fun args ->
            FStar_Tactics_V2_InterpFuns.mk_tactic_interpretation_1
+             "Steel.Effect.Common.init_resolve_tac (plugin)"
              (FStar_Tactics_Native.from_tactic_1 init_resolve_tac)
              FStar_Syntax_Embeddings.e_unit FStar_Syntax_Embeddings.e_unit
              psc ncb args)
@@ -17034,6 +17036,7 @@ let _ =
        fun ncb ->
          fun args ->
            FStar_Tactics_V2_InterpFuns.mk_tactic_interpretation_1
+             "Steel.Effect.Common.selector_tactic (plugin)"
              (FStar_Tactics_Native.from_tactic_1 selector_tactic)
              FStar_Syntax_Embeddings.e_unit FStar_Syntax_Embeddings.e_unit
              psc ncb args)

--- a/src/ocaml/plugin/generated/Steel_ST_GenElim1_Base.ml
+++ b/src/ocaml/plugin/generated/Steel_ST_GenElim1_Base.ml
@@ -4126,6 +4126,7 @@ let _ =
        fun ncb ->
          fun args ->
            FStar_Tactics_V2_InterpFuns.mk_tactic_interpretation_1
+             "Steel.ST.GenElim1.Base.init_resolve_tac (plugin)"
              (FStar_Tactics_Native.from_tactic_1 init_resolve_tac)
              FStar_Syntax_Embeddings.e_unit FStar_Syntax_Embeddings.e_unit
              psc ncb args)

--- a/src/ocaml/plugin/generated/Steel_ST_GenElim_Base.ml
+++ b/src/ocaml/plugin/generated/Steel_ST_GenElim_Base.ml
@@ -3738,6 +3738,7 @@ let _ =
        fun ncb ->
          fun args ->
            FStar_Tactics_V2_InterpFuns.mk_tactic_interpretation_1
+             "Steel.ST.GenElim.Base.init_resolve_tac (plugin)"
              (FStar_Tactics_Native.from_tactic_1 init_resolve_tac)
              FStar_Syntax_Embeddings.e_unit FStar_Syntax_Embeddings.e_unit
              psc ncb args)


### PR DESCRIPTION
This is needed to not break the build after FStarLang/FStar#3001 is merged. The plugin registration calls now take a string that will be displayed on error contexts.