### PR TITLE
examples/pulse/Makefile: include current directory too

### DIFF
--- a/share/steel/examples/pulse/Makefile
+++ b/share/steel/examples/pulse/Makefile
@@ -1,5 +1,5 @@
 STEEL_HOME=../../../..
-INCLUDE_DIRS=bug-reports lib dice/common dice/dpe dice/engine dice/l0
+INCLUDE_DIRS=bug-reports lib dice/common dice/dpe dice/engine dice/l0 .
 CACHE_DIR=.cache
 SRC_DIRS=$(addprefix $(STEEL_HOME)/share/steel/examples/pulse/, $(INCLUDE_DIRS))
 FSTAR_FILES=$(wildcard $(addsuffix /*fst, $(SRC_DIRS))) $(wildcard $(addsuffix /*fsti, $(SRC_DIRS)))


### PR DESCRIPTION
Looks like just an omission, setting for automerge.
