### PR TITLE
Query aggregation

### DIFF
--- a/lib/steel/pulse/Pulse.Checker.Prover.Match.fst
+++ b/lib/steel/pulse/Pulse.Checker.Prover.Match.fst
@@ -4,6 +4,7 @@ open Pulse.Syntax
 open Pulse.Typing
 open Pulse.Typing.Combinators
 open Pulse.Typing.Metatheory
+open Pulse.Typing.Util
 open Pulse.Checker.VPropEquiv
 open Pulse.Checker.Prover.Base
 open Pulse.Checker.Prover.Util
@@ -252,7 +253,7 @@ let unify (g:env) (uvs:env { disjoint uvs g})
   else if eligible_for_smt_equality g p q
   then let v0 = elab_term p in
        let v1 = elab_term q in
-       match T.check_equiv (elab_env g) v0 v1 with
+       match check_equiv_now (elab_env g) v0 v1 with
        | Some token, _ -> Some (| ss, RT.EQ_Token _ _ _ (FStar.Squash.return_squash token) |)
        | None, _ -> None
   else None

--- a/lib/steel/pulse/Pulse.Config.fst
+++ b/lib/steel/pulse/Pulse.Config.fst
@@ -1,0 +1,3 @@
+module Pulse.Config
+
+let join_goals : bool = true

--- a/lib/steel/pulse/Pulse.Config.fst
+++ b/lib/steel/pulse/Pulse.Config.fst
@@ -1,3 +1,3 @@
 module Pulse.Config
 
-let join_goals : bool = true
+let join_goals : bool = false

--- a/lib/steel/pulse/Pulse.Config.fsti
+++ b/lib/steel/pulse/Pulse.Config.fsti
@@ -1,0 +1,3 @@
+module Pulse.Config
+
+val join_goals : bool

--- a/lib/steel/pulse/Pulse.Main.fst
+++ b/lib/steel/pulse/Pulse.Main.fst
@@ -10,6 +10,7 @@ open Pulse.Typing
 open Pulse.Checker
 open Pulse.Elaborate
 open Pulse.Soundness
+module Cfg = Pulse.Config
 module RU = Pulse.RuntimeUtils
 module P = Pulse.Syntax.Printer
 
@@ -50,15 +51,46 @@ let main' (t:st_term) (pre:term) (g:RT.fstar_top_env)
            | _ -> fail g (Some t.range) "main: top-level term not a Tm_Abs"
       else fail g (Some t.range) "pulse main: cannot typecheck pre at type vprop"
 
-let main t pre : RT.dsl_tac_t =
- fun g ->
-  (* Solve all reflection guards as soon as they appear.
-  This is the default F* behavior, at least until
-    https://github.com/FStarLang/FStar/pull/3011
-  is merged. *)
-  set_guard_policy SMTSync;
-  main' t pre g
-  
+let join_smt_goals () : Tac unit =
+  let open FStar.Tactics.V2 in
+  let open FStar.List.Tot in
+
+  if RU.debug_at_level (top_env ()) "pulse.join" then
+    dump "PULSE: Goals before join";
+
+  (* Join *)
+  let smt_goals = smt_goals () in
+  set_goals (goals () @ smt_goals);
+  set_smt_goals [];
+  let n = List.Tot.length (goals ()) in
+  ignore (repeat join);
+
+  (* Heuristic rlimit setting :). Increase by 2 for every joined goal.
+  Default rlimit is 5, so this is "saving" 3 rlimit units per joined
+  goal. *)
+  if not (Nil? (goals ())) then (
+    let open FStar.Mul in
+    let rlimit = get_rlimit() + (n-1)*2 in
+    set_rlimit rlimit
+  );
+
+  if RU.debug_at_level (top_env ()) "pulse.join" then
+    dump "PULSE: Goals after join";
+
+  ()
+
+let main t pre : RT.dsl_tac_t = fun g ->
+  (* If we will be joining goals, make sure the guards from reflection
+  typing end up as SMT goals. This is anyway the default behavior but it
+  doesn't hurt to be explicit. *)
+  set_guard_policy SMT;
+
+  let res = main' t pre g in
+
+  if Cfg.join_goals && not (RU.debug_at_level g "DoNotJoin") then
+    join_smt_goals();
+  res
+
 [@@plugin]
 let check_pulse (namespaces:list string)
                 (module_abbrevs:list (string & string))

--- a/lib/steel/pulse/Pulse.Typing.Util.fst
+++ b/lib/steel/pulse/Pulse.Typing.Util.fst
@@ -1,0 +1,13 @@
+module Pulse.Typing.Util
+
+module L = FStar.List.Tot
+module T = FStar.Tactics.V2
+
+(* Call check_equiv under a SMTSync guard policy *)
+let check_equiv_now tcenv t0 t1 =
+  T.with_policy SMTSync (fun () ->
+    T.check_equiv tcenv t0 t1)
+
+let universe_of_now g e =
+  T.with_policy SMTSync (fun () ->
+    T.universe_of g e)

--- a/lib/steel/pulse/Pulse.Typing.Util.fsti
+++ b/lib/steel/pulse/Pulse.Typing.Util.fsti
@@ -1,0 +1,11 @@
+module Pulse.Typing.Util
+
+open FStar.Tactics.V2
+
+(* Like T.check_equiv, but will make sure to not delay any VC. *)
+val check_equiv_now : g:env -> t1:term -> t2:term ->
+  Tac (option (equiv_token g t1 t2) & issues)
+
+(* Like T.universe_of, but will make sure to not delay any VC. *)
+val universe_of_now : g:env -> e:term ->
+  Tac (option (u:universe{typing_token g e (E_Total, pack_ln (Reflection.V2.Tv_Type u))}) & issues)

--- a/share/steel/examples/pulse/ArrayTests.fst
+++ b/share/steel/examples/pulse/ArrayTests.fst
@@ -263,7 +263,7 @@ let sorted (s0 s:Seq.seq U32.t) =
 
 
 open FStar.UInt32
-#push-options "--query_stats"
+#push-options "--query_stats --z3rlimit 50"
 
 ```pulse
 fn sort3 (a:array U32.t)

--- a/src/ocaml/plugin/generated/Pulse_Checker_Prover_Match.ml
+++ b/src/ocaml/plugin/generated/Pulse_Checker_Prover_Match.ml
@@ -71,13 +71,13 @@ let (eligible_for_smt_equality :
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Checker.Prover.Match.fst"
-                   (Prims.of_int (90)) (Prims.of_int (31))
-                   (Prims.of_int (90)) (Prims.of_int (61)))))
+                   (Prims.of_int (91)) (Prims.of_int (31))
+                   (Prims.of_int (91)) (Prims.of_int (61)))))
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Checker.Prover.Match.fst"
-                   (Prims.of_int (90)) (Prims.of_int (64))
-                   (Prims.of_int (148)) (Prims.of_int (31)))))
+                   (Prims.of_int (91)) (Prims.of_int (64))
+                   (Prims.of_int (149)) (Prims.of_int (31)))))
           (FStar_Tactics_Effect.lift_div_tac
              (fun uu___ -> fun uu___1 -> (equational t0) || (equational t1)))
           (fun uu___ ->
@@ -88,14 +88,14 @@ let (eligible_for_smt_equality :
                         (Obj.magic
                            (FStar_Range.mk_range
                               "Pulse.Checker.Prover.Match.fst"
-                              (Prims.of_int (92)) (Prims.of_int (6))
-                              (Prims.of_int (95)) (Prims.of_int (18)))))
+                              (Prims.of_int (93)) (Prims.of_int (6))
+                              (Prims.of_int (96)) (Prims.of_int (18)))))
                      (FStar_Sealed.seal
                         (Obj.magic
                            (FStar_Range.mk_range
                               "Pulse.Checker.Prover.Match.fst"
-                              (Prims.of_int (97)) (Prims.of_int (4))
-                              (Prims.of_int (148)) (Prims.of_int (31)))))
+                              (Prims.of_int (98)) (Prims.of_int (4))
+                              (Prims.of_int (149)) (Prims.of_int (31)))))
                      (FStar_Tactics_Effect.lift_div_tac
                         (fun uu___ ->
                            fun t01 ->
@@ -125,17 +125,17 @@ let (eligible_for_smt_equality :
                                           (Obj.magic
                                              (FStar_Range.mk_range
                                                 "Pulse.Checker.Prover.Match.fst"
-                                                (Prims.of_int (99))
+                                                (Prims.of_int (100))
                                                 (Prims.of_int (22))
-                                                (Prims.of_int (99))
+                                                (Prims.of_int (100))
                                                 (Prims.of_int (41)))))
                                        (FStar_Sealed.seal
                                           (Obj.magic
                                              (FStar_Range.mk_range
                                                 "Pulse.Checker.Prover.Match.fst"
-                                                (Prims.of_int (98))
+                                                (Prims.of_int (99))
                                                 (Prims.of_int (34))
-                                                (Prims.of_int (147))
+                                                (Prims.of_int (148))
                                                 (Prims.of_int (5)))))
                                        (FStar_Tactics_Effect.lift_div_tac
                                           (fun uu___ ->
@@ -151,17 +151,17 @@ let (eligible_for_smt_equality :
                                                          (Obj.magic
                                                             (FStar_Range.mk_range
                                                                "Pulse.Checker.Prover.Match.fst"
-                                                               (Prims.of_int (100))
+                                                               (Prims.of_int (101))
                                                                (Prims.of_int (22))
-                                                               (Prims.of_int (100))
+                                                               (Prims.of_int (101))
                                                                (Prims.of_int (41)))))
                                                       (FStar_Sealed.seal
                                                          (Obj.magic
                                                             (FStar_Range.mk_range
                                                                "Pulse.Checker.Prover.Match.fst"
-                                                               (Prims.of_int (99))
+                                                               (Prims.of_int (100))
                                                                (Prims.of_int (44))
-                                                               (Prims.of_int (146))
+                                                               (Prims.of_int (147))
                                                                (Prims.of_int (31)))))
                                                       (FStar_Tactics_Effect.lift_div_tac
                                                          (fun uu___1 ->
@@ -196,17 +196,17 @@ let (eligible_for_smt_equality :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.Match.fst"
-                                                                    (Prims.of_int (106))
+                                                                    (Prims.of_int (107))
                                                                     (Prims.of_int (16))
-                                                                    (Prims.of_int (106))
+                                                                    (Prims.of_int (107))
                                                                     (Prims.of_int (31)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.Match.fst"
-                                                                    (Prims.of_int (105))
+                                                                    (Prims.of_int (106))
                                                                     (Prims.of_int (29))
-                                                                    (Prims.of_int (143))
+                                                                    (Prims.of_int (144))
                                                                     (Prims.of_int (9)))))
                                                                     (Obj.magic
                                                                     (type_of_fv
@@ -328,17 +328,17 @@ let (eligible_for_smt_equality :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.Match.fst"
-                                                                    (Prims.of_int (106))
+                                                                    (Prims.of_int (107))
                                                                     (Prims.of_int (16))
-                                                                    (Prims.of_int (106))
+                                                                    (Prims.of_int (107))
                                                                     (Prims.of_int (31)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.Match.fst"
-                                                                    (Prims.of_int (105))
+                                                                    (Prims.of_int (106))
                                                                     (Prims.of_int (29))
-                                                                    (Prims.of_int (143))
+                                                                    (Prims.of_int (144))
                                                                     (Prims.of_int (9)))))
                                                                     (Obj.magic
                                                                     (type_of_fv
@@ -573,27 +573,27 @@ let rec (try_solve_uvars :
             (FStar_Sealed.seal
                (Obj.magic
                   (FStar_Range.mk_range "Pulse.Checker.Prover.Match.fst"
-                     (Prims.of_int (201)) (Prims.of_int (5))
-                     (Prims.of_int (201)) (Prims.of_int (32)))))
+                     (Prims.of_int (202)) (Prims.of_int (5))
+                     (Prims.of_int (202)) (Prims.of_int (32)))))
             (FStar_Sealed.seal
                (Obj.magic
                   (FStar_Range.mk_range "Pulse.Checker.Prover.Match.fst"
-                     (Prims.of_int (201)) (Prims.of_int (2))
-                     (Prims.of_int (239)) (Prims.of_int (5)))))
+                     (Prims.of_int (202)) (Prims.of_int (2))
+                     (Prims.of_int (240)) (Prims.of_int (5)))))
             (Obj.magic
                (FStar_Tactics_Effect.tac_bind
                   (FStar_Sealed.seal
                      (Obj.magic
                         (FStar_Range.mk_range
                            "Pulse.Checker.Prover.Match.fst"
-                           (Prims.of_int (201)) (Prims.of_int (9))
-                           (Prims.of_int (201)) (Prims.of_int (32)))))
+                           (Prims.of_int (202)) (Prims.of_int (9))
+                           (Prims.of_int (202)) (Prims.of_int (32)))))
                   (FStar_Sealed.seal
                      (Obj.magic
                         (FStar_Range.mk_range
                            "Pulse.Checker.Prover.Match.fst"
-                           (Prims.of_int (201)) (Prims.of_int (5))
-                           (Prims.of_int (201)) (Prims.of_int (32)))))
+                           (Prims.of_int (202)) (Prims.of_int (5))
+                           (Prims.of_int (202)) (Prims.of_int (32)))))
                   (Obj.magic (contains_uvar q uvs g))
                   (fun uu___ ->
                      FStar_Tactics_Effect.lift_div_tac
@@ -654,17 +654,17 @@ let rec (try_solve_uvars :
                                                            (Obj.magic
                                                               (FStar_Range.mk_range
                                                                  "Pulse.Checker.Prover.Match.fst"
-                                                                 (Prims.of_int (228))
+                                                                 (Prims.of_int (229))
                                                                  (Prims.of_int (26))
-                                                                 (Prims.of_int (228))
+                                                                 (Prims.of_int (229))
                                                                  (Prims.of_int (61)))))
                                                         (FStar_Sealed.seal
                                                            (Obj.magic
                                                               (FStar_Range.mk_range
                                                                  "Pulse.Checker.Prover.Match.fst"
-                                                                 (Prims.of_int (228))
+                                                                 (Prims.of_int (229))
                                                                  (Prims.of_int (64))
-                                                                 (Prims.of_int (237))
+                                                                 (Prims.of_int (238))
                                                                  (Prims.of_int (25)))))
                                                         (Obj.magic
                                                            (try_solve_uvars g
@@ -678,17 +678,17 @@ let rec (try_solve_uvars :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.Match.fst"
-                                                                    (Prims.of_int (229))
+                                                                    (Prims.of_int (230))
                                                                     (Prims.of_int (25))
-                                                                    (Prims.of_int (229))
+                                                                    (Prims.of_int (230))
                                                                     (Prims.of_int (58)))))
                                                                    (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.Match.fst"
-                                                                    (Prims.of_int (230))
+                                                                    (Prims.of_int (231))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (237))
+                                                                    (Prims.of_int (238))
                                                                     (Prims.of_int (25)))))
                                                                    (Obj.magic
                                                                     (try_solve_uvars
@@ -735,13 +735,13 @@ let (unify :
             (FStar_Sealed.seal
                (Obj.magic
                   (FStar_Range.mk_range "Pulse.Checker.Prover.Match.fst"
-                     (Prims.of_int (246)) (Prims.of_int (11))
-                     (Prims.of_int (246)) (Prims.of_int (36)))))
+                     (Prims.of_int (247)) (Prims.of_int (11))
+                     (Prims.of_int (247)) (Prims.of_int (36)))))
             (FStar_Sealed.seal
                (Obj.magic
                   (FStar_Range.mk_range "Pulse.Checker.Prover.Match.fst"
-                     (Prims.of_int (246)) (Prims.of_int (39))
-                     (Prims.of_int (258)) (Prims.of_int (11)))))
+                     (Prims.of_int (247)) (Prims.of_int (39))
+                     (Prims.of_int (259)) (Prims.of_int (11)))))
             (Obj.magic (try_solve_uvars g uvs p q))
             (fun uu___ ->
                (fun ss ->
@@ -751,14 +751,14 @@ let (unify :
                           (Obj.magic
                              (FStar_Range.mk_range
                                 "Pulse.Checker.Prover.Match.fst"
-                                (Prims.of_int (247)) (Prims.of_int (10))
-                                (Prims.of_int (247)) (Prims.of_int (16)))))
+                                (Prims.of_int (248)) (Prims.of_int (10))
+                                (Prims.of_int (248)) (Prims.of_int (16)))))
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range
                                 "Pulse.Checker.Prover.Match.fst"
-                                (Prims.of_int (248)) (Prims.of_int (2))
-                                (Prims.of_int (258)) (Prims.of_int (11)))))
+                                (Prims.of_int (249)) (Prims.of_int (2))
+                                (Prims.of_int (259)) (Prims.of_int (11)))))
                        (FStar_Tactics_Effect.lift_div_tac
                           (fun uu___ ->
                              Pulse_Checker_Prover_Base.op_Array_Access ss q))
@@ -785,17 +785,17 @@ let (unify :
                                           (Obj.magic
                                              (FStar_Range.mk_range
                                                 "Pulse.Checker.Prover.Match.fst"
-                                                (Prims.of_int (250))
+                                                (Prims.of_int (251))
                                                 (Prims.of_int (10))
-                                                (Prims.of_int (250))
+                                                (Prims.of_int (251))
                                                 (Prims.of_int (31)))))
                                        (FStar_Sealed.seal
                                           (Obj.magic
                                              (FStar_Range.mk_range
                                                 "Pulse.Checker.Prover.Match.fst"
-                                                (Prims.of_int (250))
+                                                (Prims.of_int (251))
                                                 (Prims.of_int (7))
-                                                (Prims.of_int (258))
+                                                (Prims.of_int (259))
                                                 (Prims.of_int (11)))))
                                        (Obj.magic (contains_uvar q1 uvs g))
                                        (fun uu___1 ->
@@ -815,17 +815,17 @@ let (unify :
                                                           (Obj.magic
                                                              (FStar_Range.mk_range
                                                                 "Pulse.Checker.Prover.Match.fst"
-                                                                (Prims.of_int (252))
+                                                                (Prims.of_int (253))
                                                                 (Prims.of_int (10))
-                                                                (Prims.of_int (252))
+                                                                (Prims.of_int (253))
                                                                 (Prims.of_int (41)))))
                                                        (FStar_Sealed.seal
                                                           (Obj.magic
                                                              (FStar_Range.mk_range
                                                                 "Pulse.Checker.Prover.Match.fst"
-                                                                (Prims.of_int (252))
+                                                                (Prims.of_int (253))
                                                                 (Prims.of_int (7))
-                                                                (Prims.of_int (258))
+                                                                (Prims.of_int (259))
                                                                 (Prims.of_int (11)))))
                                                        (Obj.magic
                                                           (eligible_for_smt_equality
@@ -842,17 +842,17 @@ let (unify :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.Match.fst"
-                                                                    (Prims.of_int (253))
+                                                                    (Prims.of_int (254))
                                                                     (Prims.of_int (16))
-                                                                    (Prims.of_int (253))
+                                                                    (Prims.of_int (254))
                                                                     (Prims.of_int (27)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.Match.fst"
-                                                                    (Prims.of_int (253))
+                                                                    (Prims.of_int (254))
                                                                     (Prims.of_int (30))
-                                                                    (Prims.of_int (257))
+                                                                    (Prims.of_int (258))
                                                                     (Prims.of_int (24)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -869,17 +869,17 @@ let (unify :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.Match.fst"
-                                                                    (Prims.of_int (254))
+                                                                    (Prims.of_int (255))
                                                                     (Prims.of_int (16))
-                                                                    (Prims.of_int (254))
+                                                                    (Prims.of_int (255))
                                                                     (Prims.of_int (27)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.Match.fst"
-                                                                    (Prims.of_int (255))
+                                                                    (Prims.of_int (256))
                                                                     (Prims.of_int (7))
-                                                                    (Prims.of_int (257))
+                                                                    (Prims.of_int (258))
                                                                     (Prims.of_int (24)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -896,20 +896,20 @@ let (unify :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.Match.fst"
-                                                                    (Prims.of_int (255))
+                                                                    (Prims.of_int (256))
                                                                     (Prims.of_int (13))
-                                                                    (Prims.of_int (255))
-                                                                    (Prims.of_int (45)))))
+                                                                    (Prims.of_int (256))
+                                                                    (Prims.of_int (47)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.Match.fst"
-                                                                    (Prims.of_int (255))
+                                                                    (Prims.of_int (256))
                                                                     (Prims.of_int (7))
-                                                                    (Prims.of_int (257))
+                                                                    (Prims.of_int (258))
                                                                     (Prims.of_int (24)))))
                                                                     (Obj.magic
-                                                                    (FStar_Tactics_V2_Builtins.check_equiv
+                                                                    (Pulse_Typing_Util.check_equiv_now
                                                                     (Pulse_Typing.elab_env
                                                                     g) v0 v1))
                                                                     (fun
@@ -965,13 +965,13 @@ let (try_match_pq :
             (FStar_Sealed.seal
                (Obj.magic
                   (FStar_Range.mk_range "Pulse.Checker.Prover.Match.fst"
-                     (Prims.of_int (264)) (Prims.of_int (10))
-                     (Prims.of_int (264)) (Prims.of_int (25)))))
+                     (Prims.of_int (265)) (Prims.of_int (10))
+                     (Prims.of_int (265)) (Prims.of_int (25)))))
             (FStar_Sealed.seal
                (Obj.magic
                   (FStar_Range.mk_range "Pulse.Checker.Prover.Match.fst"
-                     (Prims.of_int (265)) (Prims.of_int (2))
-                     (Prims.of_int (269)) (Prims.of_int (27)))))
+                     (Prims.of_int (266)) (Prims.of_int (2))
+                     (Prims.of_int (270)) (Prims.of_int (27)))))
             (Obj.magic (unify g uvs p q))
             (fun r ->
                FStar_Tactics_Effect.lift_div_tac
@@ -1009,14 +1009,14 @@ let (match_step :
                      (Obj.magic
                         (FStar_Range.mk_range
                            "Pulse.Checker.Prover.Match.fst"
-                           (Prims.of_int (280)) (Prims.of_int (11))
-                           (Prims.of_int (280)) (Prims.of_int (21)))))
+                           (Prims.of_int (281)) (Prims.of_int (11))
+                           (Prims.of_int (281)) (Prims.of_int (21)))))
                   (FStar_Sealed.seal
                      (Obj.magic
                         (FStar_Range.mk_range
                            "Pulse.Checker.Prover.Match.fst"
-                           (Prims.of_int (281)) (Prims.of_int (52))
-                           (Prims.of_int (344)) (Prims.of_int (11)))))
+                           (Prims.of_int (282)) (Prims.of_int (52))
+                           (Prims.of_int (345)) (Prims.of_int (11)))))
                   (FStar_Tactics_Effect.lift_div_tac
                      (fun uu___1 ->
                         Pulse_Checker_Prover_Base.op_Array_Access
@@ -1029,16 +1029,16 @@ let (match_step :
                                 (Obj.magic
                                    (FStar_Range.mk_range
                                       "Pulse.Checker.Prover.Match.fst"
-                                      (Prims.of_int (283))
+                                      (Prims.of_int (284))
                                       (Prims.of_int (11))
-                                      (Prims.of_int (283))
+                                      (Prims.of_int (284))
                                       (Prims.of_int (45)))))
                              (FStar_Sealed.seal
                                 (Obj.magic
                                    (FStar_Range.mk_range
                                       "Pulse.Checker.Prover.Match.fst"
-                                      (Prims.of_int (285)) Prims.int_zero
-                                      (Prims.of_int (344))
+                                      (Prims.of_int (286)) Prims.int_zero
+                                      (Prims.of_int (345))
                                       (Prims.of_int (11)))))
                              (Obj.magic
                                 (try_match_pq
@@ -1052,17 +1052,17 @@ let (match_step :
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.Checker.Prover.Match.fst"
-                                                 (Prims.of_int (285))
+                                                 (Prims.of_int (286))
                                                  Prims.int_zero
-                                                 (Prims.of_int (287))
+                                                 (Prims.of_int (288))
                                                  (Prims.of_int (92)))))
                                         (FStar_Sealed.seal
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.Checker.Prover.Match.fst"
-                                                 (Prims.of_int (289))
+                                                 (Prims.of_int (290))
                                                  Prims.int_zero
-                                                 (Prims.of_int (344))
+                                                 (Prims.of_int (345))
                                                  (Prims.of_int (11)))))
                                         (Obj.magic
                                            (Pulse_Checker_Prover_Util.debug_prover
@@ -1073,17 +1073,17 @@ let (match_step :
                                                       (Obj.magic
                                                          (FStar_Range.mk_range
                                                             "Pulse.Checker.Prover.Match.fst"
-                                                            (Prims.of_int (286))
-                                                            (Prims.of_int (2))
                                                             (Prims.of_int (287))
+                                                            (Prims.of_int (2))
+                                                            (Prims.of_int (288))
                                                             (Prims.of_int (91)))))
                                                    (FStar_Sealed.seal
                                                       (Obj.magic
                                                          (FStar_Range.mk_range
                                                             "Pulse.Checker.Prover.Match.fst"
-                                                            (Prims.of_int (286))
-                                                            (Prims.of_int (2))
                                                             (Prims.of_int (287))
+                                                            (Prims.of_int (2))
+                                                            (Prims.of_int (288))
                                                             (Prims.of_int (91)))))
                                                    (Obj.magic
                                                       (FStar_Tactics_Effect.tac_bind
@@ -1091,17 +1091,17 @@ let (match_step :
                                                             (Obj.magic
                                                                (FStar_Range.mk_range
                                                                   "Pulse.Checker.Prover.Match.fst"
-                                                                  (Prims.of_int (287))
+                                                                  (Prims.of_int (288))
                                                                   (Prims.of_int (25))
-                                                                  (Prims.of_int (287))
+                                                                  (Prims.of_int (288))
                                                                   (Prims.of_int (48)))))
                                                          (FStar_Sealed.seal
                                                             (Obj.magic
                                                                (FStar_Range.mk_range
                                                                   "Pulse.Checker.Prover.Match.fst"
-                                                                  (Prims.of_int (286))
-                                                                  (Prims.of_int (2))
                                                                   (Prims.of_int (287))
+                                                                  (Prims.of_int (2))
+                                                                  (Prims.of_int (288))
                                                                   (Prims.of_int (91)))))
                                                          (Obj.magic
                                                             (Pulse_Syntax_Printer.term_to_string
@@ -1115,18 +1115,18 @@ let (match_step :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.Match.fst"
-                                                                    (Prims.of_int (286))
-                                                                    (Prims.of_int (2))
                                                                     (Prims.of_int (287))
+                                                                    (Prims.of_int (2))
+                                                                    (Prims.of_int (288))
                                                                     (Prims.of_int (91)))))
                                                                     (
                                                                     FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.Match.fst"
-                                                                    (Prims.of_int (286))
-                                                                    (Prims.of_int (2))
                                                                     (Prims.of_int (287))
+                                                                    (Prims.of_int (2))
+                                                                    (Prims.of_int (288))
                                                                     (Prims.of_int (91)))))
                                                                     (
                                                                     Obj.magic
@@ -1135,9 +1135,9 @@ let (match_step :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.Match.fst"
-                                                                    (Prims.of_int (287))
+                                                                    (Prims.of_int (288))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (287))
+                                                                    (Prims.of_int (288))
                                                                     (Prims.of_int (24)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic

--- a/src/ocaml/plugin/generated/Pulse_Config.ml
+++ b/src/ocaml/plugin/generated/Pulse_Config.ml
@@ -1,0 +1,2 @@
+open Prims
+let (join_goals : Prims.bool) = true

--- a/src/ocaml/plugin/generated/Pulse_Config.ml
+++ b/src/ocaml/plugin/generated/Pulse_Config.ml
@@ -1,2 +1,2 @@
 open Prims
-let (join_goals : Prims.bool) = true
+let (join_goals : Prims.bool) = false

--- a/src/ocaml/plugin/generated/Pulse_Main.ml
+++ b/src/ocaml/plugin/generated/Pulse_Main.ml
@@ -18,13 +18,13 @@ let (debug_main :
                      (FStar_Sealed.seal
                         (Obj.magic
                            (FStar_Range.mk_range "Pulse.Main.fst"
-                              (Prims.of_int (19)) (Prims.of_int (15))
-                              (Prims.of_int (19)) (Prims.of_int (21)))))
+                              (Prims.of_int (20)) (Prims.of_int (15))
+                              (Prims.of_int (20)) (Prims.of_int (21)))))
                      (FStar_Sealed.seal
                         (Obj.magic
                            (FStar_Range.mk_range "Pulse.Main.fst"
-                              (Prims.of_int (19)) (Prims.of_int (7))
-                              (Prims.of_int (19)) (Prims.of_int (21)))))
+                              (Prims.of_int (20)) (Prims.of_int (7))
+                              (Prims.of_int (20)) (Prims.of_int (21)))))
                      (Obj.magic (s ()))
                      (fun uu___ ->
                         (fun uu___ ->
@@ -62,13 +62,13 @@ let (main' :
                            (FStar_Sealed.seal
                               (Obj.magic
                                  (FStar_Range.mk_range "Pulse.Main.fst"
-                                    (Prims.of_int (28)) (Prims.of_int (6))
-                                    (Prims.of_int (31)) (Prims.of_int (7)))))
+                                    (Prims.of_int (29)) (Prims.of_int (6))
+                                    (Prims.of_int (32)) (Prims.of_int (7)))))
                            (FStar_Sealed.seal
                               (Obj.magic
                                  (FStar_Range.mk_range "Pulse.Main.fst"
-                                    (Prims.of_int (31)) (Prims.of_int (8))
-                                    (Prims.of_int (51)) (Prims.of_int (81)))))
+                                    (Prims.of_int (32)) (Prims.of_int (8))
+                                    (Prims.of_int (52)) (Prims.of_int (81)))))
                            (if
                               Pulse_RuntimeUtils.debug_at_level
                                 (Pulse_Typing_Env.fstar_env g1) "Pulse"
@@ -80,17 +80,17 @@ let (main' :
                                          (Obj.magic
                                             (FStar_Range.mk_range
                                                "Pulse.Main.fst"
-                                               (Prims.of_int (30))
+                                               (Prims.of_int (31))
                                                (Prims.of_int (16))
-                                               (Prims.of_int (30))
+                                               (Prims.of_int (31))
                                                (Prims.of_int (91)))))
                                       (FStar_Sealed.seal
                                          (Obj.magic
                                             (FStar_Range.mk_range
                                                "Pulse.Main.fst"
-                                               (Prims.of_int (29))
+                                               (Prims.of_int (30))
                                                (Prims.of_int (11))
-                                               (Prims.of_int (31))
+                                               (Prims.of_int (32))
                                                (Prims.of_int (7)))))
                                       (Obj.magic
                                          (FStar_Tactics_Effect.tac_bind
@@ -98,9 +98,9 @@ let (main' :
                                                (Obj.magic
                                                   (FStar_Range.mk_range
                                                      "Pulse.Main.fst"
-                                                     (Prims.of_int (30))
+                                                     (Prims.of_int (31))
                                                      (Prims.of_int (67))
-                                                     (Prims.of_int (30))
+                                                     (Prims.of_int (31))
                                                      (Prims.of_int (90)))))
                                             (FStar_Sealed.seal
                                                (Obj.magic
@@ -138,17 +138,17 @@ let (main' :
                                          (Obj.magic
                                             (FStar_Range.mk_range
                                                "Pulse.Main.fst"
-                                               (Prims.of_int (32))
+                                               (Prims.of_int (33))
                                                (Prims.of_int (38))
-                                               (Prims.of_int (32))
+                                               (Prims.of_int (33))
                                                (Prims.of_int (73)))))
                                       (FStar_Sealed.seal
                                          (Obj.magic
                                             (FStar_Range.mk_range
                                                "Pulse.Main.fst"
-                                               (Prims.of_int (31))
+                                               (Prims.of_int (32))
                                                (Prims.of_int (8))
-                                               (Prims.of_int (51))
+                                               (Prims.of_int (52))
                                                (Prims.of_int (81)))))
                                       (Obj.magic
                                          (Pulse_Checker_Pure.check_term g1
@@ -168,17 +168,17 @@ let (main' :
                                                           (Obj.magic
                                                              (FStar_Range.mk_range
                                                                 "Pulse.Main.fst"
-                                                                (Prims.of_int (34))
+                                                                (Prims.of_int (35))
                                                                 (Prims.of_int (56))
-                                                                (Prims.of_int (34))
+                                                                (Prims.of_int (35))
                                                                 (Prims.of_int (68)))))
                                                        (FStar_Sealed.seal
                                                           (Obj.magic
                                                              (FStar_Range.mk_range
                                                                 "Pulse.Main.fst"
-                                                                (Prims.of_int (35))
+                                                                (Prims.of_int (36))
                                                                 (Prims.of_int (11))
-                                                                (Prims.of_int (50))
+                                                                (Prims.of_int (51))
                                                                 (Prims.of_int (75)))))
                                                        (FStar_Tactics_Effect.lift_div_tac
                                                           (fun uu___2 -> ()))
@@ -194,17 +194,17 @@ let (main' :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Main.fst"
-                                                                    (Prims.of_int (37))
+                                                                    (Prims.of_int (38))
                                                                     (Prims.of_int (40))
-                                                                    (Prims.of_int (37))
+                                                                    (Prims.of_int (38))
                                                                     (Prims.of_int (91)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Main.fst"
-                                                                    (Prims.of_int (36))
+                                                                    (Prims.of_int (37))
                                                                     (Prims.of_int (24))
-                                                                    (Prims.of_int (49))
+                                                                    (Prims.of_int (50))
                                                                     (Prims.of_int (29)))))
                                                                     (Obj.magic
                                                                     (Pulse_Checker_Abs.check_abs
@@ -227,17 +227,17 @@ let (main' :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Main.fst"
-                                                                    (Prims.of_int (39))
+                                                                    (Prims.of_int (40))
                                                                     (Prims.of_int (13))
-                                                                    (Prims.of_int (41))
+                                                                    (Prims.of_int (42))
                                                                     (Prims.of_int (49)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Main.fst"
-                                                                    (Prims.of_int (42))
+                                                                    (Prims.of_int (43))
                                                                     (Prims.of_int (13))
-                                                                    (Prims.of_int (49))
+                                                                    (Prims.of_int (50))
                                                                     (Prims.of_int (29)))))
                                                                     (Obj.magic
                                                                     (Pulse_Checker_Prover_Util.debug_prover
@@ -249,9 +249,9 @@ let (main' :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Main.fst"
-                                                                    (Prims.of_int (41))
+                                                                    (Prims.of_int (42))
                                                                     (Prims.of_int (25))
-                                                                    (Prims.of_int (41))
+                                                                    (Prims.of_int (42))
                                                                     (Prims.of_int (48)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -284,17 +284,17 @@ let (main' :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Main.fst"
-                                                                    (Prims.of_int (42))
+                                                                    (Prims.of_int (43))
                                                                     (Prims.of_int (13))
-                                                                    (Prims.of_int (45))
+                                                                    (Prims.of_int (46))
                                                                     (Prims.of_int (73)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Main.fst"
-                                                                    (Prims.of_int (49))
+                                                                    (Prims.of_int (50))
                                                                     (Prims.of_int (13))
-                                                                    (Prims.of_int (49))
+                                                                    (Prims.of_int (50))
                                                                     (Prims.of_int (29)))))
                                                                     (Obj.magic
                                                                     (debug_main
@@ -306,17 +306,17 @@ let (main' :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Main.fst"
-                                                                    (Prims.of_int (45))
+                                                                    (Prims.of_int (46))
                                                                     (Prims.of_int (25))
-                                                                    (Prims.of_int (45))
+                                                                    (Prims.of_int (46))
                                                                     (Prims.of_int (72)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Main.fst"
-                                                                    (Prims.of_int (43))
+                                                                    (Prims.of_int (44))
                                                                     (Prims.of_int (25))
-                                                                    (Prims.of_int (45))
+                                                                    (Prims.of_int (46))
                                                                     (Prims.of_int (72)))))
                                                                     (Obj.magic
                                                                     (Pulse_Typing_Printer.print_st_typing
@@ -332,17 +332,17 @@ let (main' :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Main.fst"
-                                                                    (Prims.of_int (43))
+                                                                    (Prims.of_int (44))
                                                                     (Prims.of_int (25))
-                                                                    (Prims.of_int (45))
+                                                                    (Prims.of_int (46))
                                                                     (Prims.of_int (72)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Main.fst"
-                                                                    (Prims.of_int (43))
+                                                                    (Prims.of_int (44))
                                                                     (Prims.of_int (25))
-                                                                    (Prims.of_int (45))
+                                                                    (Prims.of_int (46))
                                                                     (Prims.of_int (72)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -350,9 +350,9 @@ let (main' :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Main.fst"
-                                                                    (Prims.of_int (44))
+                                                                    (Prims.of_int (45))
                                                                     (Prims.of_int (25))
-                                                                    (Prims.of_int (44))
+                                                                    (Prims.of_int (45))
                                                                     (Prims.of_int (48)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -415,6 +415,514 @@ let (main' :
                                                        "pulse main: cannot typecheck pre at type vprop"))
                                            uu___1))) uu___)))) uu___2 uu___1
           uu___
+let (join_smt_goals : unit -> (unit, unit) FStar_Tactics_Effect.tac_repr) =
+  fun uu___ ->
+    FStar_Tactics_Effect.tac_bind
+      (FStar_Sealed.seal
+         (Obj.magic
+            (FStar_Range.mk_range "Pulse.Main.fst" (Prims.of_int (58))
+               (Prims.of_int (2)) (Prims.of_int (59)) (Prims.of_int (35)))))
+      (FStar_Sealed.seal
+         (Obj.magic
+            (FStar_Range.mk_range "Pulse.Main.fst" (Prims.of_int (59))
+               (Prims.of_int (36)) (Prims.of_int (80)) (Prims.of_int (4)))))
+      (Obj.magic
+         (FStar_Tactics_Effect.tac_bind
+            (FStar_Sealed.seal
+               (Obj.magic
+                  (FStar_Range.mk_range "Pulse.Main.fst" (Prims.of_int (58))
+                     (Prims.of_int (5)) (Prims.of_int (58))
+                     (Prims.of_int (48)))))
+            (FStar_Sealed.seal
+               (Obj.magic
+                  (FStar_Range.mk_range "Pulse.Main.fst" (Prims.of_int (58))
+                     (Prims.of_int (2)) (Prims.of_int (59))
+                     (Prims.of_int (35)))))
+            (Obj.magic
+               (FStar_Tactics_Effect.tac_bind
+                  (FStar_Sealed.seal
+                     (Obj.magic
+                        (FStar_Range.mk_range "Pulse.Main.fst"
+                           (Prims.of_int (58)) (Prims.of_int (23))
+                           (Prims.of_int (58)) (Prims.of_int (35)))))
+                  (FStar_Sealed.seal
+                     (Obj.magic
+                        (FStar_Range.mk_range "Pulse.Main.fst"
+                           (Prims.of_int (58)) (Prims.of_int (5))
+                           (Prims.of_int (58)) (Prims.of_int (48)))))
+                  (Obj.magic (FStar_Tactics_V2_Builtins.top_env ()))
+                  (fun uu___1 ->
+                     FStar_Tactics_Effect.lift_div_tac
+                       (fun uu___2 ->
+                          Pulse_RuntimeUtils.debug_at_level uu___1
+                            "pulse.join"))))
+            (fun uu___1 ->
+               (fun uu___1 ->
+                  if uu___1
+                  then
+                    Obj.magic
+                      (Obj.repr
+                         (FStar_Tactics_V2_Builtins.dump
+                            "PULSE: Goals before join"))
+                  else
+                    Obj.magic
+                      (Obj.repr
+                         (FStar_Tactics_Effect.lift_div_tac
+                            (fun uu___3 -> ())))) uu___1)))
+      (fun uu___1 ->
+         (fun uu___1 ->
+            Obj.magic
+              (FStar_Tactics_Effect.tac_bind
+                 (FStar_Sealed.seal
+                    (Obj.magic
+                       (FStar_Range.mk_range "Pulse.Main.fst"
+                          (Prims.of_int (62)) (Prims.of_int (18))
+                          (Prims.of_int (62)) (Prims.of_int (30)))))
+                 (FStar_Sealed.seal
+                    (Obj.magic
+                       (FStar_Range.mk_range "Pulse.Main.fst"
+                          (Prims.of_int (63)) (Prims.of_int (2))
+                          (Prims.of_int (80)) (Prims.of_int (4)))))
+                 (Obj.magic (FStar_Tactics_V2_Derived.smt_goals ()))
+                 (fun uu___2 ->
+                    (fun smt_goals ->
+                       Obj.magic
+                         (FStar_Tactics_Effect.tac_bind
+                            (FStar_Sealed.seal
+                               (Obj.magic
+                                  (FStar_Range.mk_range "Pulse.Main.fst"
+                                     (Prims.of_int (63)) (Prims.of_int (2))
+                                     (Prims.of_int (63)) (Prims.of_int (34)))))
+                            (FStar_Sealed.seal
+                               (Obj.magic
+                                  (FStar_Range.mk_range "Pulse.Main.fst"
+                                     (Prims.of_int (64)) (Prims.of_int (2))
+                                     (Prims.of_int (80)) (Prims.of_int (4)))))
+                            (Obj.magic
+                               (FStar_Tactics_Effect.tac_bind
+                                  (FStar_Sealed.seal
+                                     (Obj.magic
+                                        (FStar_Range.mk_range
+                                           "Pulse.Main.fst"
+                                           (Prims.of_int (63))
+                                           (Prims.of_int (12))
+                                           (Prims.of_int (63))
+                                           (Prims.of_int (34)))))
+                                  (FStar_Sealed.seal
+                                     (Obj.magic
+                                        (FStar_Range.mk_range
+                                           "Pulse.Main.fst"
+                                           (Prims.of_int (63))
+                                           (Prims.of_int (2))
+                                           (Prims.of_int (63))
+                                           (Prims.of_int (34)))))
+                                  (Obj.magic
+                                     (FStar_Tactics_Effect.tac_bind
+                                        (FStar_Sealed.seal
+                                           (Obj.magic
+                                              (FStar_Range.mk_range
+                                                 "Pulse.Main.fst"
+                                                 (Prims.of_int (63))
+                                                 (Prims.of_int (13))
+                                                 (Prims.of_int (63))
+                                                 (Prims.of_int (21)))))
+                                        (FStar_Sealed.seal
+                                           (Obj.magic
+                                              (FStar_Range.mk_range
+                                                 "Pulse.Main.fst"
+                                                 (Prims.of_int (63))
+                                                 (Prims.of_int (12))
+                                                 (Prims.of_int (63))
+                                                 (Prims.of_int (34)))))
+                                        (Obj.magic
+                                           (FStar_Tactics_V2_Derived.goals ()))
+                                        (fun uu___2 ->
+                                           FStar_Tactics_Effect.lift_div_tac
+                                             (fun uu___3 ->
+                                                FStar_List_Tot_Base.op_At
+                                                  uu___2 smt_goals))))
+                                  (fun uu___2 ->
+                                     (fun uu___2 ->
+                                        Obj.magic
+                                          (FStar_Tactics_V2_Builtins.set_goals
+                                             uu___2)) uu___2)))
+                            (fun uu___2 ->
+                               (fun uu___2 ->
+                                  Obj.magic
+                                    (FStar_Tactics_Effect.tac_bind
+                                       (FStar_Sealed.seal
+                                          (Obj.magic
+                                             (FStar_Range.mk_range
+                                                "Pulse.Main.fst"
+                                                (Prims.of_int (64))
+                                                (Prims.of_int (2))
+                                                (Prims.of_int (64))
+                                                (Prims.of_int (18)))))
+                                       (FStar_Sealed.seal
+                                          (Obj.magic
+                                             (FStar_Range.mk_range
+                                                "Pulse.Main.fst"
+                                                (Prims.of_int (64))
+                                                (Prims.of_int (19))
+                                                (Prims.of_int (80))
+                                                (Prims.of_int (4)))))
+                                       (Obj.magic
+                                          (FStar_Tactics_V2_Builtins.set_smt_goals
+                                             []))
+                                       (fun uu___3 ->
+                                          (fun uu___3 ->
+                                             Obj.magic
+                                               (FStar_Tactics_Effect.tac_bind
+                                                  (FStar_Sealed.seal
+                                                     (Obj.magic
+                                                        (FStar_Range.mk_range
+                                                           "Pulse.Main.fst"
+                                                           (Prims.of_int (65))
+                                                           (Prims.of_int (10))
+                                                           (Prims.of_int (65))
+                                                           (Prims.of_int (36)))))
+                                                  (FStar_Sealed.seal
+                                                     (Obj.magic
+                                                        (FStar_Range.mk_range
+                                                           "Pulse.Main.fst"
+                                                           (Prims.of_int (66))
+                                                           (Prims.of_int (2))
+                                                           (Prims.of_int (80))
+                                                           (Prims.of_int (4)))))
+                                                  (Obj.magic
+                                                     (FStar_Tactics_Effect.tac_bind
+                                                        (FStar_Sealed.seal
+                                                           (Obj.magic
+                                                              (FStar_Range.mk_range
+                                                                 "Pulse.Main.fst"
+                                                                 (Prims.of_int (65))
+                                                                 (Prims.of_int (26))
+                                                                 (Prims.of_int (65))
+                                                                 (Prims.of_int (36)))))
+                                                        (FStar_Sealed.seal
+                                                           (Obj.magic
+                                                              (FStar_Range.mk_range
+                                                                 "Pulse.Main.fst"
+                                                                 (Prims.of_int (65))
+                                                                 (Prims.of_int (10))
+                                                                 (Prims.of_int (65))
+                                                                 (Prims.of_int (36)))))
+                                                        (Obj.magic
+                                                           (FStar_Tactics_V2_Derived.goals
+                                                              ()))
+                                                        (fun uu___4 ->
+                                                           FStar_Tactics_Effect.lift_div_tac
+                                                             (fun uu___5 ->
+                                                                FStar_List_Tot_Base.length
+                                                                  uu___4))))
+                                                  (fun uu___4 ->
+                                                     (fun n ->
+                                                        Obj.magic
+                                                          (FStar_Tactics_Effect.tac_bind
+                                                             (FStar_Sealed.seal
+                                                                (Obj.magic
+                                                                   (FStar_Range.mk_range
+                                                                    "Pulse.Main.fst"
+                                                                    (Prims.of_int (66))
+                                                                    (Prims.of_int (2))
+                                                                    (Prims.of_int (66))
+                                                                    (Prims.of_int (22)))))
+                                                             (FStar_Sealed.seal
+                                                                (Obj.magic
+                                                                   (FStar_Range.mk_range
+                                                                    "Pulse.Main.fst"
+                                                                    (Prims.of_int (71))
+                                                                    (Prims.of_int (2))
+                                                                    (Prims.of_int (80))
+                                                                    (Prims.of_int (4)))))
+                                                             (Obj.magic
+                                                                (FStar_Tactics_Effect.tac_bind
+                                                                   (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Main.fst"
+                                                                    (Prims.of_int (66))
+                                                                    (Prims.of_int (9))
+                                                                    (Prims.of_int (66))
+                                                                    (Prims.of_int (22)))))
+                                                                   (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Main.fst"
+                                                                    (Prims.of_int (66))
+                                                                    (Prims.of_int (2))
+                                                                    (Prims.of_int (66))
+                                                                    (Prims.of_int (22)))))
+                                                                   (Obj.magic
+                                                                    (FStar_Tactics_V2_Derived.repeat
+                                                                    FStar_Tactics_V2_Builtins.join))
+                                                                   (fun
+                                                                    uu___4 ->
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___5 ->
+                                                                    ()))))
+                                                             (fun uu___4 ->
+                                                                (fun uu___4
+                                                                   ->
+                                                                   Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Main.fst"
+                                                                    (Prims.of_int (71))
+                                                                    (Prims.of_int (2))
+                                                                    (Prims.of_int (75))
+                                                                    (Prims.of_int (3)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Main.fst"
+                                                                    (Prims.of_int (77))
+                                                                    (Prims.of_int (2))
+                                                                    (Prims.of_int (80))
+                                                                    (Prims.of_int (4)))))
+                                                                    (Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Main.fst"
+                                                                    (Prims.of_int (71))
+                                                                    (Prims.of_int (5))
+                                                                    (Prims.of_int (71))
+                                                                    (Prims.of_int (26)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Main.fst"
+                                                                    (Prims.of_int (71))
+                                                                    (Prims.of_int (2))
+                                                                    (Prims.of_int (75))
+                                                                    (Prims.of_int (3)))))
+                                                                    (Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Main.fst"
+                                                                    (Prims.of_int (71))
+                                                                    (Prims.of_int (9))
+                                                                    (Prims.of_int (71))
+                                                                    (Prims.of_int (26)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Main.fst"
+                                                                    (Prims.of_int (71))
+                                                                    (Prims.of_int (5))
+                                                                    (Prims.of_int (71))
+                                                                    (Prims.of_int (26)))))
+                                                                    (Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Main.fst"
+                                                                    (Prims.of_int (71))
+                                                                    (Prims.of_int (15))
+                                                                    (Prims.of_int (71))
+                                                                    (Prims.of_int (25)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Main.fst"
+                                                                    (Prims.of_int (71))
+                                                                    (Prims.of_int (9))
+                                                                    (Prims.of_int (71))
+                                                                    (Prims.of_int (26)))))
+                                                                    (Obj.magic
+                                                                    (FStar_Tactics_V2_Derived.goals
+                                                                    ()))
+                                                                    (fun
+                                                                    uu___5 ->
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___6 ->
+                                                                    Prims.uu___is_Nil
+                                                                    uu___5))))
+                                                                    (fun
+                                                                    uu___5 ->
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___6 ->
+                                                                    Prims.op_Negation
+                                                                    uu___5))))
+                                                                    (fun
+                                                                    uu___5 ->
+                                                                    (fun
+                                                                    uu___5 ->
+                                                                    if uu___5
+                                                                    then
+                                                                    Obj.magic
+                                                                    (Obj.repr
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Main.fst"
+                                                                    (Prims.of_int (73))
+                                                                    (Prims.of_int (17))
+                                                                    (Prims.of_int (73))
+                                                                    (Prims.of_int (39)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Main.fst"
+                                                                    (Prims.of_int (74))
+                                                                    (Prims.of_int (4))
+                                                                    (Prims.of_int (74))
+                                                                    (Prims.of_int (21)))))
+                                                                    (Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Main.fst"
+                                                                    (Prims.of_int (73))
+                                                                    (Prims.of_int (17))
+                                                                    (Prims.of_int (73))
+                                                                    (Prims.of_int (29)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Main.fst"
+                                                                    (Prims.of_int (73))
+                                                                    (Prims.of_int (17))
+                                                                    (Prims.of_int (73))
+                                                                    (Prims.of_int (39)))))
+                                                                    (Obj.magic
+                                                                    (FStar_Tactics_SMT.get_rlimit
+                                                                    ()))
+                                                                    (fun
+                                                                    uu___6 ->
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___7 ->
+                                                                    uu___6 +
+                                                                    ((n -
+                                                                    Prims.int_one)
+                                                                    *
+                                                                    (Prims.of_int (2)))))))
+                                                                    (fun
+                                                                    uu___6 ->
+                                                                    (fun
+                                                                    rlimit ->
+                                                                    Obj.magic
+                                                                    (FStar_Tactics_SMT.set_rlimit
+                                                                    rlimit))
+                                                                    uu___6)))
+                                                                    else
+                                                                    Obj.magic
+                                                                    (Obj.repr
+                                                                    (FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___7 ->
+                                                                    ()))))
+                                                                    uu___5)))
+                                                                    (fun
+                                                                    uu___5 ->
+                                                                    (fun
+                                                                    uu___5 ->
+                                                                    Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Main.fst"
+                                                                    (Prims.of_int (77))
+                                                                    (Prims.of_int (2))
+                                                                    (Prims.of_int (78))
+                                                                    (Prims.of_int (34)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Main.fst"
+                                                                    (Prims.of_int (80))
+                                                                    (Prims.of_int (2))
+                                                                    (Prims.of_int (80))
+                                                                    (Prims.of_int (4)))))
+                                                                    (Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Main.fst"
+                                                                    (Prims.of_int (77))
+                                                                    (Prims.of_int (5))
+                                                                    (Prims.of_int (77))
+                                                                    (Prims.of_int (48)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Main.fst"
+                                                                    (Prims.of_int (77))
+                                                                    (Prims.of_int (2))
+                                                                    (Prims.of_int (78))
+                                                                    (Prims.of_int (34)))))
+                                                                    (Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Main.fst"
+                                                                    (Prims.of_int (77))
+                                                                    (Prims.of_int (23))
+                                                                    (Prims.of_int (77))
+                                                                    (Prims.of_int (35)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Main.fst"
+                                                                    (Prims.of_int (77))
+                                                                    (Prims.of_int (5))
+                                                                    (Prims.of_int (77))
+                                                                    (Prims.of_int (48)))))
+                                                                    (Obj.magic
+                                                                    (FStar_Tactics_V2_Builtins.top_env
+                                                                    ()))
+                                                                    (fun
+                                                                    uu___6 ->
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___7 ->
+                                                                    Pulse_RuntimeUtils.debug_at_level
+                                                                    uu___6
+                                                                    "pulse.join"))))
+                                                                    (fun
+                                                                    uu___6 ->
+                                                                    (fun
+                                                                    uu___6 ->
+                                                                    if uu___6
+                                                                    then
+                                                                    Obj.magic
+                                                                    (Obj.repr
+                                                                    (FStar_Tactics_V2_Builtins.dump
+                                                                    "PULSE: Goals after join"))
+                                                                    else
+                                                                    Obj.magic
+                                                                    (Obj.repr
+                                                                    (FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___8 ->
+                                                                    ()))))
+                                                                    uu___6)))
+                                                                    (fun
+                                                                    uu___6 ->
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___7 ->
+                                                                    ()))))
+                                                                    uu___5)))
+                                                                  uu___4)))
+                                                       uu___4))) uu___3)))
+                                 uu___2))) uu___2))) uu___1)
 let (main :
   Pulse_Syntax_Base.st_term ->
     Pulse_Syntax_Base.term -> FStar_Reflection_Typing.dsl_tac_t)
@@ -425,16 +933,63 @@ let (main :
         FStar_Tactics_Effect.tac_bind
           (FStar_Sealed.seal
              (Obj.magic
-                (FStar_Range.mk_range "Pulse.Main.fst" (Prims.of_int (59))
-                   (Prims.of_int (2)) (Prims.of_int (59)) (Prims.of_int (26)))))
+                (FStar_Range.mk_range "Pulse.Main.fst" (Prims.of_int (86))
+                   (Prims.of_int (2)) (Prims.of_int (86)) (Prims.of_int (22)))))
           (FStar_Sealed.seal
              (Obj.magic
-                (FStar_Range.mk_range "Pulse.Main.fst" (Prims.of_int (60))
-                   (Prims.of_int (2)) (Prims.of_int (60)) (Prims.of_int (15)))))
+                (FStar_Range.mk_range "Pulse.Main.fst" (Prims.of_int (86))
+                   (Prims.of_int (23)) (Prims.of_int (92)) (Prims.of_int (5)))))
           (Obj.magic
              (FStar_Tactics_V2_Builtins.set_guard_policy
-                FStar_Tactics_Types.SMTSync))
-          (fun uu___ -> (fun uu___ -> Obj.magic (main' t pre g)) uu___)
+                FStar_Tactics_Types.SMT))
+          (fun uu___ ->
+             (fun uu___ ->
+                Obj.magic
+                  (FStar_Tactics_Effect.tac_bind
+                     (FStar_Sealed.seal
+                        (Obj.magic
+                           (FStar_Range.mk_range "Pulse.Main.fst"
+                              (Prims.of_int (88)) (Prims.of_int (12))
+                              (Prims.of_int (88)) (Prims.of_int (25)))))
+                     (FStar_Sealed.seal
+                        (Obj.magic
+                           (FStar_Range.mk_range "Pulse.Main.fst"
+                              (Prims.of_int (90)) (Prims.of_int (2))
+                              (Prims.of_int (92)) (Prims.of_int (5)))))
+                     (Obj.magic (main' t pre g))
+                     (fun uu___1 ->
+                        (fun res ->
+                           Obj.magic
+                             (FStar_Tactics_Effect.tac_bind
+                                (FStar_Sealed.seal
+                                   (Obj.magic
+                                      (FStar_Range.mk_range "Pulse.Main.fst"
+                                         (Prims.of_int (90))
+                                         (Prims.of_int (2))
+                                         (Prims.of_int (91))
+                                         (Prims.of_int (20)))))
+                                (FStar_Sealed.seal
+                                   (Obj.magic
+                                      (FStar_Range.mk_range "Pulse.Main.fst"
+                                         (Prims.of_int (88))
+                                         (Prims.of_int (6))
+                                         (Prims.of_int (88))
+                                         (Prims.of_int (9)))))
+                                (if
+                                   Pulse_Config.join_goals &&
+                                     (Prims.op_Negation
+                                        (Pulse_RuntimeUtils.debug_at_level g
+                                           "DoNotJoin"))
+                                 then
+                                   Obj.magic (Obj.repr (join_smt_goals ()))
+                                 else
+                                   Obj.magic
+                                     (Obj.repr
+                                        (FStar_Tactics_Effect.lift_div_tac
+                                           (fun uu___2 -> ()))))
+                                (fun uu___1 ->
+                                   FStar_Tactics_Effect.lift_div_tac
+                                     (fun uu___2 -> res)))) uu___1))) uu___)
 let (check_pulse :
   Prims.string Prims.list ->
     (Prims.string * Prims.string) Prims.list ->
@@ -453,13 +1008,13 @@ let (check_pulse :
                   (FStar_Sealed.seal
                      (Obj.magic
                         (FStar_Range.mk_range "Pulse.Main.fst"
-                           (Prims.of_int (70)) (Prims.of_int (12))
-                           (Prims.of_int (70)) (Prims.of_int (97)))))
+                           (Prims.of_int (102)) (Prims.of_int (12))
+                           (Prims.of_int (102)) (Prims.of_int (97)))))
                   (FStar_Sealed.seal
                      (Obj.magic
                         (FStar_Range.mk_range "Pulse.Main.fst"
-                           (Prims.of_int (70)) (Prims.of_int (6))
-                           (Prims.of_int (76)) (Prims.of_int (22)))))
+                           (Prims.of_int (102)) (Prims.of_int (6))
+                           (Prims.of_int (108)) (Prims.of_int (22)))))
                   (FStar_Tactics_Effect.lift_div_tac
                      (fun uu___ ->
                         Pulse_ASTBuilder.parse_pulse env namespaces
@@ -476,16 +1031,16 @@ let (check_pulse :
                                  (FStar_Sealed.seal
                                     (Obj.magic
                                        (FStar_Range.mk_range "Pulse.Main.fst"
-                                          (Prims.of_int (74))
+                                          (Prims.of_int (106))
                                           (Prims.of_int (15))
-                                          (Prims.of_int (76))
+                                          (Prims.of_int (108))
                                           (Prims.of_int (22)))))
                                  (FStar_Sealed.seal
                                     (Obj.magic
                                        (FStar_Range.mk_range "Pulse.Main.fst"
-                                          (Prims.of_int (74))
+                                          (Prims.of_int (106))
                                           (Prims.of_int (8))
-                                          (Prims.of_int (76))
+                                          (Prims.of_int (108))
                                           (Prims.of_int (22)))))
                                  (Obj.magic
                                     (FStar_Tactics_Effect.tac_bind
@@ -493,17 +1048,17 @@ let (check_pulse :
                                           (Obj.magic
                                              (FStar_Range.mk_range
                                                 "Pulse.Main.fst"
-                                                (Prims.of_int (74))
+                                                (Prims.of_int (106))
                                                 (Prims.of_int (15))
-                                                (Prims.of_int (76))
+                                                (Prims.of_int (108))
                                                 (Prims.of_int (22)))))
                                        (FStar_Sealed.seal
                                           (Obj.magic
                                              (FStar_Range.mk_range
                                                 "Pulse.Main.fst"
-                                                (Prims.of_int (74))
+                                                (Prims.of_int (106))
                                                 (Prims.of_int (15))
-                                                (Prims.of_int (76))
+                                                (Prims.of_int (108))
                                                 (Prims.of_int (22)))))
                                        (Obj.magic
                                           (FStar_Tactics_Effect.tac_bind
@@ -511,9 +1066,9 @@ let (check_pulse :
                                                 (Obj.magic
                                                    (FStar_Range.mk_range
                                                       "Pulse.Main.fst"
-                                                      (Prims.of_int (75))
+                                                      (Prims.of_int (107))
                                                       (Prims.of_int (18))
-                                                      (Prims.of_int (75))
+                                                      (Prims.of_int (107))
                                                       (Prims.of_int (43)))))
                                              (FStar_Sealed.seal
                                                 (Obj.magic

--- a/src/ocaml/plugin/generated/Pulse_Typing_Util.ml
+++ b/src/ocaml/plugin/generated/Pulse_Typing_Util.ml
@@ -1,0 +1,25 @@
+open Prims
+let (check_equiv_now :
+  FStar_Reflection_Types.env ->
+    FStar_Tactics_NamedView.term ->
+      FStar_Tactics_NamedView.term ->
+        (((unit, unit, unit) FStar_Tactics_Types.equiv_token
+           FStar_Pervasives_Native.option * FStar_Tactics_Types.issues),
+          unit) FStar_Tactics_Effect.tac_repr)
+  =
+  fun tcenv ->
+    fun t0 ->
+      fun t1 ->
+        FStar_Tactics_V2_Derived.with_policy FStar_Tactics_Types.SMTSync
+          (fun uu___ -> FStar_Tactics_V2_Builtins.check_equiv tcenv t0 t1)
+let (universe_of_now :
+  FStar_Reflection_Types.env ->
+    FStar_Tactics_NamedView.term ->
+      ((FStar_Tactics_NamedView.universe FStar_Pervasives_Native.option *
+         FStar_Tactics_Types.issues),
+        unit) FStar_Tactics_Effect.tac_repr)
+  =
+  fun g ->
+    fun e ->
+      FStar_Tactics_V2_Derived.with_policy FStar_Tactics_Types.SMTSync
+        (fun uu___ -> FStar_Tactics_V2_Builtins.universe_of g e)


### PR DESCRIPTION
This is based on https://github.com/FStarLang/FStar/pull/3011. With that change, F* will now treat the guards generated during Reflection.Typing primitive calls as Meta-F* guards, which can be pushed as SMT goals (the default), solved synchronously with SMT, without SMT, etc.

Keeping guards as (separate) SMT goals is the default. This PR joins them all into a single goal at the end of the checker run, to economize on Z3 calls. 

These merged goals can clearly require more solvers resources to be proven, so there's a question of what to do with the rlimit. I wrote some heuristic that increases the rlimit when merging goals... but it'd be good to find something more principled.

Note: CI will likely be green but it's running against F* previous to merging PR https://github.com/FStarLang/FStar/pull/3011, so not really testing the new features.