### PR TITLE
Pulse: elaborate annotations before check_universe

### DIFF
--- a/lib/steel/pulse/Pulse.Checker.Pure.fsti
+++ b/lib/steel/pulse/Pulse.Checker.Pure.fsti
@@ -85,3 +85,5 @@ val core_check_tot_term_with_expected_type (g:env) (e:term) (t:typ)
 val is_non_informative (g:env) (c:comp)
   : T.Tac (option (T.non_informative_token (elab_env g) (elab_comp c)))
 
+val check_subtyping (g:env) (t1 t2 : term)
+  : T.Tac (subtyping_token g t1 t2)

--- a/lib/steel/pulse/Pulse.Typing.fst
+++ b/lib/steel/pulse/Pulse.Typing.fst
@@ -598,6 +598,9 @@ type comp_typing : env -> comp -> universe -> Type =
 let prop_validity (g:env) (t:term) =
   FTB.prop_validity_token (elab_env g) (elab_term t)
 
+let subtyping_token g t1 t2 =
+  T.subtyping_token (elab_env g) (elab_term t1) (elab_term t2)
+
 val readback_binding : R.binding -> binding
 let readback_binding b =
   assume (host_term == R.term); // fixme! expose this fact

--- a/src/ocaml/plugin/generated/Pulse_Checker_Bind.ml
+++ b/src/ocaml/plugin/generated/Pulse_Checker_Bind.ml
@@ -1,6 +1,4 @@
 open Prims
-let coerce_eq : 'a 'b . 'a -> unit -> 'b =
-  fun uu___1 -> fun uu___ -> (fun x -> fun uu___ -> Obj.magic x) uu___1 uu___
 let (check_bind :
   Pulse_Typing_Env.env ->
     Pulse_Syntax_Base.term ->
@@ -23,13 +21,13 @@ let (check_bind :
                   (FStar_Sealed.seal
                      (Obj.magic
                         (FStar_Range.mk_range "Pulse.Checker.Bind.fst"
-                           (Prims.of_int (28)) (Prims.of_int (10))
-                           (Prims.of_int (28)) (Prims.of_int (62)))))
+                           (Prims.of_int (26)) (Prims.of_int (10))
+                           (Prims.of_int (26)) (Prims.of_int (62)))))
                   (FStar_Sealed.seal
                      (Obj.magic
                         (FStar_Range.mk_range "Pulse.Checker.Bind.fst"
-                           (Prims.of_int (30)) (Prims.of_int (2))
-                           (Prims.of_int (58)) (Prims.of_int (43)))))
+                           (Prims.of_int (28)) (Prims.of_int (2))
+                           (Prims.of_int (66)) (Prims.of_int (43)))))
                   (FStar_Tactics_Effect.lift_div_tac
                      (fun uu___ ->
                         Pulse_Typing_Env.push_context g "check_bind"
@@ -42,14 +40,14 @@ let (check_bind :
                                 (Obj.magic
                                    (FStar_Range.mk_range
                                       "Pulse.Checker.Bind.fst"
-                                      (Prims.of_int (30)) (Prims.of_int (2))
-                                      (Prims.of_int (31)) (Prims.of_int (66)))))
+                                      (Prims.of_int (28)) (Prims.of_int (2))
+                                      (Prims.of_int (29)) (Prims.of_int (66)))))
                              (FStar_Sealed.seal
                                 (Obj.magic
                                    (FStar_Range.mk_range
                                       "Pulse.Checker.Bind.fst"
-                                      (Prims.of_int (33)) (Prims.of_int (2))
-                                      (Prims.of_int (58)) (Prims.of_int (43)))))
+                                      (Prims.of_int (31)) (Prims.of_int (2))
+                                      (Prims.of_int (66)) (Prims.of_int (43)))))
                              (Obj.magic
                                 (Pulse_Checker_Prover_Util.debug_prover g1
                                    (fun uu___ ->
@@ -58,9 +56,9 @@ let (check_bind :
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.Checker.Bind.fst"
-                                                 (Prims.of_int (31))
+                                                 (Prims.of_int (29))
                                                  (Prims.of_int (42))
-                                                 (Prims.of_int (31))
+                                                 (Prims.of_int (29))
                                                  (Prims.of_int (65)))))
                                         (FStar_Sealed.seal
                                            (Obj.magic
@@ -87,17 +85,17 @@ let (check_bind :
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.Checker.Bind.fst"
-                                                 (Prims.of_int (33))
+                                                 (Prims.of_int (31))
                                                  (Prims.of_int (2))
-                                                 (Prims.of_int (34))
+                                                 (Prims.of_int (32))
                                                  (Prims.of_int (89)))))
                                         (FStar_Sealed.seal
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.Checker.Bind.fst"
-                                                 (Prims.of_int (34))
+                                                 (Prims.of_int (32))
                                                  (Prims.of_int (90))
-                                                 (Prims.of_int (58))
+                                                 (Prims.of_int (66))
                                                  (Prims.of_int (43)))))
                                         (if
                                            FStar_Pervasives_Native.uu___is_None
@@ -122,17 +120,17 @@ let (check_bind :
                                                       (Obj.magic
                                                          (FStar_Range.mk_range
                                                             "Pulse.Checker.Bind.fst"
-                                                            (Prims.of_int (36))
+                                                            (Prims.of_int (34))
                                                             (Prims.of_int (45))
-                                                            (Prims.of_int (36))
+                                                            (Prims.of_int (34))
                                                             (Prims.of_int (51)))))
                                                    (FStar_Sealed.seal
                                                       (Obj.magic
                                                          (FStar_Range.mk_range
                                                             "Pulse.Checker.Bind.fst"
-                                                            (Prims.of_int (34))
+                                                            (Prims.of_int (32))
                                                             (Prims.of_int (90))
-                                                            (Prims.of_int (58))
+                                                            (Prims.of_int (66))
                                                             (Prims.of_int (43)))))
                                                    (FStar_Tactics_Effect.lift_div_tac
                                                       (fun uu___2 ->
@@ -155,17 +153,17 @@ let (check_bind :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (38))
+                                                                    (Prims.of_int (36))
                                                                     (Prims.of_int (53))
-                                                                    (Prims.of_int (49))
+                                                                    (Prims.of_int (57))
                                                                     (Prims.of_int (5)))))
                                                                   (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (36))
+                                                                    (Prims.of_int (34))
                                                                     (Prims.of_int (54))
-                                                                    (Prims.of_int (58))
+                                                                    (Prims.of_int (66))
                                                                     (Prims.of_int (43)))))
                                                                   (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -173,17 +171,17 @@ let (check_bind :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (39))
+                                                                    (Prims.of_int (37))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (39))
+                                                                    (Prims.of_int (37))
                                                                     (Prims.of_int (65)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (41))
-                                                                    (Prims.of_int (4))
-                                                                    (Prims.of_int (49))
+                                                                    (Prims.of_int (37))
+                                                                    (Prims.of_int (68))
+                                                                    (Prims.of_int (57))
                                                                     (Prims.of_int (5)))))
                                                                     (Obj.magic
                                                                     (check g1
@@ -200,20 +198,46 @@ let (check_bind :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (41))
-                                                                    (Prims.of_int (10))
-                                                                    (Prims.of_int (47))
-                                                                    (Prims.of_int (120)))))
+                                                                    (Prims.of_int (39))
+                                                                    (Prims.of_int (13))
+                                                                    (Prims.of_int (39))
+                                                                    (Prims.of_int (29)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (39))
+                                                                    (Prims.of_int (40))
+                                                                    (Prims.of_int (4))
+                                                                    (Prims.of_int (57))
+                                                                    (Prims.of_int (5)))))
+                                                                    (FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___3 ->
+                                                                    binder.Pulse_Syntax_Base.binder_ty))
+                                                                    (fun
+                                                                    uu___3 ->
+                                                                    (fun ty
+                                                                    ->
+                                                                    Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Bind.fst"
+                                                                    (Prims.of_int (40))
+                                                                    (Prims.of_int (10))
+                                                                    (Prims.of_int (55))
+                                                                    (Prims.of_int (106)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Bind.fst"
+                                                                    (Prims.of_int (37))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (39))
+                                                                    (Prims.of_int (37))
                                                                     (Prims.of_int (9)))))
                                                                     (match 
-                                                                    (binder.Pulse_Syntax_Base.binder_ty).Pulse_Syntax_Base.t
+                                                                    ty.Pulse_Syntax_Base.t
                                                                     with
                                                                     | 
                                                                     Pulse_Syntax_Base.Tm_Unknown
@@ -233,6 +257,39 @@ let (check_bind :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
+                                                                    (Prims.of_int (43))
+                                                                    (Prims.of_int (27))
+                                                                    (Prims.of_int (43))
+                                                                    (Prims.of_int (46)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Bind.fst"
+                                                                    (Prims.of_int (42))
+                                                                    (Prims.of_int (10))
+                                                                    (Prims.of_int (55))
+                                                                    (Prims.of_int (106)))))
+                                                                    (Obj.magic
+                                                                    (Pulse_Checker_Pure.check_tot_term
+                                                                    g1 ty))
+                                                                    (fun
+                                                                    uu___4 ->
+                                                                    (fun
+                                                                    uu___4 ->
+                                                                    match uu___4
+                                                                    with
+                                                                    | 
+                                                                    FStar_Pervasives.Mkdtuple3
+                                                                    (ty1,
+                                                                    uu___5,
+                                                                    uu___6)
+                                                                    ->
+                                                                    Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Bind.fst"
                                                                     (Prims.of_int (44))
                                                                     (Prims.of_int (44))
                                                                     (Prims.of_int (44))
@@ -242,35 +299,34 @@ let (check_bind :
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
                                                                     (Prims.of_int (43))
-                                                                    (Prims.of_int (10))
-                                                                    (Prims.of_int (47))
-                                                                    (Prims.of_int (120)))))
+                                                                    (Prims.of_int (49))
+                                                                    (Prims.of_int (55))
+                                                                    (Prims.of_int (106)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
-                                                                    uu___4 ->
+                                                                    uu___7 ->
                                                                     r))
                                                                     (fun
-                                                                    uu___4 ->
+                                                                    uu___7 ->
                                                                     (fun
-                                                                    uu___4 ->
-                                                                    match uu___4
+                                                                    uu___7 ->
+                                                                    match uu___7
                                                                     with
                                                                     | 
                                                                     FStar_Pervasives.Mkdtuple5
-                                                                    (uu___5,
-                                                                    uu___6,
-                                                                    FStar_Pervasives.Mkdtuple3
-                                                                    (uu___7,
-                                                                    t1,
-                                                                    uu___8),
+                                                                    (uu___8,
                                                                     uu___9,
-                                                                    uu___10)
+                                                                    FStar_Pervasives.Mkdtuple3
+                                                                    (uu___10,
+                                                                    t1,
+                                                                    uu___11),
+                                                                    uu___12,
+                                                                    uu___13)
                                                                     ->
                                                                     if
                                                                     Prims.op_Negation
                                                                     (Pulse_Syntax_Base.eq_tm
-                                                                    binder.Pulse_Syntax_Base.binder_ty
-                                                                    t1)
+                                                                    ty1 t1)
                                                                     then
                                                                     Obj.magic
                                                                     (Obj.repr
@@ -279,44 +335,44 @@ let (check_bind :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (47))
+                                                                    (Prims.of_int (55))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (47))
-                                                                    (Prims.of_int (120)))))
+                                                                    (Prims.of_int (55))
+                                                                    (Prims.of_int (106)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (46))
+                                                                    (Prims.of_int (54))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (47))
-                                                                    (Prims.of_int (120)))))
+                                                                    (Prims.of_int (55))
+                                                                    (Prims.of_int (106)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (47))
-                                                                    (Prims.of_int (99))
-                                                                    (Prims.of_int (47))
-                                                                    (Prims.of_int (119)))))
+                                                                    (Prims.of_int (55))
+                                                                    (Prims.of_int (85))
+                                                                    (Prims.of_int (55))
+                                                                    (Prims.of_int (105)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (47))
+                                                                    (Prims.of_int (55))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (47))
-                                                                    (Prims.of_int (120)))))
+                                                                    (Prims.of_int (55))
+                                                                    (Prims.of_int (106)))))
                                                                     (Obj.magic
                                                                     (Pulse_Syntax_Printer.term_to_string
                                                                     t1))
                                                                     (fun
-                                                                    uu___11
+                                                                    uu___14
                                                                     ->
                                                                     (fun
-                                                                    uu___11
+                                                                    uu___14
                                                                     ->
                                                                     Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -324,28 +380,28 @@ let (check_bind :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (47))
+                                                                    (Prims.of_int (55))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (47))
-                                                                    (Prims.of_int (120)))))
+                                                                    (Prims.of_int (55))
+                                                                    (Prims.of_int (106)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (47))
+                                                                    (Prims.of_int (55))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (47))
-                                                                    (Prims.of_int (120)))))
+                                                                    (Prims.of_int (55))
+                                                                    (Prims.of_int (106)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (47))
+                                                                    (Prims.of_int (55))
                                                                     (Prims.of_int (63))
-                                                                    (Prims.of_int (47))
-                                                                    (Prims.of_int (98)))))
+                                                                    (Prims.of_int (55))
+                                                                    (Prims.of_int (84)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
@@ -356,53 +412,54 @@ let (check_bind :
                                                                     (Prims.of_int (44)))))
                                                                     (Obj.magic
                                                                     (Pulse_Syntax_Printer.term_to_string
-                                                                    binder.Pulse_Syntax_Base.binder_ty))
+                                                                    ty1))
                                                                     (fun
-                                                                    uu___12
+                                                                    uu___15
                                                                     ->
                                                                     FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
-                                                                    uu___13
+                                                                    uu___16
                                                                     ->
                                                                     fun x ->
                                                                     Prims.strcat
                                                                     (Prims.strcat
                                                                     "Type mismatch: expected "
                                                                     (Prims.strcat
-                                                                    uu___12
+                                                                    uu___15
                                                                     ", got "))
                                                                     (Prims.strcat
                                                                     x "")))))
                                                                     (fun
-                                                                    uu___12
+                                                                    uu___15
                                                                     ->
                                                                     FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
-                                                                    uu___13
+                                                                    uu___16
                                                                     ->
-                                                                    uu___12
-                                                                    uu___11))))
-                                                                    uu___11)))
+                                                                    uu___15
+                                                                    uu___14))))
+                                                                    uu___14)))
                                                                     (fun
-                                                                    uu___11
+                                                                    uu___14
                                                                     ->
                                                                     (fun
-                                                                    uu___11
+                                                                    uu___14
                                                                     ->
                                                                     Obj.magic
                                                                     (Pulse_Typing_Env.fail
                                                                     g1
                                                                     (FStar_Pervasives_Native.Some
                                                                     (e1.Pulse_Syntax_Base.range2))
-                                                                    uu___11))
-                                                                    uu___11)))
+                                                                    uu___14))
+                                                                    uu___14)))
                                                                     else
                                                                     Obj.magic
                                                                     (Obj.repr
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
-                                                                    uu___12
+                                                                    uu___15
                                                                     -> ()))))
+                                                                    uu___7)))
                                                                     uu___4))))
                                                                     (fun
                                                                     uu___3 ->
@@ -410,6 +467,7 @@ let (check_bind :
                                                                     (fun
                                                                     uu___4 ->
                                                                     r))))
+                                                                    uu___3)))
                                                                     uu___3)))
                                                                   (fun uu___3
                                                                     ->
@@ -431,17 +489,17 @@ let (check_bind :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (51))
+                                                                    (Prims.of_int (59))
                                                                     (Prims.of_int (48))
-                                                                    (Prims.of_int (55))
+                                                                    (Prims.of_int (63))
                                                                     (Prims.of_int (64)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (55))
+                                                                    (Prims.of_int (63))
                                                                     (Prims.of_int (67))
-                                                                    (Prims.of_int (58))
+                                                                    (Prims.of_int (66))
                                                                     (Prims.of_int (43)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -449,17 +507,17 @@ let (check_bind :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (52))
+                                                                    (Prims.of_int (60))
                                                                     (Prims.of_int (17))
-                                                                    (Prims.of_int (52))
+                                                                    (Prims.of_int (60))
                                                                     (Prims.of_int (45)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (52))
+                                                                    (Prims.of_int (60))
                                                                     (Prims.of_int (48))
-                                                                    (Prims.of_int (55))
+                                                                    (Prims.of_int (63))
                                                                     (Prims.of_int (64)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -476,17 +534,17 @@ let (check_bind :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (54))
+                                                                    (Prims.of_int (62))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (54))
+                                                                    (Prims.of_int (62))
                                                                     (Prims.of_int (97)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (55))
+                                                                    (Prims.of_int (63))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (55))
+                                                                    (Prims.of_int (63))
                                                                     (Prims.of_int (64)))))
                                                                     (Obj.magic
                                                                     (check
@@ -518,17 +576,17 @@ let (check_bind :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (56))
+                                                                    (Prims.of_int (64))
                                                                     (Prims.of_int (47))
-                                                                    (Prims.of_int (56))
+                                                                    (Prims.of_int (64))
                                                                     (Prims.of_int (61)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (58))
+                                                                    (Prims.of_int (66))
                                                                     (Prims.of_int (2))
-                                                                    (Prims.of_int (58))
+                                                                    (Prims.of_int (66))
                                                                     (Prims.of_int (43)))))
                                                                     (Obj.magic
                                                                     (k1
@@ -571,16 +629,16 @@ let (check_tot_bind :
                   (FStar_Sealed.seal
                      (Obj.magic
                         (FStar_Range.mk_range "Pulse.Checker.Bind.fst"
-                           (Prims.of_int (70)) (Prims.of_int (10))
-                           (Prims.of_int (70)) (Prims.of_int (62)))))
+                           (Prims.of_int (78)) (Prims.of_int (10))
+                           (Prims.of_int (78)) (Prims.of_int (66)))))
                   (FStar_Sealed.seal
                      (Obj.magic
                         (FStar_Range.mk_range "Pulse.Checker.Bind.fst"
-                           (Prims.of_int (72)) (Prims.of_int (2))
-                           (Prims.of_int (118)) (Prims.of_int (43)))))
+                           (Prims.of_int (80)) (Prims.of_int (2))
+                           (Prims.of_int (127)) (Prims.of_int (43)))))
                   (FStar_Tactics_Effect.lift_div_tac
                      (fun uu___ ->
-                        Pulse_Typing_Env.push_context g "check_bind"
+                        Pulse_Typing_Env.push_context g "check_tot_bind"
                           t.Pulse_Syntax_Base.range2))
                   (fun uu___ ->
                      (fun g1 ->
@@ -590,14 +648,14 @@ let (check_tot_bind :
                                 (Obj.magic
                                    (FStar_Range.mk_range
                                       "Pulse.Checker.Bind.fst"
-                                      (Prims.of_int (72)) (Prims.of_int (2))
-                                      (Prims.of_int (73)) (Prims.of_int (93)))))
+                                      (Prims.of_int (80)) (Prims.of_int (2))
+                                      (Prims.of_int (81)) (Prims.of_int (93)))))
                              (FStar_Sealed.seal
                                 (Obj.magic
                                    (FStar_Range.mk_range
                                       "Pulse.Checker.Bind.fst"
-                                      (Prims.of_int (73)) (Prims.of_int (94))
-                                      (Prims.of_int (118))
+                                      (Prims.of_int (81)) (Prims.of_int (94))
+                                      (Prims.of_int (127))
                                       (Prims.of_int (43)))))
                              (if
                                 FStar_Pervasives_Native.uu___is_None
@@ -622,17 +680,17 @@ let (check_tot_bind :
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.Checker.Bind.fst"
-                                                 (Prims.of_int (78))
+                                                 (Prims.of_int (86))
                                                  (Prims.of_int (50))
-                                                 (Prims.of_int (78))
+                                                 (Prims.of_int (86))
                                                  (Prims.of_int (56)))))
                                         (FStar_Sealed.seal
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.Checker.Bind.fst"
-                                                 (Prims.of_int (73))
+                                                 (Prims.of_int (81))
                                                  (Prims.of_int (94))
-                                                 (Prims.of_int (118))
+                                                 (Prims.of_int (127))
                                                  (Prims.of_int (43)))))
                                         (FStar_Tactics_Effect.lift_div_tac
                                            (fun uu___1 ->
@@ -655,17 +713,17 @@ let (check_tot_bind :
                                                           (Obj.magic
                                                              (FStar_Range.mk_range
                                                                 "Pulse.Checker.Bind.fst"
-                                                                (Prims.of_int (79))
+                                                                (Prims.of_int (87))
                                                                 (Prims.of_int (60))
-                                                                (Prims.of_int (92))
+                                                                (Prims.of_int (101))
                                                                 (Prims.of_int (106)))))
                                                        (FStar_Sealed.seal
                                                           (Obj.magic
                                                              (FStar_Range.mk_range
                                                                 "Pulse.Checker.Bind.fst"
-                                                                (Prims.of_int (78))
+                                                                (Prims.of_int (86))
                                                                 (Prims.of_int (59))
-                                                                (Prims.of_int (118))
+                                                                (Prims.of_int (127))
                                                                 (Prims.of_int (43)))))
                                                        (Obj.magic
                                                           (FStar_Tactics_Effect.tac_bind
@@ -673,17 +731,17 @@ let (check_tot_bind :
                                                                 (Obj.magic
                                                                    (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (82))
+                                                                    (Prims.of_int (90))
                                                                     (Prims.of_int (13))
-                                                                    (Prims.of_int (82))
+                                                                    (Prims.of_int (90))
                                                                     (Prims.of_int (24)))))
                                                              (FStar_Sealed.seal
                                                                 (Obj.magic
                                                                    (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (83))
+                                                                    (Prims.of_int (91))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (92))
+                                                                    (Prims.of_int (101))
                                                                     (Prims.of_int (106)))))
                                                              (FStar_Tactics_Effect.lift_div_tac
                                                                 (fun uu___2
@@ -708,26 +766,59 @@ let (check_tot_bind :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (87))
-                                                                    (Prims.of_int (32))
-                                                                    (Prims.of_int (87))
-                                                                    (Prims.of_int (51)))))
+                                                                    (Prims.of_int (95))
+                                                                    (Prims.of_int (27))
+                                                                    (Prims.of_int (95))
+                                                                    (Prims.of_int (46)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (86))
+                                                                    (Prims.of_int (94))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (92))
+                                                                    (Prims.of_int (101))
                                                                     (Prims.of_int (106)))))
                                                                     (Obj.magic
-                                                                    (Pulse_Checker_Pure.check_universe
+                                                                    (Pulse_Checker_Pure.check_tot_term
                                                                     g1 ty))
                                                                     (fun
                                                                     uu___3 ->
                                                                     (fun
                                                                     uu___3 ->
                                                                     match uu___3
+                                                                    with
+                                                                    | 
+                                                                    FStar_Pervasives.Mkdtuple3
+                                                                    (ty1,
+                                                                    uu___4,
+                                                                    uu___5)
+                                                                    ->
+                                                                    Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Bind.fst"
+                                                                    (Prims.of_int (96))
+                                                                    (Prims.of_int (32))
+                                                                    (Prims.of_int (96))
+                                                                    (Prims.of_int (51)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Bind.fst"
+                                                                    (Prims.of_int (95))
+                                                                    (Prims.of_int (49))
+                                                                    (Prims.of_int (101))
+                                                                    (Prims.of_int (106)))))
+                                                                    (Obj.magic
+                                                                    (Pulse_Checker_Pure.check_universe
+                                                                    g1 ty1))
+                                                                    (fun
+                                                                    uu___6 ->
+                                                                    (fun
+                                                                    uu___6 ->
+                                                                    match uu___6
                                                                     with
                                                                     | 
                                                                     Prims.Mkdtuple2
@@ -740,27 +831,27 @@ let (check_tot_bind :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (88))
+                                                                    (Prims.of_int (97))
                                                                     (Prims.of_int (38))
-                                                                    (Prims.of_int (88))
+                                                                    (Prims.of_int (97))
                                                                     (Prims.of_int (75)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (87))
+                                                                    (Prims.of_int (96))
                                                                     (Prims.of_int (54))
-                                                                    (Prims.of_int (92))
+                                                                    (Prims.of_int (101))
                                                                     (Prims.of_int (106)))))
                                                                     (Obj.magic
                                                                     (Pulse_Checker_Pure.check_term_with_expected_type
-                                                                    g1 e1 ty))
+                                                                    g1 e1 ty1))
                                                                     (fun
-                                                                    uu___4 ->
+                                                                    uu___7 ->
                                                                     FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
-                                                                    uu___5 ->
-                                                                    match uu___4
+                                                                    uu___8 ->
+                                                                    match uu___7
                                                                     with
                                                                     | 
                                                                     FStar_Pervasives.Mkdtuple3
@@ -770,10 +861,12 @@ let (check_tot_bind :
                                                                     ->
                                                                     FStar_Pervasives.Mkdtuple5
                                                                     (e11,
-                                                                    eff1, ty,
+                                                                    eff1,
+                                                                    ty1,
                                                                     (Prims.Mkdtuple2
                                                                     (u1, ())),
                                                                     ())))))
+                                                                    uu___6)))
                                                                     uu___3)))
                                                                   uu___2)))
                                                        (fun uu___2 ->
@@ -794,17 +887,17 @@ let (check_tot_bind :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (95))
+                                                                    (Prims.of_int (104))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (98))
+                                                                    (Prims.of_int (107))
                                                                     (Prims.of_int (21)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (98))
+                                                                    (Prims.of_int (107))
                                                                     (Prims.of_int (24))
-                                                                    (Prims.of_int (118))
+                                                                    (Prims.of_int (127))
                                                                     (Prims.of_int (43)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -832,17 +925,17 @@ let (check_tot_bind :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (102))
+                                                                    (Prims.of_int (111))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (102))
+                                                                    (Prims.of_int (111))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (98))
+                                                                    (Prims.of_int (107))
                                                                     (Prims.of_int (24))
-                                                                    (Prims.of_int (118))
+                                                                    (Prims.of_int (127))
                                                                     (Prims.of_int (43)))))
                                                                     (Obj.magic
                                                                     (Pulse_Checker_Pure.check_term_with_expected_type_and_effect
@@ -865,17 +958,17 @@ let (check_tot_bind :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (104))
+                                                                    (Prims.of_int (113))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (104))
+                                                                    (Prims.of_int (113))
                                                                     (Prims.of_int (17)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (104))
+                                                                    (Prims.of_int (113))
                                                                     (Prims.of_int (20))
-                                                                    (Prims.of_int (118))
+                                                                    (Prims.of_int (127))
                                                                     (Prims.of_int (43)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -891,17 +984,17 @@ let (check_tot_bind :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (106))
+                                                                    (Prims.of_int (115))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (106))
+                                                                    (Prims.of_int (115))
                                                                     (Prims.of_int (33)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (106))
+                                                                    (Prims.of_int (115))
                                                                     (Prims.of_int (38))
-                                                                    (Prims.of_int (118))
+                                                                    (Prims.of_int (127))
                                                                     (Prims.of_int (43)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -923,17 +1016,17 @@ let (check_tot_bind :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (107))
+                                                                    (Prims.of_int (116))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (107))
+                                                                    (Prims.of_int (116))
                                                                     (Prims.of_int (85)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (107))
+                                                                    (Prims.of_int (116))
                                                                     (Prims.of_int (88))
-                                                                    (Prims.of_int (118))
+                                                                    (Prims.of_int (127))
                                                                     (Prims.of_int (43)))))
                                                                     (Obj.magic
                                                                     (Pulse_Checker_Base.continuation_elaborator_with_let
@@ -951,17 +1044,17 @@ let (check_tot_bind :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (109))
+                                                                    (Prims.of_int (118))
                                                                     (Prims.of_int (11))
-                                                                    (Prims.of_int (109))
+                                                                    (Prims.of_int (118))
                                                                     (Prims.of_int (20)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (109))
-                                                                    (Prims.of_int (23))
                                                                     (Prims.of_int (118))
+                                                                    (Prims.of_int (23))
+                                                                    (Prims.of_int (127))
                                                                     (Prims.of_int (43)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -978,17 +1071,17 @@ let (check_tot_bind :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (110))
+                                                                    (Prims.of_int (119))
                                                                     (Prims.of_int (11))
-                                                                    (Prims.of_int (110))
+                                                                    (Prims.of_int (119))
                                                                     (Prims.of_int (39)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (110))
+                                                                    (Prims.of_int (119))
                                                                     (Prims.of_int (42))
-                                                                    (Prims.of_int (118))
+                                                                    (Prims.of_int (127))
                                                                     (Prims.of_int (43)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -1007,17 +1100,17 @@ let (check_tot_bind :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (112))
+                                                                    (Prims.of_int (121))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (112))
+                                                                    (Prims.of_int (121))
                                                                     (Prims.of_int (58)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (112))
+                                                                    (Prims.of_int (121))
                                                                     (Prims.of_int (61))
-                                                                    (Prims.of_int (118))
+                                                                    (Prims.of_int (127))
                                                                     (Prims.of_int (43)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -1034,17 +1127,17 @@ let (check_tot_bind :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (113))
+                                                                    (Prims.of_int (122))
                                                                     (Prims.of_int (9))
-                                                                    (Prims.of_int (116))
+                                                                    (Prims.of_int (125))
                                                                     (Prims.of_int (62)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (116))
+                                                                    (Prims.of_int (125))
                                                                     (Prims.of_int (65))
-                                                                    (Prims.of_int (118))
+                                                                    (Prims.of_int (127))
                                                                     (Prims.of_int (43)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1052,17 +1145,17 @@ let (check_tot_bind :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (114))
+                                                                    (Prims.of_int (123))
                                                                     (Prims.of_int (17))
-                                                                    (Prims.of_int (114))
+                                                                    (Prims.of_int (123))
                                                                     (Prims.of_int (46)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (114))
+                                                                    (Prims.of_int (123))
                                                                     (Prims.of_int (49))
-                                                                    (Prims.of_int (116))
+                                                                    (Prims.of_int (125))
                                                                     (Prims.of_int (62)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -1079,17 +1172,17 @@ let (check_tot_bind :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (115))
+                                                                    (Prims.of_int (124))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (115))
+                                                                    (Prims.of_int (124))
                                                                     (Prims.of_int (77)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (116))
+                                                                    (Prims.of_int (125))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (116))
+                                                                    (Prims.of_int (125))
                                                                     (Prims.of_int (62)))))
                                                                     (Obj.magic
                                                                     (check g'
@@ -1118,17 +1211,17 @@ let (check_tot_bind :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (117))
+                                                                    (Prims.of_int (126))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (117))
+                                                                    (Prims.of_int (126))
                                                                     (Prims.of_int (23)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (118))
+                                                                    (Prims.of_int (127))
                                                                     (Prims.of_int (2))
-                                                                    (Prims.of_int (118))
+                                                                    (Prims.of_int (127))
                                                                     (Prims.of_int (43)))))
                                                                     (Obj.magic
                                                                     (k

--- a/src/ocaml/plugin/generated/Pulse_Checker_Pure.ml
+++ b/src/ocaml/plugin/generated/Pulse_Checker_Pure.ml
@@ -304,118 +304,117 @@ let (rtb_universe_of :
                uu___)
 let (rtb_check_subtyping :
   Pulse_Typing_Env.env ->
-    FStar_Reflection_Types.env ->
-      FStar_Reflection_Types.term ->
-        FStar_Reflection_Types.term ->
-          (((unit, unit, unit) FStar_Tactics_Types.subtyping_token
-             FStar_Pervasives_Native.option * FStar_Tactics_Types.issues),
-            unit) FStar_Tactics_Effect.tac_repr)
+    Pulse_Syntax_Base.term ->
+      Pulse_Syntax_Base.term ->
+        (((unit, unit, unit) FStar_Tactics_Types.subtyping_token
+           FStar_Pervasives_Native.option * FStar_Tactics_Types.issues),
+          unit) FStar_Tactics_Effect.tac_repr)
   =
   fun g ->
-    fun f ->
-      fun t1 ->
-        fun t2 ->
-          FStar_Tactics_Effect.tac_bind
-            (FStar_Sealed.seal
-               (Obj.magic
-                  (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                     (Prims.of_int (39)) (Prims.of_int (2))
-                     (Prims.of_int (41)) (Prims.of_int (61)))))
-            (FStar_Sealed.seal
-               (Obj.magic
-                  (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                     (Prims.of_int (41)) (Prims.of_int (62))
-                     (Prims.of_int (43)) (Prims.of_int (5)))))
-            (Obj.magic
-               (debug g
-                  (fun uu___ ->
-                     FStar_Tactics_Effect.tac_bind
-                       (FStar_Sealed.seal
-                          (Obj.magic
-                             (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                                (Prims.of_int (41)) (Prims.of_int (39))
-                                (Prims.of_int (41)) (Prims.of_int (60)))))
-                       (FStar_Sealed.seal
-                          (Obj.magic
-                             (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                                (Prims.of_int (39)) (Prims.of_int (20))
-                                (Prims.of_int (41)) (Prims.of_int (60)))))
-                       (Obj.magic
-                          (FStar_Tactics_V2_Builtins.term_to_string t2))
-                       (fun uu___1 ->
-                          (fun uu___1 ->
-                             Obj.magic
-                               (FStar_Tactics_Effect.tac_bind
-                                  (FStar_Sealed.seal
-                                     (Obj.magic
-                                        (FStar_Range.mk_range
-                                           "Pulse.Checker.Pure.fst"
-                                           (Prims.of_int (39))
-                                           (Prims.of_int (20))
-                                           (Prims.of_int (41))
-                                           (Prims.of_int (60)))))
-                                  (FStar_Sealed.seal
-                                     (Obj.magic
-                                        (FStar_Range.mk_range
-                                           "Pulse.Checker.Pure.fst"
-                                           (Prims.of_int (39))
-                                           (Prims.of_int (20))
-                                           (Prims.of_int (41))
-                                           (Prims.of_int (60)))))
-                                  (Obj.magic
-                                     (FStar_Tactics_Effect.tac_bind
-                                        (FStar_Sealed.seal
-                                           (Obj.magic
-                                              (FStar_Range.mk_range
-                                                 "Pulse.Checker.Pure.fst"
-                                                 (Prims.of_int (40))
-                                                 (Prims.of_int (39))
-                                                 (Prims.of_int (40))
-                                                 (Prims.of_int (60)))))
-                                        (FStar_Sealed.seal
-                                           (Obj.magic
-                                              (FStar_Range.mk_range
-                                                 "FStar.Printf.fst"
-                                                 (Prims.of_int (121))
-                                                 (Prims.of_int (8))
-                                                 (Prims.of_int (123))
-                                                 (Prims.of_int (44)))))
-                                        (Obj.magic
-                                           (FStar_Tactics_V2_Builtins.term_to_string
-                                              t1))
-                                        (fun uu___2 ->
-                                           FStar_Tactics_Effect.lift_div_tac
-                                             (fun uu___3 ->
-                                                fun x ->
-                                                  Prims.strcat
-                                                    (Prims.strcat
-                                                       "Calling check_subtyping on "
-                                                       (Prims.strcat uu___2
-                                                          " <: "))
-                                                    (Prims.strcat x "")))))
-                                  (fun uu___2 ->
-                                     FStar_Tactics_Effect.lift_div_tac
-                                       (fun uu___3 -> uu___2 uu___1))))
-                            uu___1))))
-            (fun uu___ ->
-               (fun uu___ ->
-                  Obj.magic
-                    (FStar_Tactics_Effect.tac_bind
-                       (FStar_Sealed.seal
-                          (Obj.magic
-                             (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                                (Prims.of_int (42)) (Prims.of_int (12))
-                                (Prims.of_int (42)) (Prims.of_int (39)))))
-                       (FStar_Sealed.seal
-                          (Obj.magic
-                             (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                                (Prims.of_int (42)) (Prims.of_int (6))
-                                (Prims.of_int (42)) (Prims.of_int (9)))))
-                       (Obj.magic
-                          (FStar_Tactics_V2_Builtins.check_subtyping f t1 t2))
-                       (fun res ->
-                          FStar_Tactics_Effect.lift_div_tac
-                            (fun uu___1 -> res)))) uu___)
+    fun t1 ->
+      fun t2 ->
+        FStar_Tactics_Effect.tac_bind
+          (FStar_Sealed.seal
+             (Obj.magic
+                (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
+                   (Prims.of_int (39)) (Prims.of_int (2)) (Prims.of_int (41))
+                   (Prims.of_int (61)))))
+          (FStar_Sealed.seal
+             (Obj.magic
+                (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
+                   (Prims.of_int (41)) (Prims.of_int (62))
+                   (Prims.of_int (43)) (Prims.of_int (5)))))
+          (Obj.magic
+             (debug g
+                (fun uu___ ->
+                   FStar_Tactics_Effect.tac_bind
+                     (FStar_Sealed.seal
+                        (Obj.magic
+                           (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
+                              (Prims.of_int (41)) (Prims.of_int (39))
+                              (Prims.of_int (41)) (Prims.of_int (60)))))
+                     (FStar_Sealed.seal
+                        (Obj.magic
+                           (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
+                              (Prims.of_int (39)) (Prims.of_int (20))
+                              (Prims.of_int (41)) (Prims.of_int (60)))))
+                     (Obj.magic (Pulse_Syntax_Printer.term_to_string t2))
+                     (fun uu___1 ->
+                        (fun uu___1 ->
+                           Obj.magic
+                             (FStar_Tactics_Effect.tac_bind
+                                (FStar_Sealed.seal
+                                   (Obj.magic
+                                      (FStar_Range.mk_range
+                                         "Pulse.Checker.Pure.fst"
+                                         (Prims.of_int (39))
+                                         (Prims.of_int (20))
+                                         (Prims.of_int (41))
+                                         (Prims.of_int (60)))))
+                                (FStar_Sealed.seal
+                                   (Obj.magic
+                                      (FStar_Range.mk_range
+                                         "Pulse.Checker.Pure.fst"
+                                         (Prims.of_int (39))
+                                         (Prims.of_int (20))
+                                         (Prims.of_int (41))
+                                         (Prims.of_int (60)))))
+                                (Obj.magic
+                                   (FStar_Tactics_Effect.tac_bind
+                                      (FStar_Sealed.seal
+                                         (Obj.magic
+                                            (FStar_Range.mk_range
+                                               "Pulse.Checker.Pure.fst"
+                                               (Prims.of_int (40))
+                                               (Prims.of_int (39))
+                                               (Prims.of_int (40))
+                                               (Prims.of_int (60)))))
+                                      (FStar_Sealed.seal
+                                         (Obj.magic
+                                            (FStar_Range.mk_range
+                                               "FStar.Printf.fst"
+                                               (Prims.of_int (121))
+                                               (Prims.of_int (8))
+                                               (Prims.of_int (123))
+                                               (Prims.of_int (44)))))
+                                      (Obj.magic
+                                         (Pulse_Syntax_Printer.term_to_string
+                                            t1))
+                                      (fun uu___2 ->
+                                         FStar_Tactics_Effect.lift_div_tac
+                                           (fun uu___3 ->
+                                              fun x ->
+                                                Prims.strcat
+                                                  (Prims.strcat
+                                                     "Calling check_subtyping on "
+                                                     (Prims.strcat uu___2
+                                                        " <: "))
+                                                  (Prims.strcat x "")))))
+                                (fun uu___2 ->
+                                   FStar_Tactics_Effect.lift_div_tac
+                                     (fun uu___3 -> uu___2 uu___1)))) uu___1))))
+          (fun uu___ ->
+             (fun uu___ ->
+                Obj.magic
+                  (FStar_Tactics_Effect.tac_bind
+                     (FStar_Sealed.seal
+                        (Obj.magic
+                           (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
+                              (Prims.of_int (42)) (Prims.of_int (12))
+                              (Prims.of_int (42)) (Prims.of_int (74)))))
+                     (FStar_Sealed.seal
+                        (Obj.magic
+                           (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
+                              (Prims.of_int (42)) (Prims.of_int (6))
+                              (Prims.of_int (42)) (Prims.of_int (9)))))
+                     (Obj.magic
+                        (FStar_Tactics_V2_Builtins.check_subtyping
+                           (Pulse_Typing.elab_env g)
+                           (Pulse_Elaborate_Pure.elab_term t1)
+                           (Pulse_Elaborate_Pure.elab_term t2)))
+                     (fun res ->
+                        FStar_Tactics_Effect.lift_div_tac (fun uu___1 -> res))))
+               uu___)
 let (rtb_instantiate_implicits :
   Pulse_Typing_Env.env ->
     FStar_Reflection_Types.env ->
@@ -3257,3 +3256,175 @@ let (is_non_informative :
                        (fun uu___1 ->
                           FStar_Tactics_Effect.lift_div_tac
                             (fun uu___2 -> ropt)))) uu___)
+let (check_subtyping :
+  Pulse_Typing_Env.env ->
+    Pulse_Syntax_Base.term ->
+      Pulse_Syntax_Base.term ->
+        ((unit, unit, unit) Pulse_Typing.subtyping_token, unit)
+          FStar_Tactics_Effect.tac_repr)
+  =
+  fun g ->
+    fun t1 ->
+      fun t2 ->
+        FStar_Tactics_V2_Derived.with_policy FStar_Tactics_Types.SMTSync
+          (fun uu___ ->
+             FStar_Tactics_Effect.tac_bind
+               (FStar_Sealed.seal
+                  (Obj.magic
+                     (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
+                        (Prims.of_int (361)) (Prims.of_int (20))
+                        (Prims.of_int (361)) (Prims.of_int (47)))))
+               (FStar_Sealed.seal
+                  (Obj.magic
+                     (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
+                        (Prims.of_int (360)) (Prims.of_int (34))
+                        (Prims.of_int (370)) (Prims.of_int (31)))))
+               (Obj.magic (rtb_check_subtyping g t1 t2))
+               (fun uu___1 ->
+                  (fun uu___1 ->
+                     match uu___1 with
+                     | (res, issues) ->
+                         Obj.magic
+                           (FStar_Tactics_Effect.tac_bind
+                              (FStar_Sealed.seal
+                                 (Obj.magic
+                                    (FStar_Range.mk_range
+                                       "Pulse.Checker.Pure.fst"
+                                       (Prims.of_int (362))
+                                       (Prims.of_int (2))
+                                       (Prims.of_int (362))
+                                       (Prims.of_int (21)))))
+                              (FStar_Sealed.seal
+                                 (Obj.magic
+                                    (FStar_Range.mk_range
+                                       "Pulse.Checker.Pure.fst"
+                                       (Prims.of_int (363))
+                                       (Prims.of_int (2))
+                                       (Prims.of_int (370))
+                                       (Prims.of_int (31)))))
+                              (Obj.magic
+                                 (FStar_Tactics_V2_Builtins.log_issues issues))
+                              (fun uu___2 ->
+                                 (fun uu___2 ->
+                                    match res with
+                                    | FStar_Pervasives_Native.Some tok ->
+                                        Obj.magic
+                                          (Obj.repr
+                                             (FStar_Tactics_Effect.lift_div_tac
+                                                (fun uu___3 -> tok)))
+                                    | FStar_Pervasives_Native.None ->
+                                        Obj.magic
+                                          (Obj.repr
+                                             (FStar_Tactics_Effect.tac_bind
+                                                (FStar_Sealed.seal
+                                                   (Obj.magic
+                                                      (FStar_Range.mk_range
+                                                         "Pulse.Checker.Pure.fst"
+                                                         (Prims.of_int (367))
+                                                         (Prims.of_int (6))
+                                                         (Prims.of_int (370))
+                                                         (Prims.of_int (31)))))
+                                                (FStar_Sealed.seal
+                                                   (Obj.magic
+                                                      (FStar_Range.mk_range
+                                                         "Pulse.Checker.Pure.fst"
+                                                         (Prims.of_int (366))
+                                                         (Prims.of_int (4))
+                                                         (Prims.of_int (370))
+                                                         (Prims.of_int (31)))))
+                                                (Obj.magic
+                                                   (FStar_Tactics_Effect.tac_bind
+                                                      (FStar_Sealed.seal
+                                                         (Obj.magic
+                                                            (FStar_Range.mk_range
+                                                               "Pulse.Checker.Pure.fst"
+                                                               (Prims.of_int (370))
+                                                               (Prims.of_int (9))
+                                                               (Prims.of_int (370))
+                                                               (Prims.of_int (30)))))
+                                                      (FStar_Sealed.seal
+                                                         (Obj.magic
+                                                            (FStar_Range.mk_range
+                                                               "Pulse.Checker.Pure.fst"
+                                                               (Prims.of_int (367))
+                                                               (Prims.of_int (6))
+                                                               (Prims.of_int (370))
+                                                               (Prims.of_int (31)))))
+                                                      (Obj.magic
+                                                         (Pulse_Syntax_Printer.term_to_string
+                                                            t2))
+                                                      (fun uu___3 ->
+                                                         (fun uu___3 ->
+                                                            Obj.magic
+                                                              (FStar_Tactics_Effect.tac_bind
+                                                                 (FStar_Sealed.seal
+                                                                    (
+                                                                    Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Pure.fst"
+                                                                    (Prims.of_int (367))
+                                                                    (Prims.of_int (6))
+                                                                    (Prims.of_int (370))
+                                                                    (Prims.of_int (31)))))
+                                                                 (FStar_Sealed.seal
+                                                                    (
+                                                                    Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Pure.fst"
+                                                                    (Prims.of_int (367))
+                                                                    (Prims.of_int (6))
+                                                                    (Prims.of_int (370))
+                                                                    (Prims.of_int (31)))))
+                                                                 (Obj.magic
+                                                                    (
+                                                                    FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Pure.fst"
+                                                                    (Prims.of_int (369))
+                                                                    (Prims.of_int (9))
+                                                                    (Prims.of_int (369))
+                                                                    (Prims.of_int (30)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "FStar.Printf.fst"
+                                                                    (Prims.of_int (121))
+                                                                    (Prims.of_int (8))
+                                                                    (Prims.of_int (123))
+                                                                    (Prims.of_int (44)))))
+                                                                    (Obj.magic
+                                                                    (Pulse_Syntax_Printer.term_to_string
+                                                                    t1))
+                                                                    (fun
+                                                                    uu___4 ->
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___5 ->
+                                                                    fun x ->
+                                                                    Prims.strcat
+                                                                    (Prims.strcat
+                                                                    "Could not prove subtyping of "
+                                                                    (Prims.strcat
+                                                                    uu___4
+                                                                    " and "))
+                                                                    (Prims.strcat
+                                                                    x "")))))
+                                                                 (fun uu___4
+                                                                    ->
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___5 ->
+                                                                    uu___4
+                                                                    uu___3))))
+                                                           uu___3)))
+                                                (fun uu___3 ->
+                                                   (fun uu___3 ->
+                                                      Obj.magic
+                                                        (Pulse_Typing_Env.fail
+                                                           g
+                                                           (FStar_Pervasives_Native.Some
+                                                              (t1.Pulse_Syntax_Base.range1))
+                                                           uu___3)) uu___3))))
+                                   uu___2))) uu___1))

--- a/src/ocaml/plugin/generated/Pulse_Typing.ml
+++ b/src/ocaml/plugin/generated/Pulse_Typing.ml
@@ -804,6 +804,8 @@ let uu___is_CT_STGhost uu___2 uu___1 uu___ uu___3 =
   match uu___3 with | CT_STGhost _ -> true | _ -> false
 type ('g, 't) prop_validity =
   (unit, unit) FStar_Tactics_V2_Builtins.prop_validity_token
+type ('g, 't1, 't2) subtyping_token =
+  (unit, unit, unit) FStar_Tactics_Types.subtyping_token
 let (readback_binding :
   FStar_Reflection_V2_Data.binding -> Pulse_Typing_Env.binding) =
   fun b ->


### PR DESCRIPTION
Without this, any kind of complex type in an annotations would fail, as the check was being done over unelaborated terms.