### PR TITLE
Fixes for F* PR #3004

### DIFF
--- a/lib/steel/Steel.ST.Array.fsti
+++ b/lib/steel/Steel.ST.Array.fsti
@@ -357,7 +357,7 @@ let join
   ghost_join a1 a2 ();
   let res = merge a1 a2 in
   rewrite
-    (pts_to (merge a1 (Ghost.reveal a2)) p (x1 `Seq.append` x2))
+    (pts_to (merge a1 (Ghost.hide (Ghost.reveal a2))) p (x1 `Seq.append` x2))
     (pts_to res p (x1 `Seq.append` x2));
   return res
 

--- a/lib/steel/Steel.ST.HigherArray.fsti
+++ b/lib/steel/Steel.ST.HigherArray.fsti
@@ -388,7 +388,7 @@ let join
   (a2: Ghost.erased (array elt))
 : STAtomicBase (array elt) false opened Unobservable
     (pts_to a1 p x1 `star` pts_to a2 p x2)
-    (fun res -> pts_to res p ((Ghost.reveal x1) `Seq.append` (Ghost.reveal x2)))
+    (fun res -> pts_to res p (x1 `Seq.append` x2))
     (adjacent a1 a2)
     (fun res -> merge_into a1 a2 res)
 = let _ : squash (adjacent a1 a2) = () in

--- a/lib/steel/Steel.ST.HigherArray.fsti
+++ b/lib/steel/Steel.ST.HigherArray.fsti
@@ -388,14 +388,14 @@ let join
   (a2: Ghost.erased (array elt))
 : STAtomicBase (array elt) false opened Unobservable
     (pts_to a1 p x1 `star` pts_to a2 p x2)
-    (fun res -> pts_to res p (x1 `Seq.append` x2))
+    (fun res -> pts_to res p ((Ghost.reveal x1) `Seq.append` (Ghost.reveal x2)))
     (adjacent a1 a2)
     (fun res -> merge_into a1 a2 res)
 = let _ : squash (adjacent a1 a2) = () in
   ghost_join a1 a2 ();
   let res = merge a1 a2 in
   rewrite
-    (pts_to (merge a1 (Ghost.reveal a2)) p (x1 `Seq.append` x2))
+    (pts_to (merge a1 (Ghost.hide (Ghost.reveal a2))) p (x1 `Seq.append` x2))
     (pts_to res p (x1 `Seq.append` x2));
   return res
 

--- a/share/steel/examples/pulse/dice/engine/EngineCore.fst
+++ b/share/steel/examples/pulse/dice/engine/EngineCore.fst
@@ -142,13 +142,13 @@ fn engine_main (cdi:cdi_t) (uds:A.larray U8.t (US.v uds_len)) (record:engine_rec
   {
     compute_cdi cdi uds record #repr #(coerce dice_digest_len c0);
     with s. assert (A.pts_to uds full_perm s);
-    A.zeroize uds_len uds #(coerce_refined uds_len s);
+    A.zeroize uds_len uds;
     disable_uds();
     DICE_SUCCESS
   }
   else
   {
-    A.zeroize uds_len uds #uds_bytes;
+    A.zeroize uds_len uds;
     disable_uds ();
     DICE_ERROR
   }


### PR DESCRIPTION
The explanation for the steel fixes is in the F* PR (https://github.com/FStarLang/FStar/pull/3004).

The Pulse breakages are due to some type conversions under `Ghost.erased`. But those implicit annotations are not needed anyway, so ended up removing these.