### PR TITLE
Pulse: References: exposing uniform pts_to_injective_eq, share, gather

### DIFF
--- a/share/steel/examples/pulse/GhostStateMachine.fst
+++ b/share/steel/examples/pulse/GhostStateMachine.fst
@@ -82,7 +82,7 @@ fn init' (_:unit)
   let ph = alloc Init;
   let h = alloc CInit;
 
-  share2 #pure_st_t ph #Init;
+  share2 #pure_st_t #emp_inames ph #Init;
   fold pure_handle_has_state ph Init;
   fold pure_handle_has_state ph Init;
   fold handle_has_state h CInit;
@@ -121,13 +121,13 @@ fn next' (_:unit)
   pts_to_injective_eq #pure_st_t #one_half #one_half #Init #ps global_locked_state.ph;
   rewrite (pts_to global_locked_state.ph #one_half ps)
        as (pts_to global_locked_state.ph #one_half Init);
-  gather2 #pure_st_t global_locked_state.ph #Init;
+  gather2 #pure_st_t #emp_inames global_locked_state.ph #Init;
 
   let st = CNext some_payload;
   global_locked_state.h := st;
   global_locked_state.ph := Next;
 
-  share2 #pure_st_t global_locked_state.ph #Next;
+  share2 #pure_st_t #emp_inames global_locked_state.ph #Next;
   fold pure_handle_has_state global_locked_state.ph Next;
   fold pure_handle_has_state global_locked_state.ph Next;
   fold handle_has_state global_locked_state.h st;
@@ -154,13 +154,13 @@ fn close' (_:unit)
   pts_to_injective_eq #pure_st_t #one_half #one_half #Next #ps global_locked_state.ph;
   rewrite (pts_to global_locked_state.ph #one_half ps)
        as (pts_to global_locked_state.ph #one_half Next);
-  gather2 #pure_st_t global_locked_state.ph #Next;
+  gather2 #pure_st_t #emp_inames global_locked_state.ph #Next;
 
   let st = CFinal some_payload;
   global_locked_state.h := st;
   global_locked_state.ph := Final;
 
-  share2 #pure_st_t global_locked_state.ph #Final;
+  share2 #pure_st_t #emp_inames global_locked_state.ph #Final;
   fold pure_handle_has_state global_locked_state.ph Final;
   fold pure_handle_has_state global_locked_state.ph Final;
   fold handle_has_state global_locked_state.h st;

--- a/share/steel/examples/pulse/GhostStateMachine.fst
+++ b/share/steel/examples/pulse/GhostStateMachine.fst
@@ -41,7 +41,7 @@ type pure_handle_t = ref pure_st_t
 
 type handle_t = ref st_t
 
-let pure_handle_has_state (h:pure_handle_t) (s:pure_st_t) : vprop = pts_to h #half_perm s
+let pure_handle_has_state (h:pure_handle_t) (s:pure_st_t) : vprop = pts_to h #one_half s
 
 let handle_has_state (h:handle_t) (s:st_t) : vprop = pts_to h s
 
@@ -82,7 +82,7 @@ fn init' (_:unit)
   let ph = alloc Init;
   let h = alloc CInit;
 
-  share #pure_st_t #emp_inames ph #Init;
+  share2 #pure_st_t ph #Init;
   fold pure_handle_has_state ph Init;
   fold pure_handle_has_state ph Init;
   fold handle_has_state h CInit;
@@ -118,16 +118,16 @@ fn next' (_:unit)
   unfold pure_handle_has_state global_locked_state.ph Init;
   unfold pure_handle_has_state global_locked_state.ph ps;
 
-  pts_to_injective_eq #pure_st_t #half_perm #half_perm #Init #ps global_locked_state.ph;
-  rewrite (pts_to global_locked_state.ph #half_perm ps)
-       as (pts_to global_locked_state.ph #half_perm Init);
-  gather #pure_st_t #emp_inames global_locked_state.ph #Init;
+  pts_to_injective_eq #pure_st_t #one_half #one_half #Init #ps global_locked_state.ph;
+  rewrite (pts_to global_locked_state.ph #one_half ps)
+       as (pts_to global_locked_state.ph #one_half Init);
+  gather2 #pure_st_t global_locked_state.ph #Init;
 
   let st = CNext some_payload;
   global_locked_state.h := st;
   global_locked_state.ph := Next;
 
-  share #pure_st_t #emp_inames global_locked_state.ph #Next;
+  share2 #pure_st_t global_locked_state.ph #Next;
   fold pure_handle_has_state global_locked_state.ph Next;
   fold pure_handle_has_state global_locked_state.ph Next;
   fold handle_has_state global_locked_state.h st;
@@ -151,16 +151,16 @@ fn close' (_:unit)
   unfold pure_handle_has_state global_locked_state.ph Next;
   unfold pure_handle_has_state global_locked_state.ph ps;
 
-  pts_to_injective_eq #pure_st_t #half_perm #half_perm #Next #ps global_locked_state.ph;
-  rewrite (pts_to global_locked_state.ph #half_perm ps)
-       as (pts_to global_locked_state.ph #half_perm Next);
-  gather #pure_st_t #emp_inames global_locked_state.ph #Next;
+  pts_to_injective_eq #pure_st_t #one_half #one_half #Next #ps global_locked_state.ph;
+  rewrite (pts_to global_locked_state.ph #one_half ps)
+       as (pts_to global_locked_state.ph #one_half Next);
+  gather2 #pure_st_t global_locked_state.ph #Next;
 
   let st = CFinal some_payload;
   global_locked_state.h := st;
   global_locked_state.ph := Final;
 
-  share #pure_st_t #emp_inames global_locked_state.ph #Final;
+  share2 #pure_st_t global_locked_state.ph #Final;
   fold pure_handle_has_state global_locked_state.ph Final;
   fold pure_handle_has_state global_locked_state.ph Final;
   fold handle_has_state global_locked_state.h st;

--- a/share/steel/examples/pulse/lib/Pulse.Lib.Core.fst
+++ b/share/steel/examples/pulse/lib/Pulse.Lib.Core.fst
@@ -8,6 +8,8 @@ open Steel.ST.Util
 open Steel.ST.Loops
 module T = FStar.Tactics
 
+let double_one_half () = ()
+
 let vprop = vprop
 
 [@@"__reduce__"; "__steel_reduce__"]

--- a/share/steel/examples/pulse/lib/Pulse.Lib.Core.fsti
+++ b/share/steel/examples/pulse/lib/Pulse.Lib.Core.fsti
@@ -3,6 +3,11 @@ open FStar.Ghost
 module U32 = FStar.UInt32
 module G = FStar.Ghost
 
+(* Common alias *)
+let one_half =
+  let open Steel.FractionalPermission in
+  half_perm full_perm
+
 (***** begin vprop_equiv *****)
 
 #set-options "--print_implicits --ugly --print_universes"

--- a/share/steel/examples/pulse/lib/Pulse.Lib.Core.fsti
+++ b/share/steel/examples/pulse/lib/Pulse.Lib.Core.fsti
@@ -1,12 +1,15 @@
 module Pulse.Lib.Core
 open FStar.Ghost
+open Steel.FractionalPermission
 module U32 = FStar.UInt32
 module G = FStar.Ghost
 
 (* Common alias *)
 let one_half =
-  let open Steel.FractionalPermission in
   half_perm full_perm
+
+val double_one_half (_:unit)
+  : Lemma (sum_perm one_half one_half == full_perm)
 
 (***** begin vprop_equiv *****)
 

--- a/share/steel/examples/pulse/lib/Pulse.Lib.GhostReference.fst
+++ b/share/steel/examples/pulse/lib/Pulse.Lib.GhostReference.fst
@@ -42,7 +42,22 @@ let gather' (#a:Type0) (r:R.ref a) (#x0 #x1:erased a) (#p0 #p1:perm)
   = fun _ -> let _ = R.gather r in ()
 let gather = gather'
 
-let pts_to_injective_eq' (#a:Type0)
+let share2 (#a:Type) (r:ref a) (#v:erased a)
+  : stt_ghost unit emp_inames
+      (pts_to r v)
+      (fun _ -> pts_to r #one_half v ** pts_to r #one_half v)
+  = share #a r #v
+
+let gather2' (#a:Type) (r:ref a) (#x0 #x1:erased a)
+  : stt_ghost unit emp_inames
+      (pts_to r #one_half x0 ** pts_to r #one_half x1)
+      (fun () -> pts_to r #(sum_perm one_half one_half) x0 `S.star` pure (x0 == x1))
+  = gather r
+let gather2 #a r #x0 #x1 =
+  (* Need the coerce to change sum_perm one_half one_half into full_perm *)
+  coerce_eq () (gather2' #a r #x0 #x1)
+
+let pts_to_injective_eq (#a:Type0)
                          (#p #q:perm)
                          (#v0 #v1:a)
                          (r:R.ref a)
@@ -50,4 +65,3 @@ let pts_to_injective_eq' (#a:Type0)
       (R.pts_to r p v0 `S.star` R.pts_to r q v1)
       (fun _ -> R.pts_to r p v0 `S.star` R.pts_to r q v0 `S.star` S.pure (v0 == v1))
     = fun _ -> let _ = R.pts_to_injective_eq #a #emp_inames #p #q #v0 #v1 r in ()
-let pts_to_injective_eq = pts_to_injective_eq'

--- a/share/steel/examples/pulse/lib/Pulse.Lib.GhostReference.fst
+++ b/share/steel/examples/pulse/lib/Pulse.Lib.GhostReference.fst
@@ -32,30 +32,30 @@ let ( := ) (#a:Type) (r:ref a) (x:erased a) (#n:erased a)
 
 let free #a r #n = fun _ -> R.free r; ()
 
-let share #a r #v #p
+let share #a #inames r #v #p
   = fun _ -> R.share r; ()
 
-let gather' (#a:Type0) (r:R.ref a) (#x0 #x1:erased a) (#p0 #p1:perm)
-  : stt_ghost unit emp_inames
+let gather' (#a:Type0) #inames (r:R.ref a) (#x0 #x1:erased a) (#p0 #p1:perm)
+  : stt_ghost unit inames
       (R.pts_to r p0 x0 `S.star` R.pts_to r p1 x1)
       (fun _ -> R.pts_to r (sum_perm p0 p1) x0 `S.star` S.pure (x0 == x1))
   = fun _ -> let _ = R.gather r in ()
 let gather = gather'
 
-let share2 (#a:Type) (r:ref a) (#v:erased a)
-  : stt_ghost unit emp_inames
+let share2 (#a:Type) #inames (r:ref a) (#v:erased a)
+  : stt_ghost unit inames
       (pts_to r v)
       (fun _ -> pts_to r #one_half v ** pts_to r #one_half v)
   = share #a r #v
 
-let gather2' (#a:Type) (r:ref a) (#x0 #x1:erased a)
-  : stt_ghost unit emp_inames
+let gather2' (#a:Type) #inames (r:ref a) (#x0 #x1:erased a)
+  : stt_ghost unit inames
       (pts_to r #one_half x0 ** pts_to r #one_half x1)
       (fun () -> pts_to r #(sum_perm one_half one_half) x0 ** pure (x0 == x1))
   = gather r
 
-let gather2 (#a:Type) (r:ref a) (#x0 #x1:erased a)
-  : Tot (stt_ghost unit emp_inames
+let gather2 (#a:Type) #inames (r:ref a) (#x0 #x1:erased a)
+  : Tot (stt_ghost unit inames
            (pts_to r #one_half x0 ** pts_to r #one_half x1)
            (fun _ -> pts_to r #full_perm x0 ** pure (x0 == x1)))
 =
@@ -63,7 +63,7 @@ let gather2 (#a:Type) (r:ref a) (#x0 #x1:erased a)
        == (fun (_:unit) -> pts_to r #full_perm x0 ** pure (x0 == x1)))
       by (T.l_to_r [`double_one_half]);
   (* NB: I'm surprised this works without extensionality and a restricted_t... bug? *)
-  coerce_eq () (gather2' #a r #x0 #x1)
+  coerce_eq () (gather2' #a #inames r #x0 #x1)
 
 let pts_to_injective_eq (#a:Type0)
                          (#p #q:perm)

--- a/share/steel/examples/pulse/lib/Pulse.Lib.GhostReference.fst
+++ b/share/steel/examples/pulse/lib/Pulse.Lib.GhostReference.fst
@@ -51,10 +51,18 @@ let share2 (#a:Type) (r:ref a) (#v:erased a)
 let gather2' (#a:Type) (r:ref a) (#x0 #x1:erased a)
   : stt_ghost unit emp_inames
       (pts_to r #one_half x0 ** pts_to r #one_half x1)
-      (fun () -> pts_to r #(sum_perm one_half one_half) x0 `S.star` pure (x0 == x1))
+      (fun () -> pts_to r #(sum_perm one_half one_half) x0 ** pure (x0 == x1))
   = gather r
-let gather2 #a r #x0 #x1 =
-  (* Need the coerce to change sum_perm one_half one_half into full_perm *)
+
+let gather2 (#a:Type) (r:ref a) (#x0 #x1:erased a)
+  : Tot (stt_ghost unit emp_inames
+           (pts_to r #one_half x0 ** pts_to r #one_half x1)
+           (fun _ -> pts_to r #full_perm x0 ** pure (x0 == x1)))
+=
+  assert ((fun (_:unit) -> pts_to r #(sum_perm one_half one_half) x0 ** pure (x0 == x1))
+       == (fun (_:unit) -> pts_to r #full_perm x0 ** pure (x0 == x1)))
+      by (T.l_to_r [`double_one_half]);
+  (* NB: I'm surprised this works without extensionality and a restricted_t... bug? *)
   coerce_eq () (gather2' #a r #x0 #x1)
 
 let pts_to_injective_eq (#a:Type0)

--- a/share/steel/examples/pulse/lib/Pulse.Lib.GhostReference.fsti
+++ b/share/steel/examples/pulse/lib/Pulse.Lib.GhostReference.fsti
@@ -37,6 +37,17 @@ val gather (#a:Type0) (r:ref a) (#x0 #x1:erased a) (#p0 #p1:perm)
       (pts_to r #p0 x0 ** pts_to r #p1 x1)
       (fun _ -> pts_to r #(sum_perm p0 p1) x0 ** pure (x0 == x1))
 
+(* Share/gather specialized to half permission *)
+val share2 (#a:Type) (r:ref a) (#v:erased a)
+  : stt_ghost unit emp_inames
+      (pts_to r v)
+      (fun _ -> pts_to r #one_half v ** pts_to r #one_half v)
+
+val gather2 (#a:Type) (r:ref a) (#x0 #x1:erased a)
+  : stt_ghost unit emp_inames
+      (pts_to r #one_half x0 ** pts_to r #one_half x1)
+      (fun _ -> pts_to r x0 ** pure (x0 == x1))
+
 val pts_to_injective_eq (#a:_)
                         (#p #q:_)
                         (#v0 #v1:a)

--- a/share/steel/examples/pulse/lib/Pulse.Lib.GhostReference.fsti
+++ b/share/steel/examples/pulse/lib/Pulse.Lib.GhostReference.fsti
@@ -25,26 +25,26 @@ val ( := ) (#a:Type) (r:ref a) (x:erased a) (#n:erased a)
 val free (#a:Type) (r:ref a) (#n:erased a)
   : stt_ghost unit emp_inames (pts_to r n) (fun _ -> emp)
 
-val share (#a:Type0) (r:ref a) (#v:erased a) (#p:perm)
-  : stt_ghost unit emp_inames
+val share (#a:Type) #inames (r:ref a) (#v:erased a) (#p:perm)
+  : stt_ghost unit inames
       (pts_to r #p v)
       (fun _ ->
        pts_to r #(half_perm p) v **
        pts_to r #(half_perm p) v)
 
-val gather (#a:Type0) (r:ref a) (#x0 #x1:erased a) (#p0 #p1:perm)
-  : stt_ghost unit emp_inames
+val gather (#a:Type) #inames (r:ref a) (#x0 #x1:erased a) (#p0 #p1:perm)
+  : stt_ghost unit inames
       (pts_to r #p0 x0 ** pts_to r #p1 x1)
       (fun _ -> pts_to r #(sum_perm p0 p1) x0 ** pure (x0 == x1))
 
 (* Share/gather specialized to half permission *)
-val share2 (#a:Type) (r:ref a) (#v:erased a)
-  : stt_ghost unit emp_inames
+val share2 (#a:Type) #inames (r:ref a) (#v:erased a)
+  : stt_ghost unit inames
       (pts_to r v)
       (fun _ -> pts_to r #one_half v ** pts_to r #one_half v)
 
-val gather2 (#a:Type) (r:ref a) (#x0 #x1:erased a)
-  : stt_ghost unit emp_inames
+val gather2 (#a:Type) #inames (r:ref a) (#x0 #x1:erased a)
+  : stt_ghost unit inames
       (pts_to r #one_half x0 ** pts_to r #one_half x1)
       (fun _ -> pts_to r x0 ** pure (x0 == x1))
 

--- a/share/steel/examples/pulse/lib/Pulse.Lib.HashTable.fst
+++ b/share/steel/examples/pulse/lib/Pulse.Lib.HashTable.fst
@@ -187,6 +187,7 @@ fn lookup' (#s:pht_sig_us)
 ```
 let lookup = lookup'
 
+#push-options "--z3rlimit 20"
 ```pulse
 fn insert' (#s:pht_sig_us)
            (#pht:(p:erased (pht_t (s_to_ps s)){PHT.not_full p.repr}))
@@ -298,6 +299,8 @@ fn insert' (#s:pht_sig_us)
   }}
 }
 ```
+#pop-options
+
 let insert = insert'
 
 ```pulse

--- a/share/steel/examples/pulse/lib/Pulse.Lib.HigherReference.fst
+++ b/share/steel/examples/pulse/lib/Pulse.Lib.HigherReference.fst
@@ -42,6 +42,31 @@ let free #a (r:ref a) (#n:erased a)
         HR.free r;
         S.return ()
 
+let share #a r #v #p
+  = fun _ -> HR.share r; ()
+
+let gather' (#a:Type) (r:HR.ref a) (#x0 #x1:erased a) (#p0 #p1:perm)
+  : stt_ghost unit emp_inames
+      (HR.pts_to r p0 x0 `S.star` HR.pts_to r p1 x1)
+      (fun _ -> HR.pts_to r (sum_perm p0 p1) x0 `S.star` S.pure (x0 == x1))
+  = fun _ -> let _ = HR.gather p1 r in ()
+let gather = gather'
+
+let share2 (#a:Type) (r:ref a) (#v:erased a)
+  : stt_ghost unit emp_inames
+      (pts_to r v)
+      (fun _ -> pts_to r #one_half v ** pts_to r #one_half v)
+  = share #a r #v
+
+let gather2' (#a:Type) (r:ref a) (#x0 #x1:erased a)
+  : stt_ghost unit emp_inames
+      (pts_to r #one_half x0 ** pts_to r #one_half x1)
+      (fun () -> pts_to r #(sum_perm one_half one_half) x0 `S.star` pure (x0 == x1))
+  = gather r
+let gather2 #a r #x0 #x1 =
+  (* Need the coerce to change sum_perm one_half one_half into full_perm *)
+  coerce_eq () (gather2' #a r #x0 #x1)
+
 let with_local #a init #pre #ret_t #post body =
   fun _ ->
     let body (r:ref a)
@@ -63,3 +88,12 @@ let with_local #a init #pre #ret_t #post body =
     in
     let v = HR.with_local init body in
     S.return v
+
+let pts_to_injective_eq (#a:Type)
+                         (#p #q:perm)
+                         (#v0 #v1:a)
+                         (r:HR.ref a)
+  : stt_ghost unit emp_inames
+      (HR.pts_to r p v0 `S.star` HR.pts_to r q v1)
+      (fun _ -> HR.pts_to r p v0 `S.star` HR.pts_to r q v0 `S.star` S.pure (v0 == v1))
+    = fun _ -> let _ = HR.pts_to_injective_eq #a #emp_inames #p #q #v0 #v1 r in ()

--- a/share/steel/examples/pulse/lib/Pulse.Lib.HigherReference.fst
+++ b/share/steel/examples/pulse/lib/Pulse.Lib.HigherReference.fst
@@ -61,10 +61,18 @@ let share2 (#a:Type) (r:ref a) (#v:erased a)
 let gather2' (#a:Type) (r:ref a) (#x0 #x1:erased a)
   : stt_ghost unit emp_inames
       (pts_to r #one_half x0 ** pts_to r #one_half x1)
-      (fun () -> pts_to r #(sum_perm one_half one_half) x0 `S.star` pure (x0 == x1))
+      (fun () -> pts_to r #(sum_perm one_half one_half) x0 ** pure (x0 == x1))
   = gather r
-let gather2 #a r #x0 #x1 =
-  (* Need the coerce to change sum_perm one_half one_half into full_perm *)
+
+let gather2 (#a:Type) (r:ref a) (#x0 #x1:erased a)
+  : Tot (stt_ghost unit emp_inames
+           (pts_to r #one_half x0 ** pts_to r #one_half x1)
+           (fun _ -> pts_to r #full_perm x0 ** pure (x0 == x1)))
+=
+  assert ((fun (_:unit) -> pts_to r #(sum_perm one_half one_half) x0 ** pure (x0 == x1))
+       == (fun (_:unit) -> pts_to r #full_perm x0 ** pure (x0 == x1)))
+      by (T.l_to_r [`double_one_half]);
+  (* NB: I'm surprised this works without extensionality and a restricted_t... bug? *)
   coerce_eq () (gather2' #a r #x0 #x1)
 
 let with_local #a init #pre #ret_t #post body =

--- a/share/steel/examples/pulse/lib/Pulse.Lib.HigherReference.fst
+++ b/share/steel/examples/pulse/lib/Pulse.Lib.HigherReference.fst
@@ -45,27 +45,27 @@ let free #a (r:ref a) (#n:erased a)
 let share #a r #v #p
   = fun _ -> HR.share r; ()
 
-let gather' (#a:Type) (r:HR.ref a) (#x0 #x1:erased a) (#p0 #p1:perm)
-  : stt_ghost unit emp_inames
+let gather' (#a:Type) #inames (r:HR.ref a) (#x0 #x1:erased a) (#p0 #p1:perm)
+  : stt_ghost unit inames
       (HR.pts_to r p0 x0 `S.star` HR.pts_to r p1 x1)
       (fun _ -> HR.pts_to r (sum_perm p0 p1) x0 `S.star` S.pure (x0 == x1))
   = fun _ -> let _ = HR.gather p1 r in ()
 let gather = gather'
 
-let share2 (#a:Type) (r:ref a) (#v:erased a)
-  : stt_ghost unit emp_inames
+let share2 (#a:Type) #inames (r:ref a) (#v:erased a)
+  : stt_ghost unit inames
       (pts_to r v)
       (fun _ -> pts_to r #one_half v ** pts_to r #one_half v)
   = share #a r #v
 
-let gather2' (#a:Type) (r:ref a) (#x0 #x1:erased a)
-  : stt_ghost unit emp_inames
+let gather2' (#a:Type) #inames (r:ref a) (#x0 #x1:erased a)
+  : stt_ghost unit inames
       (pts_to r #one_half x0 ** pts_to r #one_half x1)
       (fun () -> pts_to r #(sum_perm one_half one_half) x0 ** pure (x0 == x1))
   = gather r
 
-let gather2 (#a:Type) (r:ref a) (#x0 #x1:erased a)
-  : Tot (stt_ghost unit emp_inames
+let gather2 (#a:Type) #inames (r:ref a) (#x0 #x1:erased a)
+  : Tot (stt_ghost unit inames
            (pts_to r #one_half x0 ** pts_to r #one_half x1)
            (fun _ -> pts_to r #full_perm x0 ** pure (x0 == x1)))
 =
@@ -73,7 +73,7 @@ let gather2 (#a:Type) (r:ref a) (#x0 #x1:erased a)
        == (fun (_:unit) -> pts_to r #full_perm x0 ** pure (x0 == x1)))
       by (T.l_to_r [`double_one_half]);
   (* NB: I'm surprised this works without extensionality and a restricted_t... bug? *)
-  coerce_eq () (gather2' #a r #x0 #x1)
+  coerce_eq () (gather2' #a #inames r #x0 #x1)
 
 let with_local #a init #pre #ret_t #post body =
   fun _ ->

--- a/share/steel/examples/pulse/lib/Pulse.Lib.HigherReference.fsti
+++ b/share/steel/examples/pulse/lib/Pulse.Lib.HigherReference.fsti
@@ -24,6 +24,29 @@ val ( := ) (#a:Type) (r:ref a) (x:a) (#n:erased a)
 val free (#a:Type) (r:ref a) (#n:erased a)
   : stt unit (pts_to r n) (fun _ -> emp)
 
+val share (#a:Type) (r:ref a) (#v:erased a) (#p:perm)
+  : stt_ghost unit emp_inames
+      (pts_to r #p v)
+      (fun _ ->
+       pts_to r #(half_perm p) v **
+       pts_to r #(half_perm p) v)
+
+val gather (#a:Type) (r:ref a) (#x0 #x1:erased a) (#p0 #p1:perm)
+  : stt_ghost unit emp_inames
+      (pts_to r #p0 x0 ** pts_to r #p1 x1)
+      (fun _ -> pts_to r #(sum_perm p0 p1) x0 ** pure (x0 == x1))
+
+(* Share/gather specialized to half permission *)
+val share2 (#a:Type) (r:ref a) (#v:erased a)
+  : stt_ghost unit emp_inames
+      (pts_to r v)
+      (fun _ -> pts_to r #one_half v ** pts_to r #one_half v)
+
+val gather2 (#a:Type) (r:ref a) (#x0 #x1:erased a)
+  : stt_ghost unit emp_inames
+      (pts_to r #one_half x0 ** pts_to r #one_half x1)
+      (fun _ -> pts_to r x0 ** pure (x0 == x1))
+
 val with_local
   (#a:Type u#1)
   (init:a)
@@ -33,3 +56,11 @@ val with_local
   (body:(r:ref a) -> stt ret_t (pre ** pts_to r init)
                                (fun v -> post v ** exists_ (pts_to r)))
   : stt ret_t pre post
+
+val pts_to_injective_eq (#a:_)
+                        (#p #q:_)
+                        (#v0 #v1:a)
+                        (r:ref a)
+  : stt_ghost unit emp_inames
+      (pts_to r #p v0 ** pts_to r #q v1)
+      (fun _ -> pts_to r #p v0 ** pts_to r #q v0 ** pure (v0 == v1))

--- a/share/steel/examples/pulse/lib/Pulse.Lib.HigherReference.fsti
+++ b/share/steel/examples/pulse/lib/Pulse.Lib.HigherReference.fsti
@@ -24,26 +24,26 @@ val ( := ) (#a:Type) (r:ref a) (x:a) (#n:erased a)
 val free (#a:Type) (r:ref a) (#n:erased a)
   : stt unit (pts_to r n) (fun _ -> emp)
 
-val share (#a:Type) (r:ref a) (#v:erased a) (#p:perm)
-  : stt_ghost unit emp_inames
+val share (#a:Type) #inames (r:ref a) (#v:erased a) (#p:perm)
+  : stt_ghost unit inames
       (pts_to r #p v)
       (fun _ ->
        pts_to r #(half_perm p) v **
        pts_to r #(half_perm p) v)
 
-val gather (#a:Type) (r:ref a) (#x0 #x1:erased a) (#p0 #p1:perm)
-  : stt_ghost unit emp_inames
+val gather (#a:Type) #inames (r:ref a) (#x0 #x1:erased a) (#p0 #p1:perm)
+  : stt_ghost unit inames
       (pts_to r #p0 x0 ** pts_to r #p1 x1)
       (fun _ -> pts_to r #(sum_perm p0 p1) x0 ** pure (x0 == x1))
 
 (* Share/gather specialized to half permission *)
-val share2 (#a:Type) (r:ref a) (#v:erased a)
-  : stt_ghost unit emp_inames
+val share2 (#a:Type) #inames (r:ref a) (#v:erased a)
+  : stt_ghost unit inames
       (pts_to r v)
       (fun _ -> pts_to r #one_half v ** pts_to r #one_half v)
 
-val gather2 (#a:Type) (r:ref a) (#x0 #x1:erased a)
-  : stt_ghost unit emp_inames
+val gather2 (#a:Type) #inames (r:ref a) (#x0 #x1:erased a)
+  : stt_ghost unit inames
       (pts_to r #one_half x0 ** pts_to r #one_half x1)
       (fun _ -> pts_to r x0 ** pure (x0 == x1))
 

--- a/share/steel/examples/pulse/lib/Pulse.Lib.Reference.fst
+++ b/share/steel/examples/pulse/lib/Pulse.Lib.Reference.fst
@@ -42,26 +42,26 @@ let free #a (r:ref a) (#n:erased a)
 let share #a r #v #p
   = fun _ -> R.share r; ()
 
-let gather (#a:Type) (r:R.ref a) (#x0 #x1:erased a) (#p0 #p1:perm)
-  : stt_ghost unit emp_inames
+let gather (#a:Type) #inames (r:R.ref a) (#x0 #x1:erased a) (#p0 #p1:perm)
+  : stt_ghost unit inames
       (R.pts_to r p0 x0 `S.star` R.pts_to r p1 x1)
       (fun _ -> R.pts_to r (sum_perm p0 p1) x0 `S.star` S.pure (x0 == x1))
   = fun _ -> let _ = R.gather p1 r in ()
 
-let share2 (#a:Type) (r:ref a) (#v:erased a)
-  : stt_ghost unit emp_inames
+let share2 (#a:Type) #inames (r:ref a) (#v:erased a)
+  : stt_ghost unit inames
       (pts_to r v)
       (fun _ -> pts_to r #one_half v ** pts_to r #one_half v)
   = share #a r #v
 
-let gather2' (#a:Type) (r:ref a) (#x0 #x1:erased a)
-  : stt_ghost unit emp_inames
+let gather2' (#a:Type) #inames (r:ref a) (#x0 #x1:erased a)
+  : stt_ghost unit inames
       (pts_to r #one_half x0 ** pts_to r #one_half x1)
       (fun () -> pts_to r #(sum_perm one_half one_half) x0 ** pure (x0 == x1))
   = gather r
 
-let gather2 (#a:Type) (r:ref a) (#x0 #x1:erased a)
-  : Tot (stt_ghost unit emp_inames
+let gather2 (#a:Type) #inames (r:ref a) (#x0 #x1:erased a)
+  : Tot (stt_ghost unit inames
            (pts_to r #one_half x0 ** pts_to r #one_half x1)
            (fun _ -> pts_to r #full_perm x0 ** pure (x0 == x1)))
 =
@@ -69,7 +69,7 @@ let gather2 (#a:Type) (r:ref a) (#x0 #x1:erased a)
        == (fun (_:unit) -> pts_to r #full_perm x0 ** pure (x0 == x1)))
       by (T.l_to_r [`double_one_half]);
   (* NB: I'm surprised this works without extensionality and a restricted_t... bug? *)
-  coerce_eq () (gather2' #a r #x0 #x1)
+  coerce_eq () (gather2' #a #inames r #x0 #x1)
 
 let read_atomic_alt (r:ref U32.t) (#n:erased U32.t) (#p:perm)
  : stt_atomic U32.t emp_inames

--- a/share/steel/examples/pulse/lib/Pulse.Lib.Reference.fst
+++ b/share/steel/examples/pulse/lib/Pulse.Lib.Reference.fst
@@ -57,10 +57,18 @@ let share2 (#a:Type) (r:ref a) (#v:erased a)
 let gather2' (#a:Type) (r:ref a) (#x0 #x1:erased a)
   : stt_ghost unit emp_inames
       (pts_to r #one_half x0 ** pts_to r #one_half x1)
-      (fun () -> pts_to r #(sum_perm one_half one_half) x0 `S.star` pure (x0 == x1))
+      (fun () -> pts_to r #(sum_perm one_half one_half) x0 ** pure (x0 == x1))
   = gather r
-let gather2 #a r #x0 #x1 =
-  (* Need the coerce to change sum_perm one_half one_half into full_perm *)
+
+let gather2 (#a:Type) (r:ref a) (#x0 #x1:erased a)
+  : Tot (stt_ghost unit emp_inames
+           (pts_to r #one_half x0 ** pts_to r #one_half x1)
+           (fun _ -> pts_to r #full_perm x0 ** pure (x0 == x1)))
+=
+  assert ((fun (_:unit) -> pts_to r #(sum_perm one_half one_half) x0 ** pure (x0 == x1))
+       == (fun (_:unit) -> pts_to r #full_perm x0 ** pure (x0 == x1)))
+      by (T.l_to_r [`double_one_half]);
+  (* NB: I'm surprised this works without extensionality and a restricted_t... bug? *)
   coerce_eq () (gather2' #a r #x0 #x1)
 
 let read_atomic_alt (r:ref U32.t) (#n:erased U32.t) (#p:perm)

--- a/share/steel/examples/pulse/lib/Pulse.Lib.Reference.fsti
+++ b/share/steel/examples/pulse/lib/Pulse.Lib.Reference.fsti
@@ -25,26 +25,26 @@ val ( := ) (#a:Type) (r:ref a) (x:a) (#n:erased a)
 val free (#a:Type) (r:ref a) (#n:erased a)
   : stt unit (pts_to r n) (fun _ -> emp)
 
-val share (#a:Type) (r:ref a) (#v:erased a) (#p:perm)
-  : stt_ghost unit emp_inames
+val share (#a:Type) #inames (r:ref a) (#v:erased a) (#p:perm)
+  : stt_ghost unit inames
       (pts_to r #p v)
       (fun _ ->
        pts_to r #(half_perm p) v **
        pts_to r #(half_perm p) v)
 
-val gather (#a:Type) (r:ref a) (#x0 #x1:erased a) (#p0 #p1:perm)
-  : stt_ghost unit emp_inames
+val gather (#a:Type) #inames (r:ref a) (#x0 #x1:erased a) (#p0 #p1:perm)
+  : stt_ghost unit inames
       (pts_to r #p0 x0 ** pts_to r #p1 x1)
       (fun _ -> pts_to r #(sum_perm p0 p1) x0 ** pure (x0 == x1))
 
 (* Share/gather specialized to half permission *)
-val share2 (#a:Type) (r:ref a) (#v:erased a)
-  : stt_ghost unit emp_inames
+val share2 (#a:Type) #inames (r:ref a) (#v:erased a)
+  : stt_ghost unit inames
       (pts_to r v)
       (fun _ -> pts_to r #one_half v ** pts_to r #one_half v)
 
-val gather2 (#a:Type) (r:ref a) (#x0 #x1:erased a)
-  : stt_ghost unit emp_inames
+val gather2 (#a:Type) #inames (r:ref a) (#x0 #x1:erased a)
+  : stt_ghost unit inames
       (pts_to r #one_half x0 ** pts_to r #one_half x1)
       (fun _ -> pts_to r x0 ** pure (x0 == x1))
 

--- a/share/steel/examples/pulse/lib/Pulse.Lib.Reference.fsti
+++ b/share/steel/examples/pulse/lib/Pulse.Lib.Reference.fsti
@@ -25,6 +25,29 @@ val ( := ) (#a:Type) (r:ref a) (x:a) (#n:erased a)
 val free (#a:Type) (r:ref a) (#n:erased a)
   : stt unit (pts_to r n) (fun _ -> emp)
 
+val share (#a:Type) (r:ref a) (#v:erased a) (#p:perm)
+  : stt_ghost unit emp_inames
+      (pts_to r #p v)
+      (fun _ ->
+       pts_to r #(half_perm p) v **
+       pts_to r #(half_perm p) v)
+
+val gather (#a:Type) (r:ref a) (#x0 #x1:erased a) (#p0 #p1:perm)
+  : stt_ghost unit emp_inames
+      (pts_to r #p0 x0 ** pts_to r #p1 x1)
+      (fun _ -> pts_to r #(sum_perm p0 p1) x0 ** pure (x0 == x1))
+
+(* Share/gather specialized to half permission *)
+val share2 (#a:Type) (r:ref a) (#v:erased a)
+  : stt_ghost unit emp_inames
+      (pts_to r v)
+      (fun _ -> pts_to r #one_half v ** pts_to r #one_half v)
+
+val gather2 (#a:Type) (r:ref a) (#x0 #x1:erased a)
+  : stt_ghost unit emp_inames
+      (pts_to r #one_half x0 ** pts_to r #one_half x1)
+      (fun _ -> pts_to r x0 ** pure (x0 == x1))
+
 val read_atomic (r:ref U32.t) (#n:erased U32.t) (#p:perm)
   : stt_atomic U32.t emp_inames
     (pts_to r #p n)
@@ -45,17 +68,6 @@ val with_local
                               (fun v -> post v ** exists_ (pts_to r)))
   : stt ret_t pre post
 
-let half_perm = half_perm full_perm
-
-val share (#a:Type0) (#uses:_) (r:ref a) (#x:a)
-  : stt_ghost unit uses
-    (pts_to r x)
-    (fun _ -> pts_to r #half_perm x ** pts_to r #half_perm x)
-
-val gather (#a:Type0) (#uses:_) (r:ref a) (#x:a)
-  : stt_ghost unit uses
-    (pts_to r #half_perm x ** pts_to r #half_perm x)
-    (fun _ -> pts_to r x)
 
 val pts_to_injective_eq (#a:_)
                         (#p #q:_)


### PR DESCRIPTION
- Make sure all three flavors of references have share, gather, and
  pts_to_eq_injective exposed and implemented.

- Introduce the `one_half` permission in Pulse.Lib.Core, equal to
  `half_perm full_perm`.

- Also implement share2/gather2 for the common case of splitting a
  full_perm into halves and then joining back. This is useful
  as Pulse does not yet automate permission arithmetic.