### PR TITLE
Pulse: keep the range on syntax errors

### DIFF
--- a/lib/steel/pulse/Pulse.Main.fst
+++ b/lib/steel/pulse/Pulse.Main.fst
@@ -103,6 +103,12 @@ let check_pulse (namespaces:list string)
       | Inl st_term ->
         main st_term tm_emp env
       | Inr (msg, range) ->
-        T.fail (Printf.sprintf "%s: %s"
-                  (T.range_to_string range)
-                  msg)
+        let i =
+          Issue.mk_issue "Error"
+                   (Printf.sprintf "%s: %s" (T.range_to_string range) msg)
+                   (Some range)
+                   None
+                   []
+        in
+        T.log_issues [i];
+        T.fail "Pulse parser failed"

--- a/src/ocaml/plugin/generated/Pulse_Main.ml
+++ b/src/ocaml/plugin/generated/Pulse_Main.ml
@@ -1014,7 +1014,7 @@ let (check_pulse :
                      (Obj.magic
                         (FStar_Range.mk_range "Pulse.Main.fst"
                            (Prims.of_int (102)) (Prims.of_int (6))
-                           (Prims.of_int (108)) (Prims.of_int (22)))))
+                           (Prims.of_int (114)) (Prims.of_int (36)))))
                   (FStar_Tactics_Effect.lift_div_tac
                      (fun uu___ ->
                         Pulse_ASTBuilder.parse_pulse env namespaces
@@ -1031,71 +1031,125 @@ let (check_pulse :
                                  (FStar_Sealed.seal
                                     (Obj.magic
                                        (FStar_Range.mk_range "Pulse.Main.fst"
-                                          (Prims.of_int (106))
-                                          (Prims.of_int (15))
-                                          (Prims.of_int (108))
-                                          (Prims.of_int (22)))))
+                                          (Prims.of_int (107))
+                                          (Prims.of_int (10))
+                                          (Prims.of_int (111))
+                                          (Prims.of_int (21)))))
                                  (FStar_Sealed.seal
                                     (Obj.magic
                                        (FStar_Range.mk_range "Pulse.Main.fst"
-                                          (Prims.of_int (106))
+                                          (Prims.of_int (113))
                                           (Prims.of_int (8))
-                                          (Prims.of_int (108))
-                                          (Prims.of_int (22)))))
+                                          (Prims.of_int (114))
+                                          (Prims.of_int (36)))))
                                  (Obj.magic
                                     (FStar_Tactics_Effect.tac_bind
                                        (FStar_Sealed.seal
                                           (Obj.magic
                                              (FStar_Range.mk_range
                                                 "Pulse.Main.fst"
-                                                (Prims.of_int (106))
-                                                (Prims.of_int (15))
                                                 (Prims.of_int (108))
-                                                (Prims.of_int (22)))))
+                                                (Prims.of_int (19))
+                                                (Prims.of_int (108))
+                                                (Prims.of_int (74)))))
                                        (FStar_Sealed.seal
                                           (Obj.magic
                                              (FStar_Range.mk_range
                                                 "Pulse.Main.fst"
-                                                (Prims.of_int (106))
-                                                (Prims.of_int (15))
-                                                (Prims.of_int (108))
-                                                (Prims.of_int (22)))))
+                                                (Prims.of_int (107))
+                                                (Prims.of_int (10))
+                                                (Prims.of_int (111))
+                                                (Prims.of_int (21)))))
                                        (Obj.magic
                                           (FStar_Tactics_Effect.tac_bind
                                              (FStar_Sealed.seal
                                                 (Obj.magic
                                                    (FStar_Range.mk_range
                                                       "Pulse.Main.fst"
-                                                      (Prims.of_int (107))
-                                                      (Prims.of_int (18))
-                                                      (Prims.of_int (107))
-                                                      (Prims.of_int (43)))))
+                                                      (Prims.of_int (108))
+                                                      (Prims.of_int (19))
+                                                      (Prims.of_int (108))
+                                                      (Prims.of_int (74)))))
                                              (FStar_Sealed.seal
                                                 (Obj.magic
                                                    (FStar_Range.mk_range
-                                                      "FStar.Printf.fst"
-                                                      (Prims.of_int (121))
-                                                      (Prims.of_int (8))
-                                                      (Prims.of_int (123))
-                                                      (Prims.of_int (44)))))
+                                                      "Pulse.Main.fst"
+                                                      (Prims.of_int (108))
+                                                      (Prims.of_int (19))
+                                                      (Prims.of_int (108))
+                                                      (Prims.of_int (74)))))
                                              (Obj.magic
-                                                (FStar_Tactics_V2_Builtins.range_to_string
-                                                   range))
+                                                (FStar_Tactics_Effect.tac_bind
+                                                   (FStar_Sealed.seal
+                                                      (Obj.magic
+                                                         (FStar_Range.mk_range
+                                                            "Pulse.Main.fst"
+                                                            (Prims.of_int (108))
+                                                            (Prims.of_int (44))
+                                                            (Prims.of_int (108))
+                                                            (Prims.of_int (69)))))
+                                                   (FStar_Sealed.seal
+                                                      (Obj.magic
+                                                         (FStar_Range.mk_range
+                                                            "FStar.Printf.fst"
+                                                            (Prims.of_int (121))
+                                                            (Prims.of_int (8))
+                                                            (Prims.of_int (123))
+                                                            (Prims.of_int (44)))))
+                                                   (Obj.magic
+                                                      (FStar_Tactics_V2_Builtins.range_to_string
+                                                         range))
+                                                   (fun uu___1 ->
+                                                      FStar_Tactics_Effect.lift_div_tac
+                                                        (fun uu___2 ->
+                                                           fun x ->
+                                                             Prims.strcat
+                                                               (Prims.strcat
+                                                                  ""
+                                                                  (Prims.strcat
+                                                                    uu___1
+                                                                    ": "))
+                                                               (Prims.strcat
+                                                                  x "")))))
                                              (fun uu___1 ->
                                                 FStar_Tactics_Effect.lift_div_tac
-                                                  (fun uu___2 ->
-                                                     fun x ->
-                                                       Prims.strcat
-                                                         (Prims.strcat ""
-                                                            (Prims.strcat
-                                                               uu___1 ": "))
-                                                         (Prims.strcat x "")))))
+                                                  (fun uu___2 -> uu___1 msg))))
                                        (fun uu___1 ->
                                           FStar_Tactics_Effect.lift_div_tac
-                                            (fun uu___2 -> uu___1 msg))))
+                                            (fun uu___2 ->
+                                               FStar_Issue.mk_issue "Error"
+                                                 uu___1
+                                                 (FStar_Pervasives_Native.Some
+                                                    range)
+                                                 FStar_Pervasives_Native.None
+                                                 []))))
                                  (fun uu___1 ->
-                                    FStar_Tactics_V2_Derived.fail uu___1)))
-                       uu___)
+                                    (fun i ->
+                                       Obj.magic
+                                         (FStar_Tactics_Effect.tac_bind
+                                            (FStar_Sealed.seal
+                                               (Obj.magic
+                                                  (FStar_Range.mk_range
+                                                     "Pulse.Main.fst"
+                                                     (Prims.of_int (113))
+                                                     (Prims.of_int (8))
+                                                     (Prims.of_int (113))
+                                                     (Prims.of_int (24)))))
+                                            (FStar_Sealed.seal
+                                               (Obj.magic
+                                                  (FStar_Range.mk_range
+                                                     "Pulse.Main.fst"
+                                                     (Prims.of_int (114))
+                                                     (Prims.of_int (8))
+                                                     (Prims.of_int (114))
+                                                     (Prims.of_int (36)))))
+                                            (Obj.magic
+                                               (FStar_Tactics_V2_Builtins.log_issues
+                                                  [i]))
+                                            (fun uu___1 ->
+                                               FStar_Tactics_V2_Derived.fail
+                                                 "Pulse parser failed")))
+                                      uu___1))) uu___)
 let _ =
   FStar_Tactics_Native.register_tactic "Pulse.Main.check_pulse"
     (Prims.of_int (8))


### PR DESCRIPTION
Example (deleting the dot after `invariant`).

Before, only a pointer to the pulse header (though the actual range is printed inside of that diagnostic)

<img width="480" alt="Screenshot 2023-08-24 162001" src="https://github.com/FStarLang/steel/assets/4195583/c09dae91-adf9-4f32-9f57-5d4fa58ecf3b">

After, highlighting on the source:

<img width="481" alt="Screenshot 2023-08-24 161840" src="https://github.com/FStarLang/steel/assets/4195583/10918fe5-7025-44f2-bc7d-aa09beaf634b">
