### PR TITLE
A tweak to the matching step in the prover

### DIFF
--- a/lib/steel/pulse/Pulse.Checker.Prover.Match.fst
+++ b/lib/steel/pulse/Pulse.Checker.Prover.Match.fst
@@ -238,16 +238,6 @@ let rec try_solve_uvars (g:env) (uvs:env { disjoint uvs g })
            | _, _ -> PS.empty
   end
 
-// let unify (g:env) (uvs:env { disjoint uvs g})
-//   (p q:term) (ss:PS.ss_t)
-//   : T.Tac (option (ss':PS.ss_t { ss' `ss_extends` ss } &
-//                    RT.equiv (elab_env g) (elab_term p) (elab_term ss'.(q)))) =
-
-//   let q0 = q in
-//   let ss' = try_solve_uvars g uvs p q ss in
-//   let q = ss'.(q) in
-
-
 let unify (g:env) (uvs:env { disjoint uvs g})
   (p q:term)
   : T.Tac (option (ss:PS.ss_t { PS.dom ss `Set.subset` freevars q } &
@@ -266,119 +256,6 @@ let unify (g:env) (uvs:env { disjoint uvs g})
        | Some token, _ -> Some (| ss, RT.EQ_Token _ _ _ (FStar.Squash.return_squash token) |)
        | None, _ -> None
   else None
-
-  // let rt_equiv g t1 t2 : RT.equiv g t1 t2 =
-  //   assume (t1 == t2);
-  //   RT.EQ_Refl _ _
-  // in
-
-  // let q0 = q in
-  // let q = ss.(q) in
-  // assume (freevars q `Set.disjoint` PS.dom ss);
-
-  // debug_prover g (fun _ ->
-  //   Printf.sprintf "prover.match trying %s =?= %s" (P.term_to_string p) (P.term_to_string q));
-
-  // if eq_tm p q
-  // then begin
-  //   debug_prover g (fun _ ->
-  //     Printf.sprintf "prover.match trying %s =?= %s, eq_tm" (P.term_to_string p) (P.term_to_string q));
-
-  //   assume (PS.dom ss `Set.subset` freevars q);
-  //   Some (| ss, RT.EQ_Refl _ _ |)
-  // end
-  // else if not (contains_uvar q uvs g)
-  // then begin
-  //   if eligible_for_smt_equality g p q
-  //   then let _ =
-  //          debug_prover g (fun _ ->
-  //            Printf.sprintf "prover.match trying %s =?= %s, not eq_tm, q has no uvar, eligible for smt" (P.term_to_string p) (P.term_to_string q))
-  //        in
-  //        let _ = assume (PS.dom ss `Set.subset` freevars q) in
-  //        let v0 = elab_term p in
-  //        let v1 = elab_term q in
-  //        match T.check_equiv (elab_env g) v0 v1 with
-  //        | Some token, _ -> Some (| ss, RT.EQ_Token _ _ _ (FStar.Squash.return_squash token) |)
-  //        | None, _ -> None
-  //   else let _ =
-  //          debug_prover g (fun _ ->
-  //            Printf.sprintf "prover.match trying %s =?= %s, not eq_tm, q has no uvar, not eligible for smt" (P.term_to_string p) (P.term_to_string q))
-  //        in
-  //        None
-  // end
-  // else match is_reveal_uvar q uvs, is_reveal p with
-  //      | Some (u, ty, n), false ->
-  //        debug_prover g (fun _ ->
-  //            Printf.sprintf "prover.match trying %s =?= %s, not eq_tm, q is reveal of uvar, p is not reveal" (P.term_to_string p) (P.term_to_string q));
-  //        let w = mk_hide u ty p in
-  //        assume (Set.mem n (dom uvs));
-  //        assume (~ (PS.contains PS.empty n));
-  //        assume (Set.disjoint (freevars w) (dom uvs));
-  //        let ss_new = PS.push PS.empty n w in
-  //        assume (n `Set.mem` freevars q);
-  //        assume (Set.equal (PS.dom ss_new) (Set.singleton n));
-  //        assert (Set.disjoint (PS.dom ss_new) (PS.dom ss));
-  //        let ss' = PS.push_ss ss ss_new in
-  //        assume (ss' `ss_extends` ss);
-  //        assume (ss'.(q0) == w);
-  //        assume (PS.dom ss' `Set.subset` freevars q0);  // they are actually equal
-  //        let b, _ = T.check_equiv (elab_env g) (elab_term (mk_reveal u ty w)) (elab_term p) in
-  //        if Some? b
-  //        then let d : RT.equiv (elab_env g) (elab_term p) (elab_term ss'.(q0)) = rt_equiv _ _ _ in
-  //             Some (| ss', d |)
-  //        else None
-  //      | _ ->
-  //        match is_uvar q uvs with
-  //        | Some n ->
-  //          debug_prover g (fun _ ->
-  //            Printf.sprintf "prover.match trying %s =?= %s, not eq_tm, q is uvar" (P.term_to_string p) (P.term_to_string q));
-  //          assume (Set.mem n (dom uvs));
-  //          assume (~ (PS.contains PS.empty n));
-  //          assume (Set.disjoint (freevars p) (dom uvs));
-  //          let ss_new = PS.push PS.empty n p in
-  //          assume (n `Set.mem` freevars q);
-  //          assume (Set.equal (PS.dom ss_new) (Set.singleton n));
-  //          assert (Set.disjoint (PS.dom ss_new) (PS.dom ss));
-  //          let ss' = PS.push_ss ss ss_new in
-  //          assume (PS.dom ss' `Set.subset` freevars q0);  // again equal
-  //          assume (ss'.(q0) == p);
-  //          Some (| ss', RT.EQ_Refl _ _ |)
-  //        | _ ->
-  //          match p.t, q.t with
-  //          | Tm_Pure p1, Tm_Pure q1 ->
-  //            debug_prover g (fun _ ->
-  //              Printf.sprintf "prover.match trying %s =?= %s, both p and q are pure" (P.term_to_string p) (P.term_to_string q));
-  //            let r = unify g uvs p1 q1 ss in
-  //            (match r with
-  //             | Some (| ss', _ |) ->
-  //               assume (Set.subset (PS.dom ss') (freevars q0));
-  //               let ss' : ss':PS.ss_t { ss' `ss_extends` ss /\
-  //                                       PS.dom ss' `Set.subset` freevars q0 } = ss' in
-  //               Some (| ss', rt_equiv _ _ _ |)
-  //             | None -> None)
-
-  //          | _, _ ->
-  //            match is_pure_app p, is_pure_app q with
-  //            | Some (head_p, qual_p, arg_p), Some (head_q, qual_q, arg_q) ->
-  //              debug_prover g (fun _ ->
-  //                Printf.sprintf "prover.match trying %s =?= %s, both are pure app" (P.term_to_string p) (P.term_to_string q));
-
-  //              if not (qual_p = qual_q) then None
-  //              else begin
-  //                let r = unify g uvs head_p head_q ss in
-  //                match r with
-  //                | Some (| ss', _ |) ->
-  //                  let r = unify g uvs arg_p arg_q ss' in
-  //                  (match r with
-  //                   | Some (| ss', _|) ->
-  //                     admit ();
-  //                     let ss' : ss':PS.ss_t { ss' `ss_extends` ss /\
-  //                                             PS.dom ss' `Set.subset` freevars q0 } = ss' in
-  //                     Some (| ss', rt_equiv _ _ _ |)
-  //                   | _ -> None)
-  //                | _ -> None
-  //              end
-  //            | _, _ -> None
 
 let try_match_pq (g:env) (uvs:env { disjoint uvs g}) (p q:vprop)
   : T.Tac (option (ss:PS.ss_t { PS.dom ss `Set.subset` freevars q } &

--- a/lib/steel/pulse/Pulse.Checker.Prover.Match.fst
+++ b/lib/steel/pulse/Pulse.Checker.Prover.Match.fst
@@ -191,130 +191,200 @@ let is_reveal (t:term) : bool =
   | _ -> false
 
 module RT = FStar.Reflection.Typing
-let rec unify (g:env) (uvs:env { disjoint uvs g})
-  (p q:term) (ss:PS.ss_t)
-  : T.Tac (option (ss':PS.ss_t { ss' `ss_extends` ss /\
-                                 PS.dom ss' `Set.subset` freevars q } &
-                   RT.equiv (elab_env g) (elab_term p) (elab_term ss'.(q)))) =
 
-  let rt_equiv g t1 t2 : RT.equiv g t1 t2 =
-    assume (t1 == t2);
-    RT.EQ_Refl _ _
-  in
-
-  let q0 = q in
-  let q = ss.(q) in
-  assume (freevars q `Set.disjoint` PS.dom ss);
-
-  debug_prover g (fun _ ->
-    Printf.sprintf "prover.match trying %s =?= %s" (P.term_to_string p) (P.term_to_string q));
-
-  if eq_tm p q
-  then begin
-    debug_prover g (fun _ ->
-      Printf.sprintf "prover.match trying %s =?= %s, eq_tm" (P.term_to_string p) (P.term_to_string q));
-
-    assume (PS.dom ss `Set.subset` freevars q);
-    Some (| ss, RT.EQ_Refl _ _ |)
-  end
-  else if not (contains_uvar q uvs g)
-  then begin
-    if eligible_for_smt_equality g p q
-    then let _ =
-           debug_prover g (fun _ ->
-             Printf.sprintf "prover.match trying %s =?= %s, not eq_tm, q has no uvar, eligible for smt" (P.term_to_string p) (P.term_to_string q))
-         in
-         let _ = assume (PS.dom ss `Set.subset` freevars q) in
-         let v0 = elab_term p in
-         let v1 = elab_term q in
-         match T.check_equiv (elab_env g) v0 v1 with
-         | Some token, _ -> Some (| ss, RT.EQ_Token _ _ _ (FStar.Squash.return_squash token) |)
-         | None, _ -> None
-    else let _ =
-           debug_prover g (fun _ ->
-             Printf.sprintf "prover.match trying %s =?= %s, not eq_tm, q has no uvar, not eligible for smt" (P.term_to_string p) (P.term_to_string q))
-         in
-         None
-  end
-  else match is_reveal_uvar q uvs, is_reveal p with
-       | Some (u, ty, n), false ->
-         debug_prover g (fun _ ->
-             Printf.sprintf "prover.match trying %s =?= %s, not eq_tm, q is reveal of uvar, p is not reveal" (P.term_to_string p) (P.term_to_string q));
-         let w = mk_hide u ty p in
-         assume (Set.mem n (dom uvs));
+let rec try_solve_uvars (g:env) (uvs:env { disjoint uvs g })
+  (p q:term)
+  : T.Tac (ss:PS.ss_t { PS.dom ss `Set.subset` freevars q }) =
+  
+  assume (Set.equal (PS.dom PS.empty) Set.empty);
+  
+  if not (contains_uvar q uvs g)
+  then PS.empty
+  else begin
+    match is_reveal_uvar q uvs, is_reveal p with
+    | Some (u, ty, n), false ->
+      let w = mk_hide u ty p in
+      assume (~ (PS.contains PS.empty n));
+      let ss = PS.push PS.empty n w in
+      assume (n `Set.mem` freevars q);
+      assume (Set.equal (PS.dom ss) (Set.singleton n));
+      ss
+     | _ ->
+       match is_uvar q uvs with
+       | Some n ->
+         let w = p in
          assume (~ (PS.contains PS.empty n));
-         assume (Set.disjoint (freevars w) (dom uvs));
-         let ss_new = PS.push PS.empty n w in
+         let ss = PS.push PS.empty n w in
          assume (n `Set.mem` freevars q);
-         assume (Set.equal (PS.dom ss_new) (Set.singleton n));
-         assert (Set.disjoint (PS.dom ss_new) (PS.dom ss));
-         let ss' = PS.push_ss ss ss_new in
-         assume (ss' `ss_extends` ss);
-         assume (ss'.(q0) == w);
-         assume (PS.dom ss' `Set.subset` freevars q0);  // they are actually equal
-         let b, _ = T.check_equiv (elab_env g) (elab_term (mk_reveal u ty w)) (elab_term p) in
-         if Some? b
-         then let d : RT.equiv (elab_env g) (elab_term p) (elab_term ss'.(q0)) = rt_equiv _ _ _ in
-              Some (| ss', d |)
-         else None
+         assume (Set.equal (PS.dom ss) (Set.singleton n));
+         ss
        | _ ->
-         match is_uvar q uvs with
-         | Some n ->
-           debug_prover g (fun _ ->
-             Printf.sprintf "prover.match trying %s =?= %s, not eq_tm, q is uvar" (P.term_to_string p) (P.term_to_string q));
-           assume (Set.mem n (dom uvs));
-           assume (~ (PS.contains PS.empty n));
-           assume (Set.disjoint (freevars p) (dom uvs));
-           let ss_new = PS.push PS.empty n p in
-           assume (n `Set.mem` freevars q);
-           assume (Set.equal (PS.dom ss_new) (Set.singleton n));
-           assert (Set.disjoint (PS.dom ss_new) (PS.dom ss));
-           let ss' = PS.push_ss ss ss_new in
-           assume (PS.dom ss' `Set.subset` freevars q0);  // again equal
-           assume (ss'.(q0) == p);
-           Some (| ss', RT.EQ_Refl _ _ |)
-         | _ ->
-           match p.t, q.t with
-           | Tm_Pure p1, Tm_Pure q1 ->
-             debug_prover g (fun _ ->
-               Printf.sprintf "prover.match trying %s =?= %s, both p and q are pure" (P.term_to_string p) (P.term_to_string q));
-             let r = unify g uvs p1 q1 ss in
-             (match r with
-              | Some (| ss', _ |) ->
-                assume (Set.subset (PS.dom ss') (freevars q0));
-                let ss' : ss':PS.ss_t { ss' `ss_extends` ss /\
-                                        PS.dom ss' `Set.subset` freevars q0 } = ss' in
-                Some (| ss', rt_equiv _ _ _ |)
-              | None -> None)
+         match p.t, q.t with
+         | Tm_Pure p1, Tm_Pure q1 -> try_solve_uvars g uvs p1 q1
 
-           | _, _ ->
-             match is_pure_app p, is_pure_app q with
-             | Some (head_p, qual_p, arg_p), Some (head_q, qual_q, arg_q) ->
-               debug_prover g (fun _ ->
-                 Printf.sprintf "prover.match trying %s =?= %s, both are pure app" (P.term_to_string p) (P.term_to_string q));
+         | _, _ ->
+           match is_pure_app p, is_pure_app q with
+           | Some (head_p, qual_p, arg_p), Some (head_q, qual_q, arg_q) ->
+            let ss_head = try_solve_uvars g uvs head_p head_q in
+            let ss_arg = try_solve_uvars g uvs arg_p arg_q in
+            if PS.check_disjoint ss_head ss_arg  // TODO: should implement a better compose
+            then begin
+              let ss = PS.push_ss ss_head ss_arg in
+              assume (Set.equal (PS.dom ss) (Set.union (PS.dom ss_head) (PS.dom ss_arg)));
+              assume ((Set.union (freevars head_q) (freevars arg_q)) `Set.subset` freevars q);
+              ss
+            end
+            else PS.empty
+           | _, _ -> PS.empty
+  end
 
-               if not (qual_p = qual_q) then None
-               else begin
-                 let r = unify g uvs head_p head_q ss in
-                 match r with
-                 | Some (| ss', _ |) ->
-                   let r = unify g uvs arg_p arg_q ss' in
-                   (match r with
-                    | Some (| ss', _|) ->
-                      admit ();
-                      let ss' : ss':PS.ss_t { ss' `ss_extends` ss /\
-                                              PS.dom ss' `Set.subset` freevars q0 } = ss' in
-                      Some (| ss', rt_equiv _ _ _ |)
-                    | _ -> None)
-                 | _ -> None
-               end
-             | _, _ -> None
+// let unify (g:env) (uvs:env { disjoint uvs g})
+//   (p q:term) (ss:PS.ss_t)
+//   : T.Tac (option (ss':PS.ss_t { ss' `ss_extends` ss } &
+//                    RT.equiv (elab_env g) (elab_term p) (elab_term ss'.(q)))) =
+
+//   let q0 = q in
+//   let ss' = try_solve_uvars g uvs p q ss in
+//   let q = ss'.(q) in
+
+
+let unify (g:env) (uvs:env { disjoint uvs g})
+  (p q:term)
+  : T.Tac (option (ss:PS.ss_t { PS.dom ss `Set.subset` freevars q } &
+                   RT.equiv (elab_env g) (elab_term p) (elab_term ss.(q)))) =
+
+  let ss = try_solve_uvars g uvs p q in
+  let q = ss.(q) in
+  if eq_tm p q
+  then Some (| ss, RT.EQ_Refl _ _ |)
+  else if contains_uvar q uvs g
+  then None
+  else if eligible_for_smt_equality g p q
+  then let v0 = elab_term p in
+       let v1 = elab_term q in
+       match T.check_equiv (elab_env g) v0 v1 with
+       | Some token, _ -> Some (| ss, RT.EQ_Token _ _ _ (FStar.Squash.return_squash token) |)
+       | None, _ -> None
+  else None
+
+  // let rt_equiv g t1 t2 : RT.equiv g t1 t2 =
+  //   assume (t1 == t2);
+  //   RT.EQ_Refl _ _
+  // in
+
+  // let q0 = q in
+  // let q = ss.(q) in
+  // assume (freevars q `Set.disjoint` PS.dom ss);
+
+  // debug_prover g (fun _ ->
+  //   Printf.sprintf "prover.match trying %s =?= %s" (P.term_to_string p) (P.term_to_string q));
+
+  // if eq_tm p q
+  // then begin
+  //   debug_prover g (fun _ ->
+  //     Printf.sprintf "prover.match trying %s =?= %s, eq_tm" (P.term_to_string p) (P.term_to_string q));
+
+  //   assume (PS.dom ss `Set.subset` freevars q);
+  //   Some (| ss, RT.EQ_Refl _ _ |)
+  // end
+  // else if not (contains_uvar q uvs g)
+  // then begin
+  //   if eligible_for_smt_equality g p q
+  //   then let _ =
+  //          debug_prover g (fun _ ->
+  //            Printf.sprintf "prover.match trying %s =?= %s, not eq_tm, q has no uvar, eligible for smt" (P.term_to_string p) (P.term_to_string q))
+  //        in
+  //        let _ = assume (PS.dom ss `Set.subset` freevars q) in
+  //        let v0 = elab_term p in
+  //        let v1 = elab_term q in
+  //        match T.check_equiv (elab_env g) v0 v1 with
+  //        | Some token, _ -> Some (| ss, RT.EQ_Token _ _ _ (FStar.Squash.return_squash token) |)
+  //        | None, _ -> None
+  //   else let _ =
+  //          debug_prover g (fun _ ->
+  //            Printf.sprintf "prover.match trying %s =?= %s, not eq_tm, q has no uvar, not eligible for smt" (P.term_to_string p) (P.term_to_string q))
+  //        in
+  //        None
+  // end
+  // else match is_reveal_uvar q uvs, is_reveal p with
+  //      | Some (u, ty, n), false ->
+  //        debug_prover g (fun _ ->
+  //            Printf.sprintf "prover.match trying %s =?= %s, not eq_tm, q is reveal of uvar, p is not reveal" (P.term_to_string p) (P.term_to_string q));
+  //        let w = mk_hide u ty p in
+  //        assume (Set.mem n (dom uvs));
+  //        assume (~ (PS.contains PS.empty n));
+  //        assume (Set.disjoint (freevars w) (dom uvs));
+  //        let ss_new = PS.push PS.empty n w in
+  //        assume (n `Set.mem` freevars q);
+  //        assume (Set.equal (PS.dom ss_new) (Set.singleton n));
+  //        assert (Set.disjoint (PS.dom ss_new) (PS.dom ss));
+  //        let ss' = PS.push_ss ss ss_new in
+  //        assume (ss' `ss_extends` ss);
+  //        assume (ss'.(q0) == w);
+  //        assume (PS.dom ss' `Set.subset` freevars q0);  // they are actually equal
+  //        let b, _ = T.check_equiv (elab_env g) (elab_term (mk_reveal u ty w)) (elab_term p) in
+  //        if Some? b
+  //        then let d : RT.equiv (elab_env g) (elab_term p) (elab_term ss'.(q0)) = rt_equiv _ _ _ in
+  //             Some (| ss', d |)
+  //        else None
+  //      | _ ->
+  //        match is_uvar q uvs with
+  //        | Some n ->
+  //          debug_prover g (fun _ ->
+  //            Printf.sprintf "prover.match trying %s =?= %s, not eq_tm, q is uvar" (P.term_to_string p) (P.term_to_string q));
+  //          assume (Set.mem n (dom uvs));
+  //          assume (~ (PS.contains PS.empty n));
+  //          assume (Set.disjoint (freevars p) (dom uvs));
+  //          let ss_new = PS.push PS.empty n p in
+  //          assume (n `Set.mem` freevars q);
+  //          assume (Set.equal (PS.dom ss_new) (Set.singleton n));
+  //          assert (Set.disjoint (PS.dom ss_new) (PS.dom ss));
+  //          let ss' = PS.push_ss ss ss_new in
+  //          assume (PS.dom ss' `Set.subset` freevars q0);  // again equal
+  //          assume (ss'.(q0) == p);
+  //          Some (| ss', RT.EQ_Refl _ _ |)
+  //        | _ ->
+  //          match p.t, q.t with
+  //          | Tm_Pure p1, Tm_Pure q1 ->
+  //            debug_prover g (fun _ ->
+  //              Printf.sprintf "prover.match trying %s =?= %s, both p and q are pure" (P.term_to_string p) (P.term_to_string q));
+  //            let r = unify g uvs p1 q1 ss in
+  //            (match r with
+  //             | Some (| ss', _ |) ->
+  //               assume (Set.subset (PS.dom ss') (freevars q0));
+  //               let ss' : ss':PS.ss_t { ss' `ss_extends` ss /\
+  //                                       PS.dom ss' `Set.subset` freevars q0 } = ss' in
+  //               Some (| ss', rt_equiv _ _ _ |)
+  //             | None -> None)
+
+  //          | _, _ ->
+  //            match is_pure_app p, is_pure_app q with
+  //            | Some (head_p, qual_p, arg_p), Some (head_q, qual_q, arg_q) ->
+  //              debug_prover g (fun _ ->
+  //                Printf.sprintf "prover.match trying %s =?= %s, both are pure app" (P.term_to_string p) (P.term_to_string q));
+
+  //              if not (qual_p = qual_q) then None
+  //              else begin
+  //                let r = unify g uvs head_p head_q ss in
+  //                match r with
+  //                | Some (| ss', _ |) ->
+  //                  let r = unify g uvs arg_p arg_q ss' in
+  //                  (match r with
+  //                   | Some (| ss', _|) ->
+  //                     admit ();
+  //                     let ss' : ss':PS.ss_t { ss' `ss_extends` ss /\
+  //                                             PS.dom ss' `Set.subset` freevars q0 } = ss' in
+  //                     Some (| ss', rt_equiv _ _ _ |)
+  //                   | _ -> None)
+  //                | _ -> None
+  //              end
+  //            | _, _ -> None
 
 let try_match_pq (g:env) (uvs:env { disjoint uvs g}) (p q:vprop)
   : T.Tac (option (ss:PS.ss_t { PS.dom ss `Set.subset` freevars q } &
                    vprop_equiv g p ss.(q))) =
 
-  let r = unify g uvs p q PS.empty in
+  let r = unify g uvs p q in
   match r with
   | None -> None
   | Some (| ss, _ |) ->

--- a/src/ocaml/plugin/generated/Pulse_Checker_Prover_Match.ml
+++ b/src/ocaml/plugin/generated/Pulse_Checker_Prover_Match.ml
@@ -557,530 +557,310 @@ let (is_reveal : Pulse_Syntax_Base.term -> Prims.bool) =
              l = Pulse_Reflection_Util.reveal_lid
          | uu___ -> false)
     | uu___ -> false
-let rec (unify :
+let rec (try_solve_uvars :
   Pulse_Typing_Env.env ->
     Pulse_Typing_Env.env ->
       Pulse_Syntax_Base.term ->
         Pulse_Syntax_Base.term ->
-          Pulse_Checker_Prover_Substs.ss_t ->
-            ((Pulse_Checker_Prover_Substs.ss_t,
-               (unit, unit, unit) FStar_Reflection_Typing.equiv)
-               Prims.dtuple2 FStar_Pervasives_Native.option,
-              unit) FStar_Tactics_Effect.tac_repr)
+          (Pulse_Checker_Prover_Substs.ss_t, unit)
+            FStar_Tactics_Effect.tac_repr)
   =
   fun g ->
     fun uvs ->
       fun p ->
         fun q ->
-          fun ss ->
-            FStar_Tactics_Effect.tac_bind
-              (FStar_Sealed.seal
-                 (Obj.magic
-                    (FStar_Range.mk_range "Pulse.Checker.Prover.Match.fst"
-                       (Prims.of_int (201)) (Prims.of_int (4))
-                       (Prims.of_int (202)) (Prims.of_int (18)))))
-              (FStar_Sealed.seal
-                 (Obj.magic
-                    (FStar_Range.mk_range "Pulse.Checker.Prover.Match.fst"
-                       (Prims.of_int (203)) (Prims.of_int (4))
-                       (Prims.of_int (311)) (Prims.of_int (27)))))
-              (FStar_Tactics_Effect.lift_div_tac
-                 (fun uu___ ->
-                    fun g1 ->
-                      fun t1 ->
-                        fun t2 -> FStar_Reflection_Typing.EQ_Refl (g1, t1)))
-              (fun uu___ ->
-                 (fun rt_equiv ->
+          FStar_Tactics_Effect.tac_bind
+            (FStar_Sealed.seal
+               (Obj.magic
+                  (FStar_Range.mk_range "Pulse.Checker.Prover.Match.fst"
+                     (Prims.of_int (201)) (Prims.of_int (5))
+                     (Prims.of_int (201)) (Prims.of_int (32)))))
+            (FStar_Sealed.seal
+               (Obj.magic
+                  (FStar_Range.mk_range "Pulse.Checker.Prover.Match.fst"
+                     (Prims.of_int (201)) (Prims.of_int (2))
+                     (Prims.of_int (239)) (Prims.of_int (5)))))
+            (Obj.magic
+               (FStar_Tactics_Effect.tac_bind
+                  (FStar_Sealed.seal
+                     (Obj.magic
+                        (FStar_Range.mk_range
+                           "Pulse.Checker.Prover.Match.fst"
+                           (Prims.of_int (201)) (Prims.of_int (9))
+                           (Prims.of_int (201)) (Prims.of_int (32)))))
+                  (FStar_Sealed.seal
+                     (Obj.magic
+                        (FStar_Range.mk_range
+                           "Pulse.Checker.Prover.Match.fst"
+                           (Prims.of_int (201)) (Prims.of_int (5))
+                           (Prims.of_int (201)) (Prims.of_int (32)))))
+                  (Obj.magic (contains_uvar q uvs g))
+                  (fun uu___ ->
+                     FStar_Tactics_Effect.lift_div_tac
+                       (fun uu___1 -> Prims.op_Negation uu___))))
+            (fun uu___ ->
+               (fun uu___ ->
+                  if uu___
+                  then
                     Obj.magic
-                      (FStar_Tactics_Effect.tac_bind
-                         (FStar_Sealed.seal
-                            (Obj.magic
-                               (FStar_Range.mk_range
-                                  "Pulse.Checker.Prover.Match.fst"
-                                  (Prims.of_int (205)) (Prims.of_int (11))
-                                  (Prims.of_int (205)) (Prims.of_int (12)))))
-                         (FStar_Sealed.seal
-                            (Obj.magic
-                               (FStar_Range.mk_range
-                                  "Pulse.Checker.Prover.Match.fst"
-                                  (Prims.of_int (205)) (Prims.of_int (15))
-                                  (Prims.of_int (311)) (Prims.of_int (27)))))
-                         (FStar_Tactics_Effect.lift_div_tac (fun uu___ -> q))
-                         (fun uu___ ->
-                            (fun q0 ->
+                      (Obj.repr
+                         (FStar_Tactics_Effect.lift_div_tac
+                            (fun uu___1 -> Pulse_Checker_Prover_Substs.empty)))
+                  else
+                    Obj.magic
+                      (Obj.repr
+                         (match ((is_reveal_uvar q uvs), (is_reveal p)) with
+                          | (FStar_Pervasives_Native.Some (u, ty, n), false)
+                              ->
+                              Obj.repr
+                                (FStar_Tactics_Effect.lift_div_tac
+                                   (fun uu___2 ->
+                                      Pulse_Checker_Prover_Substs.push
+                                        Pulse_Checker_Prover_Substs.empty n
+                                        (Pulse_Typing.mk_hide u ty p)))
+                          | uu___2 ->
+                              Obj.repr
+                                (match is_uvar q uvs with
+                                 | FStar_Pervasives_Native.Some n ->
+                                     Obj.repr
+                                       (FStar_Tactics_Effect.lift_div_tac
+                                          (fun uu___3 ->
+                                             Pulse_Checker_Prover_Substs.push
+                                               Pulse_Checker_Prover_Substs.empty
+                                               n p))
+                                 | uu___3 ->
+                                     Obj.repr
+                                       (match ((p.Pulse_Syntax_Base.t),
+                                                (q.Pulse_Syntax_Base.t))
+                                        with
+                                        | (Pulse_Syntax_Base.Tm_Pure p1,
+                                           Pulse_Syntax_Base.Tm_Pure q1) ->
+                                            Obj.repr
+                                              (try_solve_uvars g uvs p1 q1)
+                                        | (uu___4, uu___5) ->
+                                            Obj.repr
+                                              (match ((Pulse_Syntax_Pure.is_pure_app
+                                                         p),
+                                                       (Pulse_Syntax_Pure.is_pure_app
+                                                          q))
+                                               with
+                                               | (FStar_Pervasives_Native.Some
+                                                  (head_p, qual_p, arg_p),
+                                                  FStar_Pervasives_Native.Some
+                                                  (head_q, qual_q, arg_q)) ->
+                                                   Obj.repr
+                                                     (FStar_Tactics_Effect.tac_bind
+                                                        (FStar_Sealed.seal
+                                                           (Obj.magic
+                                                              (FStar_Range.mk_range
+                                                                 "Pulse.Checker.Prover.Match.fst"
+                                                                 (Prims.of_int (228))
+                                                                 (Prims.of_int (26))
+                                                                 (Prims.of_int (228))
+                                                                 (Prims.of_int (61)))))
+                                                        (FStar_Sealed.seal
+                                                           (Obj.magic
+                                                              (FStar_Range.mk_range
+                                                                 "Pulse.Checker.Prover.Match.fst"
+                                                                 (Prims.of_int (228))
+                                                                 (Prims.of_int (64))
+                                                                 (Prims.of_int (237))
+                                                                 (Prims.of_int (25)))))
+                                                        (Obj.magic
+                                                           (try_solve_uvars g
+                                                              uvs head_p
+                                                              head_q))
+                                                        (fun uu___6 ->
+                                                           (fun ss_head ->
+                                                              Obj.magic
+                                                                (FStar_Tactics_Effect.tac_bind
+                                                                   (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Prover.Match.fst"
+                                                                    (Prims.of_int (229))
+                                                                    (Prims.of_int (25))
+                                                                    (Prims.of_int (229))
+                                                                    (Prims.of_int (58)))))
+                                                                   (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Prover.Match.fst"
+                                                                    (Prims.of_int (230))
+                                                                    (Prims.of_int (12))
+                                                                    (Prims.of_int (237))
+                                                                    (Prims.of_int (25)))))
+                                                                   (Obj.magic
+                                                                    (try_solve_uvars
+                                                                    g uvs
+                                                                    arg_p
+                                                                    arg_q))
+                                                                   (fun
+                                                                    ss_arg ->
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___6 ->
+                                                                    if
+                                                                    Pulse_Checker_Prover_Substs.check_disjoint
+                                                                    ss_head
+                                                                    ss_arg
+                                                                    then
+                                                                    Pulse_Checker_Prover_Substs.push_ss
+                                                                    ss_head
+                                                                    ss_arg
+                                                                    else
+                                                                    Pulse_Checker_Prover_Substs.empty))))
+                                                             uu___6))
+                                               | (uu___6, uu___7) ->
+                                                   Obj.repr
+                                                     (FStar_Tactics_Effect.lift_div_tac
+                                                        (fun uu___8 ->
+                                                           Pulse_Checker_Prover_Substs.empty))))))))
+                 uu___)
+let (unify :
+  Pulse_Typing_Env.env ->
+    Pulse_Typing_Env.env ->
+      Pulse_Syntax_Base.term ->
+        Pulse_Syntax_Base.term ->
+          ((Pulse_Checker_Prover_Substs.ss_t,
+             (unit, unit, unit) FStar_Reflection_Typing.equiv) Prims.dtuple2
+             FStar_Pervasives_Native.option,
+            unit) FStar_Tactics_Effect.tac_repr)
+  =
+  fun g ->
+    fun uvs ->
+      fun p ->
+        fun q ->
+          FStar_Tactics_Effect.tac_bind
+            (FStar_Sealed.seal
+               (Obj.magic
+                  (FStar_Range.mk_range "Pulse.Checker.Prover.Match.fst"
+                     (Prims.of_int (256)) (Prims.of_int (11))
+                     (Prims.of_int (256)) (Prims.of_int (36)))))
+            (FStar_Sealed.seal
+               (Obj.magic
+                  (FStar_Range.mk_range "Pulse.Checker.Prover.Match.fst"
+                     (Prims.of_int (256)) (Prims.of_int (39))
+                     (Prims.of_int (268)) (Prims.of_int (11)))))
+            (Obj.magic (try_solve_uvars g uvs p q))
+            (fun uu___ ->
+               (fun ss ->
+                  Obj.magic
+                    (FStar_Tactics_Effect.tac_bind
+                       (FStar_Sealed.seal
+                          (Obj.magic
+                             (FStar_Range.mk_range
+                                "Pulse.Checker.Prover.Match.fst"
+                                (Prims.of_int (257)) (Prims.of_int (10))
+                                (Prims.of_int (257)) (Prims.of_int (16)))))
+                       (FStar_Sealed.seal
+                          (Obj.magic
+                             (FStar_Range.mk_range
+                                "Pulse.Checker.Prover.Match.fst"
+                                (Prims.of_int (258)) (Prims.of_int (2))
+                                (Prims.of_int (268)) (Prims.of_int (11)))))
+                       (FStar_Tactics_Effect.lift_div_tac
+                          (fun uu___ ->
+                             Pulse_Checker_Prover_Base.op_Array_Access ss q))
+                       (fun uu___ ->
+                          (fun q1 ->
+                             if Pulse_Syntax_Base.eq_tm p q1
+                             then
                                Obj.magic
-                                 (FStar_Tactics_Effect.tac_bind
-                                    (FStar_Sealed.seal
-                                       (Obj.magic
-                                          (FStar_Range.mk_range
-                                             "Pulse.Checker.Prover.Match.fst"
-                                             (Prims.of_int (206))
-                                             (Prims.of_int (10))
-                                             (Prims.of_int (206))
-                                             (Prims.of_int (16)))))
-                                    (FStar_Sealed.seal
-                                       (Obj.magic
-                                          (FStar_Range.mk_range
-                                             "Pulse.Checker.Prover.Match.fst"
-                                             (Prims.of_int (209))
-                                             (Prims.of_int (2))
-                                             (Prims.of_int (311))
-                                             (Prims.of_int (27)))))
+                                 (Obj.repr
                                     (FStar_Tactics_Effect.lift_div_tac
                                        (fun uu___ ->
-                                          Pulse_Checker_Prover_Base.op_Array_Access
-                                            ss q))
-                                    (fun uu___ ->
-                                       (fun q1 ->
-                                          Obj.magic
-                                            (FStar_Tactics_Effect.tac_bind
-                                               (FStar_Sealed.seal
-                                                  (Obj.magic
-                                                     (FStar_Range.mk_range
-                                                        "Pulse.Checker.Prover.Match.fst"
-                                                        (Prims.of_int (209))
-                                                        (Prims.of_int (2))
-                                                        (Prims.of_int (210))
-                                                        (Prims.of_int (93)))))
-                                               (FStar_Sealed.seal
-                                                  (Obj.magic
-                                                     (FStar_Range.mk_range
-                                                        "Pulse.Checker.Prover.Match.fst"
-                                                        (Prims.of_int (212))
-                                                        (Prims.of_int (2))
-                                                        (Prims.of_int (311))
-                                                        (Prims.of_int (27)))))
-                                               (Obj.magic
-                                                  (Pulse_Checker_Prover_Util.debug_prover
-                                                     g
-                                                     (fun uu___ ->
-                                                        FStar_Tactics_Effect.tac_bind
-                                                          (FStar_Sealed.seal
-                                                             (Obj.magic
-                                                                (FStar_Range.mk_range
-                                                                   "Pulse.Checker.Prover.Match.fst"
-                                                                   (Prims.of_int (210))
-                                                                   (Prims.of_int (72))
-                                                                   (Prims.of_int (210))
-                                                                   (Prims.of_int (92)))))
-                                                          (FStar_Sealed.seal
-                                                             (Obj.magic
-                                                                (FStar_Range.mk_range
-                                                                   "Pulse.Checker.Prover.Match.fst"
-                                                                   (Prims.of_int (210))
-                                                                   (Prims.of_int (4))
-                                                                   (Prims.of_int (210))
-                                                                   (Prims.of_int (92)))))
+                                          FStar_Pervasives_Native.Some
+                                            (Prims.Mkdtuple2
+                                               (ss,
+                                                 (FStar_Reflection_Typing.EQ_Refl
+                                                    ((Pulse_Typing.elab_env g),
+                                                      (Pulse_Elaborate_Pure.elab_term
+                                                         p))))))))
+                             else
+                               Obj.magic
+                                 (Obj.repr
+                                    (FStar_Tactics_Effect.tac_bind
+                                       (FStar_Sealed.seal
+                                          (Obj.magic
+                                             (FStar_Range.mk_range
+                                                "Pulse.Checker.Prover.Match.fst"
+                                                (Prims.of_int (260))
+                                                (Prims.of_int (10))
+                                                (Prims.of_int (260))
+                                                (Prims.of_int (31)))))
+                                       (FStar_Sealed.seal
+                                          (Obj.magic
+                                             (FStar_Range.mk_range
+                                                "Pulse.Checker.Prover.Match.fst"
+                                                (Prims.of_int (260))
+                                                (Prims.of_int (7))
+                                                (Prims.of_int (268))
+                                                (Prims.of_int (11)))))
+                                       (Obj.magic (contains_uvar q1 uvs g))
+                                       (fun uu___1 ->
+                                          (fun uu___1 ->
+                                             if uu___1
+                                             then
+                                               Obj.magic
+                                                 (Obj.repr
+                                                    (FStar_Tactics_Effect.lift_div_tac
+                                                       (fun uu___2 ->
+                                                          FStar_Pervasives_Native.None)))
+                                             else
+                                               Obj.magic
+                                                 (Obj.repr
+                                                    (FStar_Tactics_Effect.tac_bind
+                                                       (FStar_Sealed.seal
                                                           (Obj.magic
-                                                             (Pulse_Syntax_Printer.term_to_string
-                                                                q1))
-                                                          (fun uu___1 ->
-                                                             (fun uu___1 ->
-                                                                Obj.magic
-                                                                  (FStar_Tactics_Effect.tac_bind
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.Match.fst"
-                                                                    (Prims.of_int (210))
-                                                                    (Prims.of_int (4))
-                                                                    (Prims.of_int (210))
-                                                                    (Prims.of_int (92)))))
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.Match.fst"
-                                                                    (Prims.of_int (210))
-                                                                    (Prims.of_int (4))
-                                                                    (Prims.of_int (210))
-                                                                    (Prims.of_int (92)))))
-                                                                    (Obj.magic
-                                                                    (FStar_Tactics_Effect.tac_bind
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.Match.fst"
-                                                                    (Prims.of_int (210))
-                                                                    (Prims.of_int (51))
-                                                                    (Prims.of_int (210))
-                                                                    (Prims.of_int (71)))))
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "FStar.Printf.fst"
-                                                                    (Prims.of_int (121))
-                                                                    (Prims.of_int (8))
-                                                                    (Prims.of_int (123))
-                                                                    (Prims.of_int (44)))))
-                                                                    (Obj.magic
-                                                                    (Pulse_Syntax_Printer.term_to_string
-                                                                    p))
-                                                                    (fun
-                                                                    uu___2 ->
-                                                                    FStar_Tactics_Effect.lift_div_tac
-                                                                    (fun
-                                                                    uu___3 ->
-                                                                    fun x ->
-                                                                    Prims.strcat
-                                                                    (Prims.strcat
-                                                                    "prover.match trying "
-                                                                    (Prims.strcat
-                                                                    uu___2
-                                                                    " =?= "))
-                                                                    (Prims.strcat
-                                                                    x "")))))
-                                                                    (fun
-                                                                    uu___2 ->
-                                                                    FStar_Tactics_Effect.lift_div_tac
-                                                                    (fun
-                                                                    uu___3 ->
-                                                                    uu___2
-                                                                    uu___1))))
-                                                               uu___1))))
-                                               (fun uu___ ->
-                                                  (fun uu___ ->
-                                                     if
-                                                       Pulse_Syntax_Base.eq_tm
-                                                         p q1
-                                                     then
-                                                       Obj.magic
-                                                         (FStar_Tactics_Effect.tac_bind
-                                                            (FStar_Sealed.seal
-                                                               (Obj.magic
-                                                                  (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.Match.fst"
-                                                                    (Prims.of_int (214))
-                                                                    (Prims.of_int (4))
-                                                                    (Prims.of_int (215))
-                                                                    (Prims.of_int (102)))))
-                                                            (FStar_Sealed.seal
-                                                               (Obj.magic
-                                                                  (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.Match.fst"
-                                                                    (Prims.of_int (218))
-                                                                    (Prims.of_int (4))
-                                                                    (Prims.of_int (218))
-                                                                    (Prims.of_int (33)))))
-                                                            (Obj.magic
-                                                               (Pulse_Checker_Prover_Util.debug_prover
-                                                                  g
-                                                                  (fun uu___1
-                                                                    ->
+                                                             (FStar_Range.mk_range
+                                                                "Pulse.Checker.Prover.Match.fst"
+                                                                (Prims.of_int (262))
+                                                                (Prims.of_int (10))
+                                                                (Prims.of_int (262))
+                                                                (Prims.of_int (41)))))
+                                                       (FStar_Sealed.seal
+                                                          (Obj.magic
+                                                             (FStar_Range.mk_range
+                                                                "Pulse.Checker.Prover.Match.fst"
+                                                                (Prims.of_int (262))
+                                                                (Prims.of_int (7))
+                                                                (Prims.of_int (268))
+                                                                (Prims.of_int (11)))))
+                                                       (Obj.magic
+                                                          (eligible_for_smt_equality
+                                                             g p q1))
+                                                       (fun uu___3 ->
+                                                          (fun uu___3 ->
+                                                             if uu___3
+                                                             then
+                                                               Obj.magic
+                                                                 (Obj.repr
+                                                                    (
                                                                     FStar_Tactics_Effect.tac_bind
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.Match.fst"
-                                                                    (Prims.of_int (215))
-                                                                    (Prims.of_int (81))
-                                                                    (Prims.of_int (215))
-                                                                    (Prims.of_int (101)))))
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.Match.fst"
-                                                                    (Prims.of_int (215))
-                                                                    (Prims.of_int (6))
-                                                                    (Prims.of_int (215))
-                                                                    (Prims.of_int (101)))))
-                                                                    (Obj.magic
-                                                                    (Pulse_Syntax_Printer.term_to_string
-                                                                    q1))
-                                                                    (fun
-                                                                    uu___2 ->
-                                                                    (fun
-                                                                    uu___2 ->
-                                                                    Obj.magic
-                                                                    (FStar_Tactics_Effect.tac_bind
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.Match.fst"
-                                                                    (Prims.of_int (215))
-                                                                    (Prims.of_int (6))
-                                                                    (Prims.of_int (215))
-                                                                    (Prims.of_int (101)))))
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.Match.fst"
-                                                                    (Prims.of_int (215))
-                                                                    (Prims.of_int (6))
-                                                                    (Prims.of_int (215))
-                                                                    (Prims.of_int (101)))))
-                                                                    (Obj.magic
-                                                                    (FStar_Tactics_Effect.tac_bind
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.Match.fst"
-                                                                    (Prims.of_int (215))
-                                                                    (Prims.of_int (60))
-                                                                    (Prims.of_int (215))
-                                                                    (Prims.of_int (80)))))
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "FStar.Printf.fst"
-                                                                    (Prims.of_int (121))
-                                                                    (Prims.of_int (8))
-                                                                    (Prims.of_int (123))
-                                                                    (Prims.of_int (44)))))
-                                                                    (Obj.magic
-                                                                    (Pulse_Syntax_Printer.term_to_string
-                                                                    p))
-                                                                    (fun
-                                                                    uu___3 ->
-                                                                    FStar_Tactics_Effect.lift_div_tac
-                                                                    (fun
-                                                                    uu___4 ->
-                                                                    fun x ->
-                                                                    Prims.strcat
-                                                                    (Prims.strcat
-                                                                    "prover.match trying "
-                                                                    (Prims.strcat
-                                                                    uu___3
-                                                                    " =?= "))
-                                                                    (Prims.strcat
-                                                                    x
-                                                                    ", eq_tm")))))
-                                                                    (fun
-                                                                    uu___3 ->
-                                                                    FStar_Tactics_Effect.lift_div_tac
-                                                                    (fun
-                                                                    uu___4 ->
-                                                                    uu___3
-                                                                    uu___2))))
-                                                                    uu___2))))
-                                                            (fun uu___1 ->
-                                                               FStar_Tactics_Effect.lift_div_tac
-                                                                 (fun uu___2
-                                                                    ->
-                                                                    FStar_Pervasives_Native.Some
-                                                                    (Prims.Mkdtuple2
-                                                                    (ss,
-                                                                    (FStar_Reflection_Typing.EQ_Refl
-                                                                    ((Pulse_Typing.elab_env
-                                                                    g),
-                                                                    (Pulse_Elaborate_Pure.elab_term
-                                                                    p))))))))
-                                                     else
-                                                       Obj.magic
-                                                         (FStar_Tactics_Effect.tac_bind
-                                                            (FStar_Sealed.seal
-                                                               (Obj.magic
-                                                                  (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.Match.fst"
-                                                                    (Prims.of_int (220))
-                                                                    (Prims.of_int (10))
-                                                                    (Prims.of_int (220))
-                                                                    (Prims.of_int (37)))))
-                                                            (FStar_Sealed.seal
-                                                               (Obj.magic
-                                                                  (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.Match.fst"
-                                                                    (Prims.of_int (220))
-                                                                    (Prims.of_int (7))
-                                                                    (Prims.of_int (311))
+                                                                    (Prims.of_int (263))
+                                                                    (Prims.of_int (16))
+                                                                    (Prims.of_int (263))
                                                                     (Prims.of_int (27)))))
-                                                            (Obj.magic
-                                                               (FStar_Tactics_Effect.tac_bind
-                                                                  (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.Match.fst"
-                                                                    (Prims.of_int (220))
-                                                                    (Prims.of_int (14))
-                                                                    (Prims.of_int (220))
-                                                                    (Prims.of_int (37)))))
-                                                                  (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.Match.fst"
-                                                                    (Prims.of_int (220))
-                                                                    (Prims.of_int (10))
-                                                                    (Prims.of_int (220))
-                                                                    (Prims.of_int (37)))))
-                                                                  (Obj.magic
-                                                                    (contains_uvar
-                                                                    q1 uvs g))
-                                                                  (fun uu___2
-                                                                    ->
-                                                                    FStar_Tactics_Effect.lift_div_tac
-                                                                    (fun
-                                                                    uu___3 ->
-                                                                    Prims.op_Negation
-                                                                    uu___2))))
-                                                            (fun uu___2 ->
-                                                               (fun uu___2 ->
-                                                                  if uu___2
-                                                                  then
-                                                                    Obj.magic
-                                                                    (Obj.repr
-                                                                    (FStar_Tactics_Effect.tac_bind
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.Match.fst"
-                                                                    (Prims.of_int (222))
-                                                                    (Prims.of_int (7))
-                                                                    (Prims.of_int (222))
-                                                                    (Prims.of_int (38)))))
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.Match.fst"
-                                                                    (Prims.of_int (222))
-                                                                    (Prims.of_int (4))
-                                                                    (Prims.of_int (237))
-                                                                    (Prims.of_int (13)))))
-                                                                    (Obj.magic
-                                                                    (eligible_for_smt_equality
-                                                                    g p q1))
-                                                                    (fun
-                                                                    uu___3 ->
-                                                                    (fun
-                                                                    uu___3 ->
-                                                                    if uu___3
-                                                                    then
-                                                                    Obj.magic
-                                                                    (FStar_Tactics_Effect.tac_bind
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.Match.fst"
-                                                                    (Prims.of_int (224))
-                                                                    (Prims.of_int (11))
-                                                                    (Prims.of_int (225))
-                                                                    (Prims.of_int (146)))))
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.Match.fst"
-                                                                    (Prims.of_int (227))
-                                                                    (Prims.of_int (62))
-                                                                    (Prims.of_int (232))
-                                                                    (Prims.of_int (26)))))
-                                                                    (Obj.magic
-                                                                    (Pulse_Checker_Prover_Util.debug_prover
-                                                                    g
-                                                                    (fun
-                                                                    uu___4 ->
-                                                                    FStar_Tactics_Effect.tac_bind
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.Match.fst"
-                                                                    (Prims.of_int (225))
-                                                                    (Prims.of_int (125))
-                                                                    (Prims.of_int (225))
-                                                                    (Prims.of_int (145)))))
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.Match.fst"
-                                                                    (Prims.of_int (225))
-                                                                    (Prims.of_int (13))
-                                                                    (Prims.of_int (225))
-                                                                    (Prims.of_int (145)))))
-                                                                    (Obj.magic
-                                                                    (Pulse_Syntax_Printer.term_to_string
-                                                                    q1))
-                                                                    (fun
-                                                                    uu___5 ->
-                                                                    (fun
-                                                                    uu___5 ->
-                                                                    Obj.magic
-                                                                    (FStar_Tactics_Effect.tac_bind
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.Match.fst"
-                                                                    (Prims.of_int (225))
-                                                                    (Prims.of_int (13))
-                                                                    (Prims.of_int (225))
-                                                                    (Prims.of_int (145)))))
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.Match.fst"
-                                                                    (Prims.of_int (225))
-                                                                    (Prims.of_int (13))
-                                                                    (Prims.of_int (225))
-                                                                    (Prims.of_int (145)))))
-                                                                    (Obj.magic
-                                                                    (FStar_Tactics_Effect.tac_bind
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.Match.fst"
-                                                                    (Prims.of_int (225))
-                                                                    (Prims.of_int (104))
-                                                                    (Prims.of_int (225))
-                                                                    (Prims.of_int (124)))))
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "FStar.Printf.fst"
-                                                                    (Prims.of_int (121))
-                                                                    (Prims.of_int (8))
-                                                                    (Prims.of_int (123))
-                                                                    (Prims.of_int (44)))))
-                                                                    (Obj.magic
-                                                                    (Pulse_Syntax_Printer.term_to_string
-                                                                    p))
-                                                                    (fun
-                                                                    uu___6 ->
-                                                                    FStar_Tactics_Effect.lift_div_tac
-                                                                    (fun
-                                                                    uu___7 ->
-                                                                    fun x ->
-                                                                    Prims.strcat
-                                                                    (Prims.strcat
-                                                                    "prover.match trying "
-                                                                    (Prims.strcat
-                                                                    uu___6
-                                                                    " =?= "))
-                                                                    (Prims.strcat
-                                                                    x
-                                                                    ", not eq_tm, q has no uvar, eligible for smt")))))
-                                                                    (fun
-                                                                    uu___6 ->
-                                                                    FStar_Tactics_Effect.lift_div_tac
-                                                                    (fun
-                                                                    uu___7 ->
-                                                                    uu___6
-                                                                    uu___5))))
-                                                                    uu___5))))
-                                                                    (fun
-                                                                    uu___4 ->
-                                                                    (fun
-                                                                    uu___4 ->
-                                                                    Obj.magic
-                                                                    (FStar_Tactics_Effect.tac_bind
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.Match.fst"
-                                                                    (Prims.of_int (228))
-                                                                    (Prims.of_int (18))
-                                                                    (Prims.of_int (228))
-                                                                    (Prims.of_int (29)))))
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.Match.fst"
-                                                                    (Prims.of_int (228))
-                                                                    (Prims.of_int (32))
-                                                                    (Prims.of_int (232))
-                                                                    (Prims.of_int (26)))))
+                                                                    (Prims.of_int (263))
+                                                                    (Prims.of_int (30))
+                                                                    (Prims.of_int (267))
+                                                                    (Prims.of_int (24)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
-                                                                    uu___5 ->
+                                                                    uu___4 ->
                                                                     Pulse_Elaborate_Pure.elab_term
                                                                     p))
                                                                     (fun
-                                                                    uu___5 ->
+                                                                    uu___4 ->
                                                                     (fun v0
                                                                     ->
                                                                     Obj.magic
@@ -1089,25 +869,25 @@ let rec (unify :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.Match.fst"
-                                                                    (Prims.of_int (229))
-                                                                    (Prims.of_int (18))
-                                                                    (Prims.of_int (229))
-                                                                    (Prims.of_int (29)))))
+                                                                    (Prims.of_int (264))
+                                                                    (Prims.of_int (16))
+                                                                    (Prims.of_int (264))
+                                                                    (Prims.of_int (27)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.Match.fst"
-                                                                    (Prims.of_int (230))
-                                                                    (Prims.of_int (9))
-                                                                    (Prims.of_int (232))
-                                                                    (Prims.of_int (26)))))
+                                                                    (Prims.of_int (265))
+                                                                    (Prims.of_int (7))
+                                                                    (Prims.of_int (267))
+                                                                    (Prims.of_int (24)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
-                                                                    uu___5 ->
+                                                                    uu___4 ->
                                                                     Pulse_Elaborate_Pure.elab_term
                                                                     q1))
                                                                     (fun
-                                                                    uu___5 ->
+                                                                    uu___4 ->
                                                                     (fun v1
                                                                     ->
                                                                     Obj.magic
@@ -1116,33 +896,33 @@ let rec (unify :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.Match.fst"
-                                                                    (Prims.of_int (230))
-                                                                    (Prims.of_int (15))
-                                                                    (Prims.of_int (230))
-                                                                    (Prims.of_int (47)))))
+                                                                    (Prims.of_int (265))
+                                                                    (Prims.of_int (13))
+                                                                    (Prims.of_int (265))
+                                                                    (Prims.of_int (45)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.Match.fst"
-                                                                    (Prims.of_int (230))
-                                                                    (Prims.of_int (9))
-                                                                    (Prims.of_int (232))
-                                                                    (Prims.of_int (26)))))
+                                                                    (Prims.of_int (265))
+                                                                    (Prims.of_int (7))
+                                                                    (Prims.of_int (267))
+                                                                    (Prims.of_int (24)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_V2_Builtins.check_equiv
                                                                     (Pulse_Typing.elab_env
                                                                     g) v0 v1))
                                                                     (fun
-                                                                    uu___5 ->
+                                                                    uu___4 ->
                                                                     FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
-                                                                    uu___6 ->
-                                                                    match uu___5
+                                                                    uu___5 ->
+                                                                    match uu___4
                                                                     with
                                                                     | 
                                                                     (FStar_Pervasives_Native.Some
                                                                     token,
-                                                                    uu___7)
+                                                                    uu___6)
                                                                     ->
                                                                     FStar_Pervasives_Native.Some
                                                                     (Prims.Mkdtuple2
@@ -1153,970 +933,21 @@ let rec (unify :
                                                                     v1, ()))))
                                                                     | 
                                                                     (FStar_Pervasives_Native.None,
-                                                                    uu___7)
+                                                                    uu___6)
                                                                     ->
                                                                     FStar_Pervasives_Native.None))))
-                                                                    uu___5)))
-                                                                    uu___5)))
-                                                                    uu___4))
-                                                                    else
-                                                                    Obj.magic
-                                                                    (FStar_Tactics_Effect.tac_bind
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.Match.fst"
-                                                                    (Prims.of_int (234))
-                                                                    (Prims.of_int (11))
-                                                                    (Prims.of_int (235))
-                                                                    (Prims.of_int (150)))))
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.Match.fst"
-                                                                    (Prims.of_int (237))
-                                                                    (Prims.of_int (9))
-                                                                    (Prims.of_int (237))
-                                                                    (Prims.of_int (13)))))
-                                                                    (Obj.magic
-                                                                    (Pulse_Checker_Prover_Util.debug_prover
-                                                                    g
+                                                                    uu___4)))
+                                                                    uu___4)))
+                                                             else
+                                                               Obj.magic
+                                                                 (Obj.repr
+                                                                    (
+                                                                    FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
                                                                     uu___5 ->
-                                                                    FStar_Tactics_Effect.tac_bind
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.Match.fst"
-                                                                    (Prims.of_int (235))
-                                                                    (Prims.of_int (129))
-                                                                    (Prims.of_int (235))
-                                                                    (Prims.of_int (149)))))
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.Match.fst"
-                                                                    (Prims.of_int (235))
-                                                                    (Prims.of_int (13))
-                                                                    (Prims.of_int (235))
-                                                                    (Prims.of_int (149)))))
-                                                                    (Obj.magic
-                                                                    (Pulse_Syntax_Printer.term_to_string
-                                                                    q1))
-                                                                    (fun
-                                                                    uu___6 ->
-                                                                    (fun
-                                                                    uu___6 ->
-                                                                    Obj.magic
-                                                                    (FStar_Tactics_Effect.tac_bind
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.Match.fst"
-                                                                    (Prims.of_int (235))
-                                                                    (Prims.of_int (13))
-                                                                    (Prims.of_int (235))
-                                                                    (Prims.of_int (149)))))
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.Match.fst"
-                                                                    (Prims.of_int (235))
-                                                                    (Prims.of_int (13))
-                                                                    (Prims.of_int (235))
-                                                                    (Prims.of_int (149)))))
-                                                                    (Obj.magic
-                                                                    (FStar_Tactics_Effect.tac_bind
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.Match.fst"
-                                                                    (Prims.of_int (235))
-                                                                    (Prims.of_int (108))
-                                                                    (Prims.of_int (235))
-                                                                    (Prims.of_int (128)))))
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "FStar.Printf.fst"
-                                                                    (Prims.of_int (121))
-                                                                    (Prims.of_int (8))
-                                                                    (Prims.of_int (123))
-                                                                    (Prims.of_int (44)))))
-                                                                    (Obj.magic
-                                                                    (Pulse_Syntax_Printer.term_to_string
-                                                                    p))
-                                                                    (fun
-                                                                    uu___7 ->
-                                                                    FStar_Tactics_Effect.lift_div_tac
-                                                                    (fun
-                                                                    uu___8 ->
-                                                                    fun x ->
-                                                                    Prims.strcat
-                                                                    (Prims.strcat
-                                                                    "prover.match trying "
-                                                                    (Prims.strcat
-                                                                    uu___7
-                                                                    " =?= "))
-                                                                    (Prims.strcat
-                                                                    x
-                                                                    ", not eq_tm, q has no uvar, not eligible for smt")))))
-                                                                    (fun
-                                                                    uu___7 ->
-                                                                    FStar_Tactics_Effect.lift_div_tac
-                                                                    (fun
-                                                                    uu___8 ->
-                                                                    uu___7
-                                                                    uu___6))))
-                                                                    uu___6))))
-                                                                    (fun
-                                                                    uu___5 ->
-                                                                    FStar_Tactics_Effect.lift_div_tac
-                                                                    (fun
-                                                                    uu___6 ->
                                                                     FStar_Pervasives_Native.None))))
-                                                                    uu___3)))
-                                                                  else
-                                                                    Obj.magic
-                                                                    (Obj.repr
-                                                                    (match 
-                                                                    ((is_reveal_uvar
-                                                                    q1 uvs),
-                                                                    (is_reveal
-                                                                    p))
-                                                                    with
-                                                                    | 
-                                                                    (FStar_Pervasives_Native.Some
-                                                                    (u, ty,
-                                                                    n),
-                                                                    false) ->
-                                                                    Obj.repr
-                                                                    (FStar_Tactics_Effect.tac_bind
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.Match.fst"
-                                                                    (Prims.of_int (241))
-                                                                    (Prims.of_int (9))
-                                                                    (Prims.of_int (242))
-                                                                    (Prims.of_int (151)))))
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.Match.fst"
-                                                                    (Prims.of_int (242))
-                                                                    (Prims.of_int (152))
-                                                                    (Prims.of_int (259))
-                                                                    (Prims.of_int (18)))))
-                                                                    (Obj.magic
-                                                                    (Pulse_Checker_Prover_Util.debug_prover
-                                                                    g
-                                                                    (fun
-                                                                    uu___4 ->
-                                                                    FStar_Tactics_Effect.tac_bind
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.Match.fst"
-                                                                    (Prims.of_int (242))
-                                                                    (Prims.of_int (130))
-                                                                    (Prims.of_int (242))
-                                                                    (Prims.of_int (150)))))
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.Match.fst"
-                                                                    (Prims.of_int (242))
-                                                                    (Prims.of_int (13))
-                                                                    (Prims.of_int (242))
-                                                                    (Prims.of_int (150)))))
-                                                                    (Obj.magic
-                                                                    (Pulse_Syntax_Printer.term_to_string
-                                                                    q1))
-                                                                    (fun
-                                                                    uu___5 ->
-                                                                    (fun
-                                                                    uu___5 ->
-                                                                    Obj.magic
-                                                                    (FStar_Tactics_Effect.tac_bind
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.Match.fst"
-                                                                    (Prims.of_int (242))
-                                                                    (Prims.of_int (13))
-                                                                    (Prims.of_int (242))
-                                                                    (Prims.of_int (150)))))
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.Match.fst"
-                                                                    (Prims.of_int (242))
-                                                                    (Prims.of_int (13))
-                                                                    (Prims.of_int (242))
-                                                                    (Prims.of_int (150)))))
-                                                                    (Obj.magic
-                                                                    (FStar_Tactics_Effect.tac_bind
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.Match.fst"
-                                                                    (Prims.of_int (242))
-                                                                    (Prims.of_int (109))
-                                                                    (Prims.of_int (242))
-                                                                    (Prims.of_int (129)))))
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "FStar.Printf.fst"
-                                                                    (Prims.of_int (121))
-                                                                    (Prims.of_int (8))
-                                                                    (Prims.of_int (123))
-                                                                    (Prims.of_int (44)))))
-                                                                    (Obj.magic
-                                                                    (Pulse_Syntax_Printer.term_to_string
-                                                                    p))
-                                                                    (fun
-                                                                    uu___6 ->
-                                                                    FStar_Tactics_Effect.lift_div_tac
-                                                                    (fun
-                                                                    uu___7 ->
-                                                                    fun x ->
-                                                                    Prims.strcat
-                                                                    (Prims.strcat
-                                                                    "prover.match trying "
-                                                                    (Prims.strcat
-                                                                    uu___6
-                                                                    " =?= "))
-                                                                    (Prims.strcat
-                                                                    x
-                                                                    ", not eq_tm, q is reveal of uvar, p is not reveal")))))
-                                                                    (fun
-                                                                    uu___6 ->
-                                                                    FStar_Tactics_Effect.lift_div_tac
-                                                                    (fun
-                                                                    uu___7 ->
-                                                                    uu___6
-                                                                    uu___5))))
-                                                                    uu___5))))
-                                                                    (fun
-                                                                    uu___4 ->
-                                                                    (fun
-                                                                    uu___4 ->
-                                                                    Obj.magic
-                                                                    (FStar_Tactics_Effect.tac_bind
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.Match.fst"
-                                                                    (Prims.of_int (243))
-                                                                    (Prims.of_int (17))
-                                                                    (Prims.of_int (243))
-                                                                    (Prims.of_int (31)))))
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.Match.fst"
-                                                                    (Prims.of_int (246))
-                                                                    (Prims.of_int (54))
-                                                                    (Prims.of_int (259))
-                                                                    (Prims.of_int (18)))))
-                                                                    (FStar_Tactics_Effect.lift_div_tac
-                                                                    (fun
-                                                                    uu___5 ->
-                                                                    Pulse_Typing.mk_hide
-                                                                    u ty p))
-                                                                    (fun
-                                                                    uu___5 ->
-                                                                    (fun w ->
-                                                                    Obj.magic
-                                                                    (FStar_Tactics_Effect.tac_bind
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.Match.fst"
-                                                                    (Prims.of_int (247))
-                                                                    (Prims.of_int (22))
-                                                                    (Prims.of_int (247))
-                                                                    (Prims.of_int (42)))))
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.Match.fst"
-                                                                    (Prims.of_int (250))
-                                                                    (Prims.of_int (59))
-                                                                    (Prims.of_int (259))
-                                                                    (Prims.of_int (18)))))
-                                                                    (FStar_Tactics_Effect.lift_div_tac
-                                                                    (fun
-                                                                    uu___5 ->
-                                                                    Pulse_Checker_Prover_Substs.push
-                                                                    Pulse_Checker_Prover_Substs.empty
-                                                                    n w))
-                                                                    (fun
-                                                                    uu___5 ->
-                                                                    (fun
-                                                                    ss_new ->
-                                                                    Obj.magic
-                                                                    (FStar_Tactics_Effect.tac_bind
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.Match.fst"
-                                                                    (Prims.of_int (251))
-                                                                    (Prims.of_int (19))
-                                                                    (Prims.of_int (251))
-                                                                    (Prims.of_int (39)))))
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.Match.fst"
-                                                                    (Prims.of_int (254))
-                                                                    (Prims.of_int (54))
-                                                                    (Prims.of_int (259))
-                                                                    (Prims.of_int (18)))))
-                                                                    (FStar_Tactics_Effect.lift_div_tac
-                                                                    (fun
-                                                                    uu___5 ->
-                                                                    Pulse_Checker_Prover_Substs.push_ss
-                                                                    ss ss_new))
-                                                                    (fun
-                                                                    uu___5 ->
-                                                                    (fun ss'
-                                                                    ->
-                                                                    Obj.magic
-                                                                    (FStar_Tactics_Effect.tac_bind
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.Match.fst"
-                                                                    (Prims.of_int (255))
-                                                                    (Prims.of_int (20))
-                                                                    (Prims.of_int (255))
-                                                                    (Prims.of_int (91)))))
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.Match.fst"
-                                                                    (Prims.of_int (254))
-                                                                    (Prims.of_int (54))
-                                                                    (Prims.of_int (259))
-                                                                    (Prims.of_int (18)))))
-                                                                    (Obj.magic
-                                                                    (FStar_Tactics_V2_Builtins.check_equiv
-                                                                    (Pulse_Typing.elab_env
-                                                                    g)
-                                                                    (Pulse_Elaborate_Pure.elab_term
-                                                                    (Pulse_Typing.mk_reveal
-                                                                    u ty w))
-                                                                    (Pulse_Elaborate_Pure.elab_term
-                                                                    p)))
-                                                                    (fun
-                                                                    uu___5 ->
-                                                                    FStar_Tactics_Effect.lift_div_tac
-                                                                    (fun
-                                                                    uu___6 ->
-                                                                    match uu___5
-                                                                    with
-                                                                    | 
-                                                                    (b,
-                                                                    uu___7)
-                                                                    ->
-                                                                    if
-                                                                    FStar_Pervasives_Native.uu___is_Some
-                                                                    b
-                                                                    then
-                                                                    FStar_Pervasives_Native.Some
-                                                                    (Prims.Mkdtuple2
-                                                                    (ss',
-                                                                    (rt_equiv
-                                                                    (Pulse_Typing.elab_env
-                                                                    g)
-                                                                    (Pulse_Elaborate_Pure.elab_term
-                                                                    p)
-                                                                    (Pulse_Elaborate_Pure.elab_term
-                                                                    (Pulse_Checker_Prover_Base.op_Array_Access
-                                                                    ss' q0)))))
-                                                                    else
-                                                                    FStar_Pervasives_Native.None))))
-                                                                    uu___5)))
-                                                                    uu___5)))
-                                                                    uu___5)))
-                                                                    uu___4))
-                                                                    | 
-                                                                    uu___4 ->
-                                                                    Obj.repr
-                                                                    (match 
-                                                                    is_uvar
-                                                                    q1 uvs
-                                                                    with
-                                                                    | 
-                                                                    FStar_Pervasives_Native.Some
-                                                                    n ->
-                                                                    Obj.repr
-                                                                    (FStar_Tactics_Effect.tac_bind
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.Match.fst"
-                                                                    (Prims.of_int (263))
-                                                                    (Prims.of_int (11))
-                                                                    (Prims.of_int (264))
-                                                                    (Prims.of_int (124)))))
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.Match.fst"
-                                                                    (Prims.of_int (275))
-                                                                    (Prims.of_int (11))
-                                                                    (Prims.of_int (275))
-                                                                    (Prims.of_int (41)))))
-                                                                    (Obj.magic
-                                                                    (Pulse_Checker_Prover_Util.debug_prover
-                                                                    g
-                                                                    (fun
-                                                                    uu___5 ->
-                                                                    FStar_Tactics_Effect.tac_bind
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.Match.fst"
-                                                                    (Prims.of_int (264))
-                                                                    (Prims.of_int (103))
-                                                                    (Prims.of_int (264))
-                                                                    (Prims.of_int (123)))))
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.Match.fst"
-                                                                    (Prims.of_int (264))
-                                                                    (Prims.of_int (13))
-                                                                    (Prims.of_int (264))
-                                                                    (Prims.of_int (123)))))
-                                                                    (Obj.magic
-                                                                    (Pulse_Syntax_Printer.term_to_string
-                                                                    q1))
-                                                                    (fun
-                                                                    uu___6 ->
-                                                                    (fun
-                                                                    uu___6 ->
-                                                                    Obj.magic
-                                                                    (FStar_Tactics_Effect.tac_bind
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.Match.fst"
-                                                                    (Prims.of_int (264))
-                                                                    (Prims.of_int (13))
-                                                                    (Prims.of_int (264))
-                                                                    (Prims.of_int (123)))))
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.Match.fst"
-                                                                    (Prims.of_int (264))
-                                                                    (Prims.of_int (13))
-                                                                    (Prims.of_int (264))
-                                                                    (Prims.of_int (123)))))
-                                                                    (Obj.magic
-                                                                    (FStar_Tactics_Effect.tac_bind
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.Match.fst"
-                                                                    (Prims.of_int (264))
-                                                                    (Prims.of_int (82))
-                                                                    (Prims.of_int (264))
-                                                                    (Prims.of_int (102)))))
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "FStar.Printf.fst"
-                                                                    (Prims.of_int (121))
-                                                                    (Prims.of_int (8))
-                                                                    (Prims.of_int (123))
-                                                                    (Prims.of_int (44)))))
-                                                                    (Obj.magic
-                                                                    (Pulse_Syntax_Printer.term_to_string
-                                                                    p))
-                                                                    (fun
-                                                                    uu___7 ->
-                                                                    FStar_Tactics_Effect.lift_div_tac
-                                                                    (fun
-                                                                    uu___8 ->
-                                                                    fun x ->
-                                                                    Prims.strcat
-                                                                    (Prims.strcat
-                                                                    "prover.match trying "
-                                                                    (Prims.strcat
-                                                                    uu___7
-                                                                    " =?= "))
-                                                                    (Prims.strcat
-                                                                    x
-                                                                    ", not eq_tm, q is uvar")))))
-                                                                    (fun
-                                                                    uu___7 ->
-                                                                    FStar_Tactics_Effect.lift_div_tac
-                                                                    (fun
-                                                                    uu___8 ->
-                                                                    uu___7
-                                                                    uu___6))))
-                                                                    uu___6))))
-                                                                    (fun
-                                                                    uu___5 ->
-                                                                    FStar_Tactics_Effect.lift_div_tac
-                                                                    (fun
-                                                                    uu___6 ->
-                                                                    FStar_Pervasives_Native.Some
-                                                                    (Prims.Mkdtuple2
-                                                                    ((Pulse_Checker_Prover_Substs.push_ss
-                                                                    ss
-                                                                    (Pulse_Checker_Prover_Substs.push
-                                                                    Pulse_Checker_Prover_Substs.empty
-                                                                    n p)),
-                                                                    (FStar_Reflection_Typing.EQ_Refl
-                                                                    ((Pulse_Typing.elab_env
-                                                                    g),
-                                                                    (Pulse_Elaborate_Pure.elab_term
-                                                                    p))))))))
-                                                                    | 
-                                                                    uu___5 ->
-                                                                    Obj.repr
-                                                                    (match 
-                                                                    ((p.Pulse_Syntax_Base.t),
-                                                                    (q1.Pulse_Syntax_Base.t))
-                                                                    with
-                                                                    | 
-                                                                    (Pulse_Syntax_Base.Tm_Pure
-                                                                    p1,
-                                                                    Pulse_Syntax_Base.Tm_Pure
-                                                                    q11) ->
-                                                                    Obj.repr
-                                                                    (FStar_Tactics_Effect.tac_bind
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.Match.fst"
-                                                                    (Prims.of_int (279))
-                                                                    (Prims.of_int (13))
-                                                                    (Prims.of_int (280))
-                                                                    (Prims.of_int (127)))))
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.Match.fst"
-                                                                    (Prims.of_int (280))
-                                                                    (Prims.of_int (128))
-                                                                    (Prims.of_int (288))
-                                                                    (Prims.of_int (29)))))
-                                                                    (Obj.magic
-                                                                    (Pulse_Checker_Prover_Util.debug_prover
-                                                                    g
-                                                                    (fun
-                                                                    uu___6 ->
-                                                                    FStar_Tactics_Effect.tac_bind
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.Match.fst"
-                                                                    (Prims.of_int (280))
-                                                                    (Prims.of_int (106))
-                                                                    (Prims.of_int (280))
-                                                                    (Prims.of_int (126)))))
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.Match.fst"
-                                                                    (Prims.of_int (280))
-                                                                    (Prims.of_int (15))
-                                                                    (Prims.of_int (280))
-                                                                    (Prims.of_int (126)))))
-                                                                    (Obj.magic
-                                                                    (Pulse_Syntax_Printer.term_to_string
-                                                                    q1))
-                                                                    (fun
-                                                                    uu___7 ->
-                                                                    (fun
-                                                                    uu___7 ->
-                                                                    Obj.magic
-                                                                    (FStar_Tactics_Effect.tac_bind
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.Match.fst"
-                                                                    (Prims.of_int (280))
-                                                                    (Prims.of_int (15))
-                                                                    (Prims.of_int (280))
-                                                                    (Prims.of_int (126)))))
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.Match.fst"
-                                                                    (Prims.of_int (280))
-                                                                    (Prims.of_int (15))
-                                                                    (Prims.of_int (280))
-                                                                    (Prims.of_int (126)))))
-                                                                    (Obj.magic
-                                                                    (FStar_Tactics_Effect.tac_bind
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.Match.fst"
-                                                                    (Prims.of_int (280))
-                                                                    (Prims.of_int (85))
-                                                                    (Prims.of_int (280))
-                                                                    (Prims.of_int (105)))))
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "FStar.Printf.fst"
-                                                                    (Prims.of_int (121))
-                                                                    (Prims.of_int (8))
-                                                                    (Prims.of_int (123))
-                                                                    (Prims.of_int (44)))))
-                                                                    (Obj.magic
-                                                                    (Pulse_Syntax_Printer.term_to_string
-                                                                    p))
-                                                                    (fun
-                                                                    uu___8 ->
-                                                                    FStar_Tactics_Effect.lift_div_tac
-                                                                    (fun
-                                                                    uu___9 ->
-                                                                    fun x ->
-                                                                    Prims.strcat
-                                                                    (Prims.strcat
-                                                                    "prover.match trying "
-                                                                    (Prims.strcat
-                                                                    uu___8
-                                                                    " =?= "))
-                                                                    (Prims.strcat
-                                                                    x
-                                                                    ", both p and q are pure")))))
-                                                                    (fun
-                                                                    uu___8 ->
-                                                                    FStar_Tactics_Effect.lift_div_tac
-                                                                    (fun
-                                                                    uu___9 ->
-                                                                    uu___8
-                                                                    uu___7))))
-                                                                    uu___7))))
-                                                                    (fun
-                                                                    uu___6 ->
-                                                                    (fun
-                                                                    uu___6 ->
-                                                                    Obj.magic
-                                                                    (FStar_Tactics_Effect.tac_bind
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.Match.fst"
-                                                                    (Prims.of_int (281))
-                                                                    (Prims.of_int (21))
-                                                                    (Prims.of_int (281))
-                                                                    (Prims.of_int (41)))))
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.Match.fst"
-                                                                    (Prims.of_int (282))
-                                                                    (Prims.of_int (13))
-                                                                    (Prims.of_int (288))
-                                                                    (Prims.of_int (29)))))
-                                                                    (Obj.magic
-                                                                    (unify g
-                                                                    uvs p1
-                                                                    q11 ss))
-                                                                    (fun r ->
-                                                                    FStar_Tactics_Effect.lift_div_tac
-                                                                    (fun
-                                                                    uu___7 ->
-                                                                    match r
-                                                                    with
-                                                                    | 
-                                                                    FStar_Pervasives_Native.Some
-                                                                    (Prims.Mkdtuple2
-                                                                    (ss',
-                                                                    uu___8))
-                                                                    ->
-                                                                    FStar_Pervasives_Native.Some
-                                                                    (Prims.Mkdtuple2
-                                                                    (ss',
-                                                                    (rt_equiv
-                                                                    (Pulse_Typing.elab_env
-                                                                    g)
-                                                                    (Pulse_Elaborate_Pure.elab_term
-                                                                    p)
-                                                                    (Pulse_Elaborate_Pure.elab_term
-                                                                    (Pulse_Checker_Prover_Base.op_Array_Access
-                                                                    ss' q)))))
-                                                                    | 
-                                                                    FStar_Pervasives_Native.None
-                                                                    ->
-                                                                    FStar_Pervasives_Native.None))))
-                                                                    uu___6))
-                                                                    | 
-                                                                    (uu___6,
-                                                                    uu___7)
-                                                                    ->
-                                                                    Obj.repr
-                                                                    (match 
-                                                                    ((Pulse_Syntax_Pure.is_pure_app
-                                                                    p),
-                                                                    (Pulse_Syntax_Pure.is_pure_app
-                                                                    q1))
-                                                                    with
-                                                                    | 
-                                                                    (FStar_Pervasives_Native.Some
-                                                                    (head_p,
-                                                                    qual_p,
-                                                                    arg_p),
-                                                                    FStar_Pervasives_Native.Some
-                                                                    (head_q,
-                                                                    qual_q,
-                                                                    arg_q))
-                                                                    ->
-                                                                    Obj.repr
-                                                                    (FStar_Tactics_Effect.tac_bind
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.Match.fst"
-                                                                    (Prims.of_int (293))
-                                                                    (Prims.of_int (15))
-                                                                    (Prims.of_int (294))
-                                                                    (Prims.of_int (125)))))
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.Match.fst"
-                                                                    (Prims.of_int (296))
-                                                                    (Prims.of_int (15))
-                                                                    (Prims.of_int (310))
-                                                                    (Prims.of_int (18)))))
-                                                                    (Obj.magic
-                                                                    (Pulse_Checker_Prover_Util.debug_prover
-                                                                    g
-                                                                    (fun
-                                                                    uu___8 ->
-                                                                    FStar_Tactics_Effect.tac_bind
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.Match.fst"
-                                                                    (Prims.of_int (294))
-                                                                    (Prims.of_int (104))
-                                                                    (Prims.of_int (294))
-                                                                    (Prims.of_int (124)))))
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.Match.fst"
-                                                                    (Prims.of_int (294))
-                                                                    (Prims.of_int (17))
-                                                                    (Prims.of_int (294))
-                                                                    (Prims.of_int (124)))))
-                                                                    (Obj.magic
-                                                                    (Pulse_Syntax_Printer.term_to_string
-                                                                    q1))
-                                                                    (fun
-                                                                    uu___9 ->
-                                                                    (fun
-                                                                    uu___9 ->
-                                                                    Obj.magic
-                                                                    (FStar_Tactics_Effect.tac_bind
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.Match.fst"
-                                                                    (Prims.of_int (294))
-                                                                    (Prims.of_int (17))
-                                                                    (Prims.of_int (294))
-                                                                    (Prims.of_int (124)))))
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.Match.fst"
-                                                                    (Prims.of_int (294))
-                                                                    (Prims.of_int (17))
-                                                                    (Prims.of_int (294))
-                                                                    (Prims.of_int (124)))))
-                                                                    (Obj.magic
-                                                                    (FStar_Tactics_Effect.tac_bind
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.Match.fst"
-                                                                    (Prims.of_int (294))
-                                                                    (Prims.of_int (83))
-                                                                    (Prims.of_int (294))
-                                                                    (Prims.of_int (103)))))
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "FStar.Printf.fst"
-                                                                    (Prims.of_int (121))
-                                                                    (Prims.of_int (8))
-                                                                    (Prims.of_int (123))
-                                                                    (Prims.of_int (44)))))
-                                                                    (Obj.magic
-                                                                    (Pulse_Syntax_Printer.term_to_string
-                                                                    p))
-                                                                    (fun
-                                                                    uu___10
-                                                                    ->
-                                                                    FStar_Tactics_Effect.lift_div_tac
-                                                                    (fun
-                                                                    uu___11
-                                                                    ->
-                                                                    fun x ->
-                                                                    Prims.strcat
-                                                                    (Prims.strcat
-                                                                    "prover.match trying "
-                                                                    (Prims.strcat
-                                                                    uu___10
-                                                                    " =?= "))
-                                                                    (Prims.strcat
-                                                                    x
-                                                                    ", both are pure app")))))
-                                                                    (fun
-                                                                    uu___10
-                                                                    ->
-                                                                    FStar_Tactics_Effect.lift_div_tac
-                                                                    (fun
-                                                                    uu___11
-                                                                    ->
-                                                                    uu___10
-                                                                    uu___9))))
-                                                                    uu___9))))
-                                                                    (fun
-                                                                    uu___8 ->
-                                                                    (fun
-                                                                    uu___8 ->
-                                                                    if
-                                                                    Prims.op_Negation
-                                                                    (qual_p =
-                                                                    qual_q)
-                                                                    then
-                                                                    Obj.magic
-                                                                    (Obj.repr
-                                                                    (FStar_Tactics_Effect.lift_div_tac
-                                                                    (fun
-                                                                    uu___9 ->
-                                                                    FStar_Pervasives_Native.None)))
-                                                                    else
-                                                                    Obj.magic
-                                                                    (Obj.repr
-                                                                    (FStar_Tactics_Effect.tac_bind
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.Match.fst"
-                                                                    (Prims.of_int (298))
-                                                                    (Prims.of_int (25))
-                                                                    (Prims.of_int (298))
-                                                                    (Prims.of_int (53)))))
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.Match.fst"
-                                                                    (Prims.of_int (299))
-                                                                    (Prims.of_int (17))
-                                                                    (Prims.of_int (309))
-                                                                    (Prims.of_int (28)))))
-                                                                    (Obj.magic
-                                                                    (unify g
-                                                                    uvs
-                                                                    head_p
-                                                                    head_q ss))
-                                                                    (fun
-                                                                    uu___10
-                                                                    ->
-                                                                    (fun r ->
-                                                                    match r
-                                                                    with
-                                                                    | 
-                                                                    FStar_Pervasives_Native.Some
-                                                                    (Prims.Mkdtuple2
-                                                                    (ss',
-                                                                    uu___10))
-                                                                    ->
-                                                                    Obj.magic
-                                                                    (Obj.repr
-                                                                    (FStar_Tactics_Effect.tac_bind
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.Match.fst"
-                                                                    (Prims.of_int (301))
-                                                                    (Prims.of_int (27))
-                                                                    (Prims.of_int (301))
-                                                                    (Prims.of_int (54)))))
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.Match.fst"
-                                                                    (Prims.of_int (302))
-                                                                    (Prims.of_int (19))
-                                                                    (Prims.of_int (308))
-                                                                    (Prims.of_int (32)))))
-                                                                    (Obj.magic
-                                                                    (unify g
-                                                                    uvs arg_p
-                                                                    arg_q ss'))
-                                                                    (fun r1
-                                                                    ->
-                                                                    FStar_Tactics_Effect.lift_div_tac
-                                                                    (fun
-                                                                    uu___11
-                                                                    ->
-                                                                    match r1
-                                                                    with
-                                                                    | 
-                                                                    FStar_Pervasives_Native.Some
-                                                                    (Prims.Mkdtuple2
-                                                                    (ss'1,
-                                                                    uu___12))
-                                                                    ->
-                                                                    FStar_Pervasives_Native.Some
-                                                                    (Prims.Mkdtuple2
-                                                                    (ss'1,
-                                                                    (rt_equiv
-                                                                    (Pulse_Typing.elab_env
-                                                                    g)
-                                                                    (Pulse_Elaborate_Pure.elab_term
-                                                                    p)
-                                                                    (Pulse_Elaborate_Pure.elab_term
-                                                                    (Pulse_Checker_Prover_Base.op_Array_Access
-                                                                    ss'1 q)))))
-                                                                    | 
-                                                                    uu___12
-                                                                    ->
-                                                                    FStar_Pervasives_Native.None))))
-                                                                    | 
-                                                                    uu___10
-                                                                    ->
-                                                                    Obj.magic
-                                                                    (Obj.repr
-                                                                    (FStar_Tactics_Effect.lift_div_tac
-                                                                    (fun
-                                                                    uu___11
-                                                                    ->
-                                                                    FStar_Pervasives_Native.None))))
-                                                                    uu___10))))
-                                                                    uu___8))
-                                                                    | 
-                                                                    (uu___8,
-                                                                    uu___9)
-                                                                    ->
-                                                                    Obj.repr
-                                                                    (FStar_Tactics_Effect.lift_div_tac
-                                                                    (fun
-                                                                    uu___10
-                                                                    ->
-                                                                    FStar_Pervasives_Native.None))))))))
-                                                                 uu___2)))
-                                                    uu___))) uu___))) uu___)))
-                   uu___)
+                                                            uu___3)))) uu___1))))
+                            uu___))) uu___)
 let (try_match_pq :
   Pulse_Typing_Env.env ->
     Pulse_Typing_Env.env ->
@@ -2134,14 +965,14 @@ let (try_match_pq :
             (FStar_Sealed.seal
                (Obj.magic
                   (FStar_Range.mk_range "Pulse.Checker.Prover.Match.fst"
-                     (Prims.of_int (317)) (Prims.of_int (10))
-                     (Prims.of_int (317)) (Prims.of_int (34)))))
+                     (Prims.of_int (387)) (Prims.of_int (10))
+                     (Prims.of_int (387)) (Prims.of_int (25)))))
             (FStar_Sealed.seal
                (Obj.magic
                   (FStar_Range.mk_range "Pulse.Checker.Prover.Match.fst"
-                     (Prims.of_int (318)) (Prims.of_int (2))
-                     (Prims.of_int (322)) (Prims.of_int (27)))))
-            (Obj.magic (unify g uvs p q Pulse_Checker_Prover_Substs.empty))
+                     (Prims.of_int (388)) (Prims.of_int (2))
+                     (Prims.of_int (392)) (Prims.of_int (27)))))
+            (Obj.magic (unify g uvs p q))
             (fun r ->
                FStar_Tactics_Effect.lift_div_tac
                  (fun uu___ ->
@@ -2178,14 +1009,14 @@ let (match_step :
                      (Obj.magic
                         (FStar_Range.mk_range
                            "Pulse.Checker.Prover.Match.fst"
-                           (Prims.of_int (333)) (Prims.of_int (11))
-                           (Prims.of_int (333)) (Prims.of_int (21)))))
+                           (Prims.of_int (403)) (Prims.of_int (11))
+                           (Prims.of_int (403)) (Prims.of_int (21)))))
                   (FStar_Sealed.seal
                      (Obj.magic
                         (FStar_Range.mk_range
                            "Pulse.Checker.Prover.Match.fst"
-                           (Prims.of_int (334)) (Prims.of_int (52))
-                           (Prims.of_int (397)) (Prims.of_int (11)))))
+                           (Prims.of_int (404)) (Prims.of_int (52))
+                           (Prims.of_int (467)) (Prims.of_int (11)))))
                   (FStar_Tactics_Effect.lift_div_tac
                      (fun uu___1 ->
                         Pulse_Checker_Prover_Base.op_Array_Access
@@ -2198,16 +1029,16 @@ let (match_step :
                                 (Obj.magic
                                    (FStar_Range.mk_range
                                       "Pulse.Checker.Prover.Match.fst"
-                                      (Prims.of_int (336))
+                                      (Prims.of_int (406))
                                       (Prims.of_int (11))
-                                      (Prims.of_int (336))
+                                      (Prims.of_int (406))
                                       (Prims.of_int (45)))))
                              (FStar_Sealed.seal
                                 (Obj.magic
                                    (FStar_Range.mk_range
                                       "Pulse.Checker.Prover.Match.fst"
-                                      (Prims.of_int (338)) Prims.int_zero
-                                      (Prims.of_int (397))
+                                      (Prims.of_int (408)) Prims.int_zero
+                                      (Prims.of_int (467))
                                       (Prims.of_int (11)))))
                              (Obj.magic
                                 (try_match_pq
@@ -2221,17 +1052,17 @@ let (match_step :
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.Checker.Prover.Match.fst"
-                                                 (Prims.of_int (338))
+                                                 (Prims.of_int (408))
                                                  Prims.int_zero
-                                                 (Prims.of_int (340))
+                                                 (Prims.of_int (410))
                                                  (Prims.of_int (92)))))
                                         (FStar_Sealed.seal
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.Checker.Prover.Match.fst"
-                                                 (Prims.of_int (342))
+                                                 (Prims.of_int (412))
                                                  Prims.int_zero
-                                                 (Prims.of_int (397))
+                                                 (Prims.of_int (467))
                                                  (Prims.of_int (11)))))
                                         (Obj.magic
                                            (Pulse_Checker_Prover_Util.debug_prover
@@ -2242,17 +1073,17 @@ let (match_step :
                                                       (Obj.magic
                                                          (FStar_Range.mk_range
                                                             "Pulse.Checker.Prover.Match.fst"
-                                                            (Prims.of_int (339))
+                                                            (Prims.of_int (409))
                                                             (Prims.of_int (2))
-                                                            (Prims.of_int (340))
+                                                            (Prims.of_int (410))
                                                             (Prims.of_int (91)))))
                                                    (FStar_Sealed.seal
                                                       (Obj.magic
                                                          (FStar_Range.mk_range
                                                             "Pulse.Checker.Prover.Match.fst"
-                                                            (Prims.of_int (339))
+                                                            (Prims.of_int (409))
                                                             (Prims.of_int (2))
-                                                            (Prims.of_int (340))
+                                                            (Prims.of_int (410))
                                                             (Prims.of_int (91)))))
                                                    (Obj.magic
                                                       (FStar_Tactics_Effect.tac_bind
@@ -2260,17 +1091,17 @@ let (match_step :
                                                             (Obj.magic
                                                                (FStar_Range.mk_range
                                                                   "Pulse.Checker.Prover.Match.fst"
-                                                                  (Prims.of_int (340))
+                                                                  (Prims.of_int (410))
                                                                   (Prims.of_int (25))
-                                                                  (Prims.of_int (340))
+                                                                  (Prims.of_int (410))
                                                                   (Prims.of_int (48)))))
                                                          (FStar_Sealed.seal
                                                             (Obj.magic
                                                                (FStar_Range.mk_range
                                                                   "Pulse.Checker.Prover.Match.fst"
-                                                                  (Prims.of_int (339))
+                                                                  (Prims.of_int (409))
                                                                   (Prims.of_int (2))
-                                                                  (Prims.of_int (340))
+                                                                  (Prims.of_int (410))
                                                                   (Prims.of_int (91)))))
                                                          (Obj.magic
                                                             (Pulse_Syntax_Printer.term_to_string
@@ -2284,18 +1115,18 @@ let (match_step :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.Match.fst"
-                                                                    (Prims.of_int (339))
+                                                                    (Prims.of_int (409))
                                                                     (Prims.of_int (2))
-                                                                    (Prims.of_int (340))
+                                                                    (Prims.of_int (410))
                                                                     (Prims.of_int (91)))))
                                                                     (
                                                                     FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.Match.fst"
-                                                                    (Prims.of_int (339))
+                                                                    (Prims.of_int (409))
                                                                     (Prims.of_int (2))
-                                                                    (Prims.of_int (340))
+                                                                    (Prims.of_int (410))
                                                                     (Prims.of_int (91)))))
                                                                     (
                                                                     Obj.magic
@@ -2304,9 +1135,9 @@ let (match_step :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.Match.fst"
-                                                                    (Prims.of_int (340))
+                                                                    (Prims.of_int (410))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (340))
+                                                                    (Prims.of_int (410))
                                                                     (Prims.of_int (24)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic

--- a/src/ocaml/plugin/generated/Pulse_Checker_Prover_Match.ml
+++ b/src/ocaml/plugin/generated/Pulse_Checker_Prover_Match.ml
@@ -735,13 +735,13 @@ let (unify :
             (FStar_Sealed.seal
                (Obj.magic
                   (FStar_Range.mk_range "Pulse.Checker.Prover.Match.fst"
-                     (Prims.of_int (256)) (Prims.of_int (11))
-                     (Prims.of_int (256)) (Prims.of_int (36)))))
+                     (Prims.of_int (246)) (Prims.of_int (11))
+                     (Prims.of_int (246)) (Prims.of_int (36)))))
             (FStar_Sealed.seal
                (Obj.magic
                   (FStar_Range.mk_range "Pulse.Checker.Prover.Match.fst"
-                     (Prims.of_int (256)) (Prims.of_int (39))
-                     (Prims.of_int (268)) (Prims.of_int (11)))))
+                     (Prims.of_int (246)) (Prims.of_int (39))
+                     (Prims.of_int (258)) (Prims.of_int (11)))))
             (Obj.magic (try_solve_uvars g uvs p q))
             (fun uu___ ->
                (fun ss ->
@@ -751,14 +751,14 @@ let (unify :
                           (Obj.magic
                              (FStar_Range.mk_range
                                 "Pulse.Checker.Prover.Match.fst"
-                                (Prims.of_int (257)) (Prims.of_int (10))
-                                (Prims.of_int (257)) (Prims.of_int (16)))))
+                                (Prims.of_int (247)) (Prims.of_int (10))
+                                (Prims.of_int (247)) (Prims.of_int (16)))))
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range
                                 "Pulse.Checker.Prover.Match.fst"
-                                (Prims.of_int (258)) (Prims.of_int (2))
-                                (Prims.of_int (268)) (Prims.of_int (11)))))
+                                (Prims.of_int (248)) (Prims.of_int (2))
+                                (Prims.of_int (258)) (Prims.of_int (11)))))
                        (FStar_Tactics_Effect.lift_div_tac
                           (fun uu___ ->
                              Pulse_Checker_Prover_Base.op_Array_Access ss q))
@@ -785,17 +785,17 @@ let (unify :
                                           (Obj.magic
                                              (FStar_Range.mk_range
                                                 "Pulse.Checker.Prover.Match.fst"
-                                                (Prims.of_int (260))
+                                                (Prims.of_int (250))
                                                 (Prims.of_int (10))
-                                                (Prims.of_int (260))
+                                                (Prims.of_int (250))
                                                 (Prims.of_int (31)))))
                                        (FStar_Sealed.seal
                                           (Obj.magic
                                              (FStar_Range.mk_range
                                                 "Pulse.Checker.Prover.Match.fst"
-                                                (Prims.of_int (260))
+                                                (Prims.of_int (250))
                                                 (Prims.of_int (7))
-                                                (Prims.of_int (268))
+                                                (Prims.of_int (258))
                                                 (Prims.of_int (11)))))
                                        (Obj.magic (contains_uvar q1 uvs g))
                                        (fun uu___1 ->
@@ -815,17 +815,17 @@ let (unify :
                                                           (Obj.magic
                                                              (FStar_Range.mk_range
                                                                 "Pulse.Checker.Prover.Match.fst"
-                                                                (Prims.of_int (262))
+                                                                (Prims.of_int (252))
                                                                 (Prims.of_int (10))
-                                                                (Prims.of_int (262))
+                                                                (Prims.of_int (252))
                                                                 (Prims.of_int (41)))))
                                                        (FStar_Sealed.seal
                                                           (Obj.magic
                                                              (FStar_Range.mk_range
                                                                 "Pulse.Checker.Prover.Match.fst"
-                                                                (Prims.of_int (262))
+                                                                (Prims.of_int (252))
                                                                 (Prims.of_int (7))
-                                                                (Prims.of_int (268))
+                                                                (Prims.of_int (258))
                                                                 (Prims.of_int (11)))))
                                                        (Obj.magic
                                                           (eligible_for_smt_equality
@@ -842,17 +842,17 @@ let (unify :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.Match.fst"
-                                                                    (Prims.of_int (263))
+                                                                    (Prims.of_int (253))
                                                                     (Prims.of_int (16))
-                                                                    (Prims.of_int (263))
+                                                                    (Prims.of_int (253))
                                                                     (Prims.of_int (27)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.Match.fst"
-                                                                    (Prims.of_int (263))
+                                                                    (Prims.of_int (253))
                                                                     (Prims.of_int (30))
-                                                                    (Prims.of_int (267))
+                                                                    (Prims.of_int (257))
                                                                     (Prims.of_int (24)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -869,17 +869,17 @@ let (unify :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.Match.fst"
-                                                                    (Prims.of_int (264))
+                                                                    (Prims.of_int (254))
                                                                     (Prims.of_int (16))
-                                                                    (Prims.of_int (264))
+                                                                    (Prims.of_int (254))
                                                                     (Prims.of_int (27)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.Match.fst"
-                                                                    (Prims.of_int (265))
+                                                                    (Prims.of_int (255))
                                                                     (Prims.of_int (7))
-                                                                    (Prims.of_int (267))
+                                                                    (Prims.of_int (257))
                                                                     (Prims.of_int (24)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -896,17 +896,17 @@ let (unify :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.Match.fst"
-                                                                    (Prims.of_int (265))
+                                                                    (Prims.of_int (255))
                                                                     (Prims.of_int (13))
-                                                                    (Prims.of_int (265))
+                                                                    (Prims.of_int (255))
                                                                     (Prims.of_int (45)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.Match.fst"
-                                                                    (Prims.of_int (265))
+                                                                    (Prims.of_int (255))
                                                                     (Prims.of_int (7))
-                                                                    (Prims.of_int (267))
+                                                                    (Prims.of_int (257))
                                                                     (Prims.of_int (24)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_V2_Builtins.check_equiv
@@ -965,13 +965,13 @@ let (try_match_pq :
             (FStar_Sealed.seal
                (Obj.magic
                   (FStar_Range.mk_range "Pulse.Checker.Prover.Match.fst"
-                     (Prims.of_int (387)) (Prims.of_int (10))
-                     (Prims.of_int (387)) (Prims.of_int (25)))))
+                     (Prims.of_int (264)) (Prims.of_int (10))
+                     (Prims.of_int (264)) (Prims.of_int (25)))))
             (FStar_Sealed.seal
                (Obj.magic
                   (FStar_Range.mk_range "Pulse.Checker.Prover.Match.fst"
-                     (Prims.of_int (388)) (Prims.of_int (2))
-                     (Prims.of_int (392)) (Prims.of_int (27)))))
+                     (Prims.of_int (265)) (Prims.of_int (2))
+                     (Prims.of_int (269)) (Prims.of_int (27)))))
             (Obj.magic (unify g uvs p q))
             (fun r ->
                FStar_Tactics_Effect.lift_div_tac
@@ -1009,14 +1009,14 @@ let (match_step :
                      (Obj.magic
                         (FStar_Range.mk_range
                            "Pulse.Checker.Prover.Match.fst"
-                           (Prims.of_int (403)) (Prims.of_int (11))
-                           (Prims.of_int (403)) (Prims.of_int (21)))))
+                           (Prims.of_int (280)) (Prims.of_int (11))
+                           (Prims.of_int (280)) (Prims.of_int (21)))))
                   (FStar_Sealed.seal
                      (Obj.magic
                         (FStar_Range.mk_range
                            "Pulse.Checker.Prover.Match.fst"
-                           (Prims.of_int (404)) (Prims.of_int (52))
-                           (Prims.of_int (467)) (Prims.of_int (11)))))
+                           (Prims.of_int (281)) (Prims.of_int (52))
+                           (Prims.of_int (344)) (Prims.of_int (11)))))
                   (FStar_Tactics_Effect.lift_div_tac
                      (fun uu___1 ->
                         Pulse_Checker_Prover_Base.op_Array_Access
@@ -1029,16 +1029,16 @@ let (match_step :
                                 (Obj.magic
                                    (FStar_Range.mk_range
                                       "Pulse.Checker.Prover.Match.fst"
-                                      (Prims.of_int (406))
+                                      (Prims.of_int (283))
                                       (Prims.of_int (11))
-                                      (Prims.of_int (406))
+                                      (Prims.of_int (283))
                                       (Prims.of_int (45)))))
                              (FStar_Sealed.seal
                                 (Obj.magic
                                    (FStar_Range.mk_range
                                       "Pulse.Checker.Prover.Match.fst"
-                                      (Prims.of_int (408)) Prims.int_zero
-                                      (Prims.of_int (467))
+                                      (Prims.of_int (285)) Prims.int_zero
+                                      (Prims.of_int (344))
                                       (Prims.of_int (11)))))
                              (Obj.magic
                                 (try_match_pq
@@ -1052,17 +1052,17 @@ let (match_step :
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.Checker.Prover.Match.fst"
-                                                 (Prims.of_int (408))
+                                                 (Prims.of_int (285))
                                                  Prims.int_zero
-                                                 (Prims.of_int (410))
+                                                 (Prims.of_int (287))
                                                  (Prims.of_int (92)))))
                                         (FStar_Sealed.seal
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.Checker.Prover.Match.fst"
-                                                 (Prims.of_int (412))
+                                                 (Prims.of_int (289))
                                                  Prims.int_zero
-                                                 (Prims.of_int (467))
+                                                 (Prims.of_int (344))
                                                  (Prims.of_int (11)))))
                                         (Obj.magic
                                            (Pulse_Checker_Prover_Util.debug_prover
@@ -1073,17 +1073,17 @@ let (match_step :
                                                       (Obj.magic
                                                          (FStar_Range.mk_range
                                                             "Pulse.Checker.Prover.Match.fst"
-                                                            (Prims.of_int (409))
+                                                            (Prims.of_int (286))
                                                             (Prims.of_int (2))
-                                                            (Prims.of_int (410))
+                                                            (Prims.of_int (287))
                                                             (Prims.of_int (91)))))
                                                    (FStar_Sealed.seal
                                                       (Obj.magic
                                                          (FStar_Range.mk_range
                                                             "Pulse.Checker.Prover.Match.fst"
-                                                            (Prims.of_int (409))
+                                                            (Prims.of_int (286))
                                                             (Prims.of_int (2))
-                                                            (Prims.of_int (410))
+                                                            (Prims.of_int (287))
                                                             (Prims.of_int (91)))))
                                                    (Obj.magic
                                                       (FStar_Tactics_Effect.tac_bind
@@ -1091,17 +1091,17 @@ let (match_step :
                                                             (Obj.magic
                                                                (FStar_Range.mk_range
                                                                   "Pulse.Checker.Prover.Match.fst"
-                                                                  (Prims.of_int (410))
+                                                                  (Prims.of_int (287))
                                                                   (Prims.of_int (25))
-                                                                  (Prims.of_int (410))
+                                                                  (Prims.of_int (287))
                                                                   (Prims.of_int (48)))))
                                                          (FStar_Sealed.seal
                                                             (Obj.magic
                                                                (FStar_Range.mk_range
                                                                   "Pulse.Checker.Prover.Match.fst"
-                                                                  (Prims.of_int (409))
+                                                                  (Prims.of_int (286))
                                                                   (Prims.of_int (2))
-                                                                  (Prims.of_int (410))
+                                                                  (Prims.of_int (287))
                                                                   (Prims.of_int (91)))))
                                                          (Obj.magic
                                                             (Pulse_Syntax_Printer.term_to_string
@@ -1115,18 +1115,18 @@ let (match_step :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.Match.fst"
-                                                                    (Prims.of_int (409))
+                                                                    (Prims.of_int (286))
                                                                     (Prims.of_int (2))
-                                                                    (Prims.of_int (410))
+                                                                    (Prims.of_int (287))
                                                                     (Prims.of_int (91)))))
                                                                     (
                                                                     FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.Match.fst"
-                                                                    (Prims.of_int (409))
+                                                                    (Prims.of_int (286))
                                                                     (Prims.of_int (2))
-                                                                    (Prims.of_int (410))
+                                                                    (Prims.of_int (287))
                                                                     (Prims.of_int (91)))))
                                                                     (
                                                                     Obj.magic
@@ -1135,9 +1135,9 @@ let (match_step :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.Match.fst"
-                                                                    (Prims.of_int (410))
+                                                                    (Prims.of_int (287))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (410))
+                                                                    (Prims.of_int (287))
                                                                     (Prims.of_int (24)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic


### PR DESCRIPTION
The match step in the prover gets a query of the form: `match p q` where, `p` is an atomic vprop in the context and `q` is an atomic vprop in the precondition of the stateful command. `q` may have uvars for logical variables. The output of the step is a substitution for the uvars such that `p` and `q` are equivalent.

This PR tweaks the step a little bit to disentangle the unification and equivalence checking. Earlier the two were interleaved, causing a lot of inefficiencies in terms of unnecessary, failing smt queries. Basically, if `p` and `q` are function calls, then recursing on head of `p` and head of `q` makes the heuristic of when to use smt much more relaxed.

The fix is to do it in two steps: first infer all the uvars, this is a structural pass over `p` and `q` and builds a substitution. Once we have all the uvars solved, then we first do `eq_tm`, and if that fails try smt.