### PR TITLE
Generalizing rewrite and a new rewrite each

### DIFF
--- a/lib/steel/pulse/Pulse.Checker.AssertWithBinders.fst
+++ b/lib/steel/pulse/Pulse.Checker.AssertWithBinders.fst
@@ -131,68 +131,89 @@ let check_unfoldable g (v:term) : T.Tac unit =
                         but %s is a primitive term that cannot be folded or unfolded"
                         (P.term_to_string v))
 
-let rewrite_one (p: (term & term)) (t:term) : term = t 
-let visit_and_rewrite (p: list (R.term & R.term)) (t:term) : T.Tac term =
+let visit_and_rewrite (p: (R.term & R.term)) (t:term) : T.Tac term =
   let open FStar.Reflection.V2.TermEq in
+  let lhs, rhs = p in
   let visitor (t:R.term) : T.Tac R.term =
-    match List.Tot.tryFind (fun (x, _) -> term_eq x t) p with
-    | None -> t
-    | Some (_, t') -> t'
+    if term_eq t lhs then rhs else t
   in
-  let rec aux (t:term) : T.Tac term =
-    match t.t with
-    | Tm_Emp
-    | Tm_VProp
-    | Tm_Inames
-    | Tm_EmpInames
-    | Tm_Unknown  -> t
-    | Tm_Pure p -> { t with t = Tm_Pure (aux p) }
-    | Tm_Star l r ->  { t with t = Tm_Star (aux l) (aux r) }
-    | Tm_ExistsSL u b body -> { t with t = Tm_ExistsSL u { b with binder_ty=aux b.binder_ty} (aux body) }
-    | Tm_ForallSL u b body -> { t with t = Tm_ForallSL u { b with binder_ty=aux b.binder_ty} (aux body) }
-    | Tm_FStar h -> 
-      let h = FStar.Tactics.Visit.visit_tm visitor h in
-      assume (is_host_term h);
-      { t with t=Tm_FStar h }
-  in
-  aux t
-
-let visit_and_rewrite_conjuncts (p: list (R.term & R.term)) (t:term) : T.Tac (term & term) =
-  let tms = Pulse.Typing.Combinators.vprop_as_list t in
-  let tms = 
-    L.flatten (
-      T.map
-        (fun t -> 
-          let s = visit_and_rewrite p t in
-          if eq_tm s t then [] else [(t, s)])
-        tms
-    )
-  in
-  let lhs, rhs = L.unzip tms in
-  let lhs = Pulse.Typing.Combinators.list_as_vprop lhs in
-  let rhs = Pulse.Typing.Combinators.list_as_vprop rhs in
-  lhs, rhs
+  match R.inspect_ln lhs with
+  | R.Tv_Var n -> (
+    let nv = R.inspect_namedv n in
+    assume (is_host_term rhs);
+    subst_term t [NT nv.uniq { t = Tm_FStar rhs; range = t.range }]
+    ) 
+  | _ ->
+    let rec aux (t:term) : T.Tac term =
+      match t.t with
+      | Tm_Emp
+      | Tm_VProp
+      | Tm_Inames
+      | Tm_EmpInames
+      | Tm_Unknown  -> t
+      | Tm_Pure p -> { t with t = Tm_Pure (aux p) }
+      | Tm_Star l r ->  { t with t = Tm_Star (aux l) (aux r) }
+      | Tm_ExistsSL u b body -> { t with t = Tm_ExistsSL u { b with binder_ty=aux b.binder_ty} (aux body) }
+      | Tm_ForallSL u b body -> { t with t = Tm_ForallSL u { b with binder_ty=aux b.binder_ty} (aux body) }
+      | Tm_FStar h -> 
+        let h = FStar.Tactics.Visit.visit_tm visitor h in
+        assume (is_host_term h);
+        { t with t=Tm_FStar h }
+    in
+    aux t
+    
+let visit_and_rewrite_conjuncts (p: (R.term & R.term)) (tms:list term) : T.Tac (list term) =
+  T.map (visit_and_rewrite p) tms
 
 
-let rec as_subst (p : list (term & term)) (out:list subst_elt)
+let visit_and_rewrite_conjuncts_all (p: list (R.term & R.term)) (goal:term) : T.Tac (term & term) =
+  let tms = Pulse.Typing.Combinators.vprop_as_list goal in
+  let tms' = T.fold_left (fun tms p -> visit_and_rewrite_conjuncts p tms) tms p in
+  assume (L.length tms' == L.length tms);
+  let lhs, rhs =
+    T.fold_left2 
+      (fun (lhs, rhs) t t' ->  
+        if eq_tm t t' then lhs, rhs
+        else (t::lhs, t'::rhs))
+      ([], [])
+      tms tms'
+  in
+  Pulse.Typing.Combinators.list_as_vprop lhs,
+  Pulse.Typing.Combinators.list_as_vprop rhs
+  
+
+let disjoint (dom:list var) (cod:Set.set var) =
+  L.for_all (fun d -> not (Set.mem d cod)) dom
+
+let rec as_subst (p : list (term & term)) 
+                 (out:list subst_elt)
+                 (domain:list var)
+                 (codomain:Set.set var)
   : option (list subst_elt) =
   match p with
-  | [] -> Some out
+  | [] -> 
+    if disjoint domain codomain
+    then Some out
+    else None
   | (e1, e2)::p -> (
     match e1.t with
     | Tm_FStar e1 -> ( 
       match R.inspect_ln e1 with
       | R.Tv_Var n -> (
         let nv = R.inspect_namedv n in
-        as_subst p (NT nv.uniq e2::out)
+        as_subst p 
+          (NT nv.uniq e2::out) 
+          (nv.uniq ::domain )
+          (Set.union codomain (freevars e2))
       ) 
       | _ -> None
     )
     | _ -> None
   )
 
+
 let rewrite_all (g:env) (p: list (term & term)) (t:term) : T.Tac (term & term) =
-  match as_subst p [] with
+  match as_subst p [] [] Set.empty with
   | Some s ->
     t, subst_term t s
   | _ ->
@@ -203,7 +224,7 @@ let rewrite_all (g:env) (p: list (term & term)) (t:term) : T.Tac (term & term) =
           elab_term (fst (Pulse.Checker.Pure.instantiate_term_implicits g e2)))
         p
     in
-    let lhs, rhs = visit_and_rewrite_conjuncts p t in
+    let lhs, rhs = visit_and_rewrite_conjuncts_all p t in
     debug_log g (fun _ -> Printf.sprintf "Rewrote %s to %s" (P.term_to_string lhs) (P.term_to_string rhs));
     lhs, rhs
 
@@ -262,10 +283,22 @@ let check
 
   match hint_type with
   | RENAME { pairs; goal } ->
-
     let st = check_renaming g pre st in
     check g pre pre_typing post_hint res_ppname st
-    
+
+  | REWRITE { t1; t2 } -> (
+    match bs with
+    | [] -> 
+      let t = { st with term = Tm_Rewrite { t1; t2 } } in
+      check g pre pre_typing post_hint res_ppname 
+          { st with term = Tm_Bind { binder = as_binder tm_unit; head = t; body } } 
+    | _ ->
+      let t = { st with term = Tm_Rewrite { t1; t2 } } in
+      let body = { st with term = Tm_Bind { binder = as_binder tm_unit; head = t; body } } in
+      let st = { st with term = Tm_ProofHintWithBinders { hint_type = ASSERT { p = t1 }; binders = bs; t = body } } in
+      check g pre pre_typing post_hint res_ppname st
+  )
+  
   | ASSERT { p = v } ->
     let bs = infer_binder_types g bs v in
     let (| uvs, v_opened, body_opened |) = open_binders g bs (mk_env (fstar_env g)) v body in
@@ -273,7 +306,9 @@ let check
     let (| v, d |) = PC.check_vprop (push_env g uvs) v in
     let (| g1, nts, pre', k_frame |) = Prover.prove pre_typing uvs d in
     let (| x, x_ty, pre'', g2, k |) =
-      check g1 (tm_star (PS.nt_subst_term v nts) pre') (magic ()) post_hint res_ppname (PS.nt_subst_st_term body nts) in
+      check g1 (tm_star (PS.nt_subst_term v nts) pre')
+              (magic ()) 
+              post_hint res_ppname (PS.nt_subst_st_term body nts) in
     (| x, x_ty, pre'', g2, k_elab_trans k_frame k |)
 
 

--- a/lib/steel/pulse/Pulse.Checker.AssertWithBinders.fst
+++ b/lib/steel/pulse/Pulse.Checker.AssertWithBinders.fst
@@ -147,6 +147,9 @@ let check
   let Tm_ProofHintWithBinders { hint_type; binders=bs; t=body } = st.term in
 
   match hint_type with
+  | RENAME _ ->
+    T.fail "Renaming not yet handled"
+    
   | ASSERT { p = v } ->
     let bs = infer_binder_types g bs v in
     let (| uvs, v_opened, body_opened |) = open_binders g bs (mk_env (fstar_env g)) v body in

--- a/lib/steel/pulse/Pulse.Checker.AssertWithBinders.fst
+++ b/lib/steel/pulse/Pulse.Checker.AssertWithBinders.fst
@@ -132,27 +132,80 @@ let check_unfoldable g (v:term) : T.Tac unit =
                         (P.term_to_string v))
 
 let rewrite_one (p: (term & term)) (t:term) : term = t 
+let visit_and_rewrite (p: list (R.term & R.term)) (t:term) : T.Tac term =
+  let open FStar.Reflection.V2.TermEq in
+  let visitor (t:R.term) : T.Tac R.term =
+    match List.Tot.tryFind (fun (x, _) -> term_eq x t) p with
+    | None -> t
+    | Some (_, t') -> t'
+  in
+  let rec aux (t:term) : T.Tac term =
+    match t.t with
+    | Tm_Emp
+    | Tm_VProp
+    | Tm_Inames
+    | Tm_EmpInames
+    | Tm_Unknown  -> t
+    | Tm_Pure p -> { t with t = Tm_Pure (aux p) }
+    | Tm_Star l r ->  { t with t = Tm_Star (aux l) (aux r) }
+    | Tm_ExistsSL u b body -> { t with t = Tm_ExistsSL u { b with binder_ty=aux b.binder_ty} (aux body) }
+    | Tm_ForallSL u b body -> { t with t = Tm_ForallSL u { b with binder_ty=aux b.binder_ty} (aux body) }
+    | Tm_FStar h -> 
+      let h = FStar.Tactics.Visit.visit_tm visitor h in
+      assume (is_host_term h);
+      { t with t=Tm_FStar h }
+  in
+  aux t
 
-let rewrite_all (p: list (term & term)) (t:term) : option term =
-  let rec as_subst (p : list (term & term)) (out:list subst_elt) =
-    match p with
-    | [] -> Some out
-    | (e1, e2)::p -> (
-      match e1.t with
-      | Tm_FStar e1 -> ( 
-        match R.inspect_ln e1 with
-        | R.Tv_Var n -> (
-          let nv = R.inspect_namedv n in
-          as_subst p (NT nv.uniq e2::out)
-        ) 
-        | _ -> None
-      )
-      | _ -> None
+let visit_and_rewrite_conjuncts (p: list (R.term & R.term)) (t:term) : T.Tac (term & term) =
+  let tms = Pulse.Typing.Combinators.vprop_as_list t in
+  let tms = 
+    L.flatten (
+      T.map
+        (fun t -> 
+          let s = visit_and_rewrite p t in
+          if eq_tm s t then [] else [(t, s)])
+        tms
     )
   in
+  let lhs, rhs = L.unzip tms in
+  let lhs = Pulse.Typing.Combinators.list_as_vprop lhs in
+  let rhs = Pulse.Typing.Combinators.list_as_vprop rhs in
+  lhs, rhs
+
+
+let rec as_subst (p : list (term & term)) (out:list subst_elt)
+  : option (list subst_elt) =
+  match p with
+  | [] -> Some out
+  | (e1, e2)::p -> (
+    match e1.t with
+    | Tm_FStar e1 -> ( 
+      match R.inspect_ln e1 with
+      | R.Tv_Var n -> (
+        let nv = R.inspect_namedv n in
+        as_subst p (NT nv.uniq e2::out)
+      ) 
+      | _ -> None
+    )
+    | _ -> None
+  )
+
+let rewrite_all (g:env) (p: list (term & term)) (t:term) : T.Tac (term & term) =
   match as_subst p [] with
-  | Some s -> Some (subst_term t s)
-  | _ -> None
+  | Some s ->
+    t, subst_term t s
+  | _ ->
+    let p : list (R.term & R.term) = 
+      T.map 
+        (fun (e1, e2) -> 
+          elab_term (fst (Pulse.Checker.Pure.instantiate_term_implicits g e1)),
+          elab_term (fst (Pulse.Checker.Pure.instantiate_term_implicits g e2)))
+        p
+    in
+    let lhs, rhs = visit_and_rewrite_conjuncts p t in
+    debug_log g (fun _ -> Printf.sprintf "Rewrote %s to %s" (P.term_to_string lhs) (P.term_to_string rhs));
+    lhs, rhs
 
 let rec check_renaming 
     (g:env)
@@ -180,18 +233,15 @@ let rec check_renaming
 
   | [], None ->
     // if there is no goal, take the goal to be the full current pre
-    check_renaming g pre
-      {st with term = Tm_ProofHintWithBinders { ht with hint_type = RENAME { pairs; goal = Some pre } }}
-
+    let lhs, rhs = rewrite_all g pairs pre in
+    let t = { st with term = Tm_Rewrite { t1 = lhs; t2 = rhs } } in
+    { st with term = Tm_Bind { binder = as_binder tm_unit; head = t; body } }
 
   | [], Some goal -> (
-      match rewrite_all pairs goal with
-      | Some goal' -> 
-        let t = { st with term = Tm_Rewrite { t1 = goal; t2 = goal' } } in
-        { st with term = Tm_Bind { binder = as_binder tm_unit; head = t; body } }
-
-      | None ->
-        fail g (Some st.range) "Failed to rewrite the goal with the given renaming pairs"
+      let goal, _ = PC.instantiate_term_implicits g goal in
+      let lhs, rhs = rewrite_all g pairs goal in
+      let t = { st with term = Tm_Rewrite { t1 = lhs; t2 = rhs } } in
+      { st with term = Tm_Bind { binder = as_binder tm_unit; head = t; body } }
   )
 
 

--- a/lib/steel/pulse/Pulse.Checker.fst
+++ b/lib/steel/pulse/Pulse.Checker.fst
@@ -81,20 +81,22 @@ let instantiate_unknown_witnesses (g:env) (t:st_term { Tm_IntroExists? t.term })
   | _ ->
     let e2 = {t with term=Tm_IntroExists { p; witnesses=new_ws }} in
     let e1 =
-      let hint_type = ASSERT in
+      let hint_type = ASSERT { p = opened_p } in
       let binders = [] in
-      let v = opened_p in
-      {term=Tm_ProofHintWithBinders { hint_type;binders;v;t=e2 }; range=t.range} in
+      {term=Tm_ProofHintWithBinders { hint_type;binders;t=e2 }; range=t.range} in
     
-    let t = L.fold_right (fun new_name (e:st_term { Tm_ProofHintWithBinders? e.term }) ->
-      let (ppname, x), ty = new_name in
-      let e = close_st_term' e x 0 in
-      match e.term with
-      | Tm_ProofHintWithBinders {hint_type;binders;v;t} ->
-        let new_binder = {binder_ty=ty; binder_ppname=ppname} in
-        let t' = Tm_ProofHintWithBinders {hint_type;binders=new_binder::binders;v;t} in
-        {e with term=t'}
-    ) new_names e1 in
+    let t = 
+      L.fold_right
+        (fun new_name (e:st_term { Tm_ProofHintWithBinders? e.term }) ->
+          let (ppname, x), ty = new_name in
+          let e = close_st_term' e x 0 in
+          match e.term with
+          | Tm_ProofHintWithBinders {hint_type;binders;t} ->
+            let new_binder = {binder_ty=ty; binder_ppname=ppname} in
+            let t' = Tm_ProofHintWithBinders {hint_type;binders=new_binder::binders;t} in
+            {e with term=t'})
+        new_names
+        e1 in
     Some t
 
 let rec transform_to_unary_intro_exists (g:env) (t:term) (ws:list term)

--- a/lib/steel/pulse/Pulse.Syntax.Base.fst
+++ b/lib/steel/pulse/Pulse.Syntax.Base.fst
@@ -141,6 +141,9 @@ let eq_hint_type (ht1 ht2:proof_hint_type)
     | RENAME { pairs=ps1; goal=p1 }, RENAME { pairs=ps2; goal=p2 } ->
       eq_list (fun (x1, y1) (x2, y2) -> eq_tm x1 x2 && eq_tm y1 y2) ps1 ps2 &&
       eq_opt eq_tm p1 p2
+    | REWRITE { t1; t2 }, REWRITE { t1=s1; t2=s2 } ->
+      eq_tm t1 s1 &&
+      eq_tm t2 s2
     | _ -> false
 
 let rec eq_st_term (t1 t2:st_term) 

--- a/lib/steel/pulse/Pulse.Syntax.Base.fst
+++ b/lib/steel/pulse/Pulse.Syntax.Base.fst
@@ -214,6 +214,10 @@ let rec eq_st_term (t1 t2:st_term)
       eq_tm l1 l2 &&
       eq_tm r1 r2
 
+    | Tm_Rename { pairs=p1 },
+      Tm_Rename { pairs=p2 } ->
+      eq_list_dec t1 t2 (fun (x1, y1) (x2, y2) -> eq_tm x1 x2 && eq_tm y1 y2) p1 p2
+
     | Tm_Admit { ctag=c1; u=u1; typ=t1; post=post1 }, 
       Tm_Admit { ctag=c2; u=u2; typ=t2; post=post2 } ->
       c1 = c2 &&

--- a/lib/steel/pulse/Pulse.Syntax.Base.fst
+++ b/lib/steel/pulse/Pulse.Syntax.Base.fst
@@ -225,11 +225,10 @@ let rec eq_st_term (t1 t2:st_term)
       eq_tm t1 t2 &&
       eq_tm_opt post1 post2
       
-    | Tm_ProofHintWithBinders { hint_type=ht1; binders=bs1; t=t1; v=v1 },
-      Tm_ProofHintWithBinders { hint_type=ht2; binders=bs2; t=t2; v=v2 } ->
-      ht1 = ht2 &&
+    | Tm_ProofHintWithBinders { hint_type=ht1; binders=bs1; t=t1 },
+      Tm_ProofHintWithBinders { hint_type=ht2; binders=bs2; t=t2 } ->
+      eq_hint_type ht1 ht2 &&
       eq_list eq_binder bs1 bs2 &&
-      eq_tm v1 v2 &&
       eq_st_term t1 t2
 
     | _ -> false
@@ -239,3 +238,14 @@ and eq_branch (b1 b2 : pattern & st_term)
   = let (p1, e1) = b1 in
     let (p2, e2) = b2 in
     eq_pattern p1 p2 && eq_st_term e1 e2
+
+and eq_hint_type (ht1 ht2:proof_hint_type)
+  : b:bool { b <==> (ht1 == ht2) }
+  = match ht1, ht2 with
+    | ASSERT { p=p1 }, ASSERT { p=p2 } ->
+      eq_tm p1 p2
+    | FOLD { names=ns1; p=p1}, FOLD { names=ns2; p=p2 }
+    | UNFOLD { names=ns1; p=p1}, UNFOLD { names=ns2; p=p2 } ->
+      eq_opt (eq_list (fun n1 n2 -> n1 = n2)) ns1 ns2 &&
+      eq_tm p1 p2
+    | _ -> false

--- a/lib/steel/pulse/Pulse.Syntax.Base.fsti
+++ b/lib/steel/pulse/Pulse.Syntax.Base.fsti
@@ -148,6 +148,24 @@ let ctag_of_comp_st (c:comp_st) : ctag =
   | C_STAtomic _ _ -> STT_Atomic
   | C_STGhost _ _ -> STT_Ghost
 
+noeq
+type proof_hint_type =
+  | ASSERT {
+      p:vprop
+    }
+  | FOLD { 
+      names:option (list string);
+      p:vprop;
+    }
+  | UNFOLD {
+      names:option (list string);
+      p:vprop
+    }
+  | RENAME { //rename e as e' [in p]
+      pairs:list (term & term);
+      goal: option term
+    }
+
 (* terms with STT types *)
 [@@ no_auto_projectors]
 noeq
@@ -222,16 +240,13 @@ type st_term' =
       t1:term;
       t2:term;
     } 
-  | Tm_Rename {
-      pairs:list (term & term);
-    }
   | Tm_Admit {
       ctag:ctag;
       u:universe;
       typ:term;
       post:option term;
     }
-  | Tm_ProofHintWithBinders { // assert (R.pts_to x ?p ?v) in body
+  | Tm_ProofHintWithBinders {
       hint_type:proof_hint_type;
       binders:list binder;
       t:st_term
@@ -244,18 +259,6 @@ and st_term = {
 
 and branch = pattern & st_term
 
-and proof_hint_type =
-  | ASSERT {
-      p:vprop
-    }
-  | FOLD { 
-      names:option (list string);
-      p:vprop;
-    }
-  | UNFOLD {
-      names:option (list string);
-      p:vprop
-    }
 
 let null_binder (t:term) : binder =
   {binder_ty=t;binder_ppname=ppname_default}

--- a/lib/steel/pulse/Pulse.Syntax.Base.fsti
+++ b/lib/steel/pulse/Pulse.Syntax.Base.fsti
@@ -148,11 +148,6 @@ let ctag_of_comp_st (c:comp_st) : ctag =
   | C_STAtomic _ _ -> STT_Atomic
   | C_STGhost _ _ -> STT_Ghost
 
-type proof_hint_type =
-  | ASSERT
-  | FOLD of option (list string)
-  | UNFOLD of option (list string)
-
 (* terms with STT types *)
 [@@ no_auto_projectors]
 noeq
@@ -239,7 +234,6 @@ type st_term' =
   | Tm_ProofHintWithBinders { // assert (R.pts_to x ?p ?v) in body
       hint_type:proof_hint_type;
       binders:list binder;
-      v:vprop;
       t:st_term
   }
 
@@ -249,6 +243,19 @@ and st_term = {
 } 
 
 and branch = pattern & st_term
+
+and proof_hint_type =
+  | ASSERT {
+      p:vprop
+    }
+  | FOLD { 
+      names:option (list string);
+      p:vprop;
+    }
+  | UNFOLD {
+      names:option (list string);
+      p:vprop
+    }
 
 let null_binder (t:term) : binder =
   {binder_ty=t;binder_ppname=ppname_default}

--- a/lib/steel/pulse/Pulse.Syntax.Base.fsti
+++ b/lib/steel/pulse/Pulse.Syntax.Base.fsti
@@ -165,6 +165,10 @@ type proof_hint_type =
       pairs:list (term & term);
       goal: option term
     }
+  | REWRITE {
+      t1:vprop;
+      t2:vprop;
+    }
 
 (* terms with STT types *)
 [@@ no_auto_projectors]

--- a/lib/steel/pulse/Pulse.Syntax.Base.fsti
+++ b/lib/steel/pulse/Pulse.Syntax.Base.fsti
@@ -227,6 +227,9 @@ type st_term' =
       t1:term;
       t2:term;
     } 
+  | Tm_Rename {
+      pairs:list (term & term);
+    }
   | Tm_Admit {
       ctag:ctag;
       u:universe;

--- a/lib/steel/pulse/Pulse.Syntax.Builder.fst
+++ b/lib/steel/pulse/Pulse.Syntax.Builder.fst
@@ -18,6 +18,7 @@ let tm_while invariant condition condition_var body = Tm_While { invariant; cond
 let tm_par pre1 body1 post1 pre2 body2 post2 = Tm_Par { pre1; body1; post1; pre2; body2; post2 }
 let tm_with_local binder initializer body = Tm_WithLocal { binder; initializer; body }
 let tm_rewrite t1 t2 = Tm_Rewrite { t1; t2 }
+let tm_rename pairs = Tm_Rename { pairs }
 let tm_admit ctag u typ post = Tm_Admit { ctag; u; typ; post }
 let with_range t r = { term = t; range = r}
 let tm_assert_with_binders bs v t = Tm_ProofHintWithBinders { hint_type=ASSERT; binders=bs; v; t }

--- a/lib/steel/pulse/Pulse.Syntax.Builder.fst
+++ b/lib/steel/pulse/Pulse.Syntax.Builder.fst
@@ -26,3 +26,4 @@ let mk_assert_hint_type p = ASSERT { p }
 let mk_unfold_hint_type names p = UNFOLD { names; p }
 let mk_fold_hint_type names p = FOLD { names; p }
 let mk_rename_hint_type pairs goal = RENAME { pairs; goal }
+let mk_rewrite_hint_type t1 t2 = REWRITE { t1; t2 }

--- a/lib/steel/pulse/Pulse.Syntax.Builder.fst
+++ b/lib/steel/pulse/Pulse.Syntax.Builder.fst
@@ -18,7 +18,11 @@ let tm_while invariant condition condition_var body = Tm_While { invariant; cond
 let tm_par pre1 body1 post1 pre2 body2 post2 = Tm_Par { pre1; body1; post1; pre2; body2; post2 }
 let tm_with_local binder initializer body = Tm_WithLocal { binder; initializer; body }
 let tm_rewrite t1 t2 = Tm_Rewrite { t1; t2 }
-let tm_rename pairs = Tm_Rename { pairs }
+let tm_rename pairs t = Tm_ProofHintWithBinders { hint_type = RENAME { pairs; goal=None}; binders=[]; t}
 let tm_admit ctag u typ post = Tm_Admit { ctag; u; typ; post }
 let with_range t r = { term = t; range = r}
 let tm_assert_with_binders bs p t = Tm_ProofHintWithBinders { hint_type=ASSERT { p }; binders=bs; t }
+let mk_assert_hint_type p = ASSERT { p }
+let mk_unfold_hint_type names p = UNFOLD { names; p }
+let mk_fold_hint_type names p = FOLD { names; p }
+let mk_rename_hint_type pairs goal = RENAME { pairs; goal }

--- a/lib/steel/pulse/Pulse.Syntax.Builder.fst
+++ b/lib/steel/pulse/Pulse.Syntax.Builder.fst
@@ -21,4 +21,4 @@ let tm_rewrite t1 t2 = Tm_Rewrite { t1; t2 }
 let tm_rename pairs = Tm_Rename { pairs }
 let tm_admit ctag u typ post = Tm_Admit { ctag; u; typ; post }
 let with_range t r = { term = t; range = r}
-let tm_assert_with_binders bs v t = Tm_ProofHintWithBinders { hint_type=ASSERT; binders=bs; v; t }
+let tm_assert_with_binders bs p t = Tm_ProofHintWithBinders { hint_type=ASSERT { p }; binders=bs; t }

--- a/lib/steel/pulse/Pulse.Syntax.Naming.fst
+++ b/lib/steel/pulse/Pulse.Syntax.Naming.fst
@@ -73,6 +73,22 @@ let rec close_open_inverse_list' (t:list term)
       close_open_inverse' hd x i;
       close_open_inverse_list' tl x i
 
+let open_term_pairs' (t:list (term * term)) (v:term) (i:index) =
+  subst_term_pairs t [DT i v]
+
+let close_term_pairs' (t:list (term * term)) (x:var) (i:index) =
+  subst_term_pairs t [ND x i]
+
+let rec close_open_inverse_pairs' (t:list (term * term))
+                                  (x:var { ~(x `Set.mem` freevars_pairs t) })
+                                  (i:index)
+  : Lemma (ensures close_term_pairs' (open_term_pairs' t (U.term_of_no_name_var x) i) x i == t)
+  = match t with
+    | [] -> ()
+    | (hd1, hd2)::tl ->
+      close_open_inverse' hd1 x i;
+      close_open_inverse' hd2 x i;
+      close_open_inverse_pairs' tl x i
 
 let rec close_open_inverse_st'  (t:st_term) 
                                 (x:var { ~(x `Set.mem` freevars_st t) } )
@@ -147,6 +163,9 @@ let rec close_open_inverse_st'  (t:st_term)
       close_open_inverse' t1 x i;
       close_open_inverse' t2 x i
 
+    | Tm_Rename { pairs } ->
+      close_open_inverse_pairs' pairs x i
+      
     | Tm_Admit { typ; post } ->
       close_open_inverse' typ x i;
       close_open_inverse_opt' post x (i + 1)

--- a/lib/steel/pulse/Pulse.Syntax.Naming.fst
+++ b/lib/steel/pulse/Pulse.Syntax.Naming.fst
@@ -93,6 +93,9 @@ let close_open_inverse_proof_hint_type' (ht:proof_hint_type)
     | ASSERT { p }
     | FOLD { p }
     | UNFOLD { p } -> close_open_inverse' p x i
+    | RENAME { pairs; goal } ->
+      close_open_inverse_pairs' pairs x i;
+      close_open_inverse_opt' goal x i
 
 
 let rec close_open_inverse_st'  (t:st_term) 
@@ -168,9 +171,6 @@ let rec close_open_inverse_st'  (t:st_term)
       close_open_inverse' t1 x i;
       close_open_inverse' t2 x i
 
-    | Tm_Rename { pairs } ->
-      close_open_inverse_pairs' pairs x i
-      
     | Tm_Admit { typ; post } ->
       close_open_inverse' typ x i;
       close_open_inverse_opt' post x (i + 1)

--- a/lib/steel/pulse/Pulse.Syntax.Naming.fst
+++ b/lib/steel/pulse/Pulse.Syntax.Naming.fst
@@ -96,6 +96,9 @@ let close_open_inverse_proof_hint_type' (ht:proof_hint_type)
     | RENAME { pairs; goal } ->
       close_open_inverse_pairs' pairs x i;
       close_open_inverse_opt' goal x i
+    | REWRITE { t1; t2 } ->
+      close_open_inverse' t1 x i;
+      close_open_inverse' t2 x i
 
 
 let rec close_open_inverse_st'  (t:st_term) 

--- a/lib/steel/pulse/Pulse.Syntax.Naming.fst
+++ b/lib/steel/pulse/Pulse.Syntax.Naming.fst
@@ -73,11 +73,6 @@ let rec close_open_inverse_list' (t:list term)
       close_open_inverse' hd x i;
       close_open_inverse_list' tl x i
 
-let open_term_pairs' (t:list (term * term)) (v:term) (i:index) =
-  subst_term_pairs t [DT i v]
-
-let close_term_pairs' (t:list (term * term)) (x:var) (i:index) =
-  subst_term_pairs t [ND x i]
 
 let rec close_open_inverse_pairs' (t:list (term * term))
                                   (x:var { ~(x `Set.mem` freevars_pairs t) })
@@ -89,6 +84,16 @@ let rec close_open_inverse_pairs' (t:list (term * term))
       close_open_inverse' hd1 x i;
       close_open_inverse' hd2 x i;
       close_open_inverse_pairs' tl x i
+
+let close_open_inverse_proof_hint_type' (ht:proof_hint_type)
+                                        (x:var { ~(x `Set.mem` freevars_proof_hint ht) })
+                                        (i:index)
+  : Lemma (ensures close_proof_hint' (open_proof_hint' ht (U.term_of_no_name_var x) i) x i == ht)
+  = match ht with
+    | ASSERT { p }
+    | FOLD { p }
+    | UNFOLD { p } -> close_open_inverse' p x i
+
 
 let rec close_open_inverse_st'  (t:st_term) 
                                 (x:var { ~(x `Set.mem` freevars_st t) } )
@@ -170,9 +175,9 @@ let rec close_open_inverse_st'  (t:st_term)
       close_open_inverse' typ x i;
       close_open_inverse_opt' post x (i + 1)
 
-    | Tm_ProofHintWithBinders { binders; v; t} ->
+    | Tm_ProofHintWithBinders { binders; hint_type; t} ->
       let n = L.length binders in
-      close_open_inverse' v x (i + n);
+      close_open_inverse_proof_hint_type' hint_type x (i + n);
       close_open_inverse_st' t x (i + n)
       
 let close_open_inverse (t:term) (x:var { ~(x `Set.mem` freevars t) } )

--- a/lib/steel/pulse/Pulse.Syntax.Naming.fsti
+++ b/lib/steel/pulse/Pulse.Syntax.Naming.fsti
@@ -68,6 +68,8 @@ let freevars_proof_hint (ht:proof_hint_type) : Set.set var =
   | UNFOLD { p } -> freevars p
   | RENAME { pairs; goal } ->
     Set.union (freevars_pairs pairs) (freevars_term_opt goal)
+  | REWRITE { t1; t2 } ->
+    Set.union (freevars t1) (freevars t2)
 
 let rec freevars_st (t:st_term)
   : Set.set var
@@ -200,6 +202,9 @@ let ln_proof_hint' (ht:proof_hint_type) (i:int) : bool =
   | RENAME { pairs; goal } ->
     ln_terms' pairs i &&
     ln_opt' goal i
+  | REWRITE { t1; t2 } ->
+    ln' t1 i &&
+    ln' t2 i
 
 let rec ln_st' (t:st_term) (i:int)
   : Tot bool (decreases t)
@@ -419,6 +424,8 @@ let subst_proof_hint (ht:proof_hint_type) (ss:subst)
     | FOLD { names; p } -> FOLD { names; p=subst_term p ss }
     | RENAME { pairs; goal } -> RENAME { pairs=subst_term_pairs pairs ss;
                                          goal=subst_term_opt goal ss }
+    | REWRITE { t1; t2 } -> REWRITE { t1=subst_term t1 ss;
+                                      t2=subst_term t2 ss }
 
 let open_term_pairs' (t:list (term * term)) (v:term) (i:index) =
   subst_term_pairs t [DT i v]

--- a/lib/steel/pulse/Pulse.Syntax.Printer.fst
+++ b/lib/steel/pulse/Pulse.Syntax.Printer.fst
@@ -235,13 +235,6 @@ let rec st_term_to_string' (level:string) (t:st_term)
         (term_to_string t1)
         (term_to_string t2)
 
-    | Tm_Rename { pairs } ->
-      sprintf "rename %s"
-        (String.concat ", "
-          (T.map
-            (fun (x, y) -> sprintf "%s as %s" (term_to_string x) (term_to_string y))
-            pairs))
-
     | Tm_WithLocal { binder; initializer; body } ->
       sprintf "let mut %s = %s;\n%s%s"
         (binder_to_string binder)
@@ -276,6 +269,15 @@ let rec st_term_to_string' (level:string) (t:st_term)
         | ASSERT { p } -> "assert", term_to_string p
         | UNFOLD { names; p } -> sprintf "unfold%s" (names_to_string names), term_to_string p
         | FOLD { names; p } -> sprintf "fold%s" (names_to_string names), term_to_string p
+        | RENAME { pairs; goal } ->
+          sprintf "rename %s"
+            (String.concat ", "
+              (T.map
+                (fun (x, y) -> sprintf "%s as %s" (term_to_string x) (term_to_string y))
+              pairs)),
+            (match goal with
+            | None -> ""
+            | Some t -> sprintf " in %s" (term_to_string t))
       in
       sprintf "%s %s %s; %s" with_prefix ht p
         (st_term_to_string' level t)
@@ -320,7 +322,6 @@ let tag_of_st_term (t:st_term) =
   | Tm_Par _ -> "Tm_Par"
   | Tm_WithLocal _ -> "Tm_WithLocal"
   | Tm_Rewrite _ -> "Tm_Rewrite"
-  | Tm_Rename _ -> "Tm_Rename"
   | Tm_Admit _ -> "Tm_Admit"
   | Tm_ProofHintWithBinders _ -> "Tm_ProofHintWithBinders"
 
@@ -346,7 +347,6 @@ let rec print_st_head (t:st_term)
   | Tm_Admit _ -> "Admit"
   | Tm_Par _ -> "Par"
   | Tm_Rewrite _ -> "Rewrite"
-  | Tm_Rename _ -> "Rename"
   | Tm_WithLocal _ -> "WithLocal"
   | Tm_STApp { head = p } -> print_head p
   | Tm_IntroPure _ -> "IntroPure"
@@ -373,7 +373,6 @@ let rec print_skel (t:st_term) =
   | Tm_Admit _ -> "Admit"
   | Tm_Par _ -> "Par"
   | Tm_Rewrite _ -> "Rewrite"
-  | Tm_Rename _ -> "Rename"
   | Tm_WithLocal _ -> "WithLocal"
   | Tm_STApp { head = p } -> print_head p
   | Tm_IntroPure _ -> "IntroPure"

--- a/lib/steel/pulse/Pulse.Syntax.Printer.fst
+++ b/lib/steel/pulse/Pulse.Syntax.Printer.fst
@@ -232,8 +232,15 @@ let rec st_term_to_string' (level:string) (t:st_term)
 
     | Tm_Rewrite { t1; t2 } ->
        sprintf "rewrite %s %s"
-	       (term_to_string t1)
-               (term_to_string t2)
+        (term_to_string t1)
+        (term_to_string t2)
+
+    | Tm_Rename { pairs } ->
+      sprintf "rename %s"
+        (String.concat ", "
+          (T.map
+            (fun (x, y) -> sprintf "%s as %s" (term_to_string x) (term_to_string y))
+            pairs))
 
     | Tm_WithLocal { binder; initializer; body } ->
       sprintf "let mut %s = %s;\n%s%s"
@@ -302,6 +309,7 @@ let tag_of_st_term (t:st_term) =
   | Tm_Par _ -> "Tm_Par"
   | Tm_WithLocal _ -> "Tm_WithLocal"
   | Tm_Rewrite _ -> "Tm_Rewrite"
+  | Tm_Rename _ -> "Tm_Rename"
   | Tm_Admit _ -> "Tm_Admit"
   | Tm_ProofHintWithBinders _ -> "Tm_ProofHintWithBinders"
 
@@ -327,6 +335,7 @@ let rec print_st_head (t:st_term)
   | Tm_Admit _ -> "Admit"
   | Tm_Par _ -> "Par"
   | Tm_Rewrite _ -> "Rewrite"
+  | Tm_Rename _ -> "Rename"
   | Tm_WithLocal _ -> "WithLocal"
   | Tm_STApp { head = p } -> print_head p
   | Tm_IntroPure _ -> "IntroPure"
@@ -353,6 +362,7 @@ let rec print_skel (t:st_term) =
   | Tm_Admit _ -> "Admit"
   | Tm_Par _ -> "Par"
   | Tm_Rewrite _ -> "Rewrite"
+  | Tm_Rename _ -> "Rename"
   | Tm_WithLocal _ -> "WithLocal"
   | Tm_STApp { head = p } -> print_head p
   | Tm_IntroPure _ -> "IntroPure"

--- a/lib/steel/pulse/Pulse.Syntax.Printer.fst
+++ b/lib/steel/pulse/Pulse.Syntax.Printer.fst
@@ -270,7 +270,7 @@ let rec st_term_to_string' (level:string) (t:st_term)
         | UNFOLD { names; p } -> sprintf "unfold%s" (names_to_string names), term_to_string p
         | FOLD { names; p } -> sprintf "fold%s" (names_to_string names), term_to_string p
         | RENAME { pairs; goal } ->
-          sprintf "rename %s"
+          sprintf "rewrite each %s"
             (String.concat ", "
               (T.map
                 (fun (x, y) -> sprintf "%s as %s" (term_to_string x) (term_to_string y))
@@ -278,6 +278,8 @@ let rec st_term_to_string' (level:string) (t:st_term)
             (match goal with
             | None -> ""
             | Some t -> sprintf " in %s" (term_to_string t))
+        | REWRITE { t1; t2 } ->
+          sprintf "rewrite %s as %s" (term_to_string t1) (term_to_string t2), ""
       in
       sprintf "%s %s %s; %s" with_prefix ht p
         (st_term_to_string' level t)

--- a/lib/steel/pulse/Pulse.Typing.FV.fst
+++ b/lib/steel/pulse/Pulse.Typing.FV.fst
@@ -111,6 +111,9 @@ let freevars_close_proof_hint' (ht:proof_hint_type) (x:var) (i:index)
     | RENAME { pairs; goal } ->
       freevars_close_term_pairs' pairs x i;
       freevars_close_term_opt' goal x i
+    | REWRITE { t1; t2 } ->
+      freevars_close_term' t1 x i;
+      freevars_close_term' t2 x i
 
 // Needs a bit more rlimit sometimes. Also splitting is too expensive
 #push-options "--z3rlimit 20 --split_queries no"

--- a/lib/steel/pulse/Pulse.Typing.FV.fst
+++ b/lib/steel/pulse/Pulse.Typing.FV.fst
@@ -108,6 +108,9 @@ let freevars_close_proof_hint' (ht:proof_hint_type) (x:var) (i:index)
     | FOLD { p }
     | UNFOLD { p } ->
       freevars_close_term' p x i
+    | RENAME { pairs; goal } ->
+      freevars_close_term_pairs' pairs x i;
+      freevars_close_term_opt' goal x i
 
 // Needs a bit more rlimit sometimes. Also splitting is too expensive
 #push-options "--z3rlimit 20 --split_queries no"
@@ -172,9 +175,6 @@ let rec freevars_close_st_term' (t:st_term) (x:var) (i:index)
     | Tm_Rewrite { t1; t2 } ->
       freevars_close_term' t1 x i;
       freevars_close_term' t2 x i
-
-    | Tm_Rename { pairs } ->
-      freevars_close_term_pairs' pairs x i
 
     | Tm_WithLocal { binder; initializer; body } ->
       freevars_close_term' binder.binder_ty x i;

--- a/lib/steel/pulse/Pulse.Typing.LN.fst
+++ b/lib/steel/pulse/Pulse.Typing.LN.fst
@@ -133,6 +133,9 @@ let open_proof_hint_ln (t:proof_hint_type) (x:term) (i:index)
     | RENAME { pairs; goal } ->
       open_term_ln_pairs pairs x i;
       open_term_ln_opt' goal x i
+    | REWRITE { t1; t2 } ->
+      open_term_ln' t1 x i;
+      open_term_ln' t2 x i
 
 let rec open_st_term_ln' (e:st_term)
                          (x:term)
@@ -356,6 +359,9 @@ let ln_weakening_proof_hint (t:proof_hint_type) (i j:int)
     | RENAME { pairs; goal } ->
       ln_weakening_pairs pairs i j;
       ln_weakening_opt goal i j
+    | REWRITE { t1; t2 } ->
+      ln_weakening t1 i j;
+      ln_weakening t2 i j
 
 let rec ln_weakening_st (t:st_term) (i j:int)
   : Lemma
@@ -542,6 +548,9 @@ let open_proof_hint_ln_inv (ht:proof_hint_type) (x:term { ln x }) (i:index)
     | RENAME { pairs; goal } ->
       open_term_ln_inv_pairs pairs x i;
       open_term_ln_inv_opt' goal x i
+    | REWRITE { t1; t2 } ->
+      open_term_ln_inv' t1 x i;
+      open_term_ln_inv' t2 x i
 
 #push-options "--z3rlimit_factor 2 --fuel 2 --ifuel 2"
 let rec open_term_ln_inv_st' (t:st_term)
@@ -730,6 +739,9 @@ let close_proof_hint_ln (ht:proof_hint_type) (v:var) (i:index)
     | RENAME { pairs; goal } ->
       close_term_ln_pairs pairs v i;
       close_term_ln_opt' goal v i
+    | REWRITE { t1; t2 } ->
+      close_term_ln' t1 v i;
+      close_term_ln' t2 v i
 
 let rec close_st_term_ln' (t:st_term) (x:var) (i:index)
   : Lemma

--- a/lib/steel/pulse/Pulse.Typing.LN.fst
+++ b/lib/steel/pulse/Pulse.Typing.LN.fst
@@ -130,6 +130,9 @@ let open_proof_hint_ln (t:proof_hint_type) (x:term) (i:index)
     | FOLD { p }
     | UNFOLD { p } ->
       open_term_ln' p x i
+    | RENAME { pairs; goal } ->
+      open_term_ln_pairs pairs x i;
+      open_term_ln_opt' goal x i
 
 let rec open_st_term_ln' (e:st_term)
                          (x:term)
@@ -198,9 +201,6 @@ let rec open_st_term_ln' (e:st_term)
     | Tm_Rewrite { t1; t2 } ->
       open_term_ln' t1 x i;
       open_term_ln' t2 x i
-
-    | Tm_Rename { pairs } ->
-      open_term_ln_pairs pairs x i
 
     | Tm_WithLocal { binder; initializer; body } ->
       open_term_ln' binder.binder_ty x i;
@@ -353,6 +353,9 @@ let ln_weakening_proof_hint (t:proof_hint_type) (i j:int)
     | FOLD { p }
     | UNFOLD { p } ->
       ln_weakening p i j 
+    | RENAME { pairs; goal } ->
+      ln_weakening_pairs pairs i j;
+      ln_weakening_opt goal i j
 
 let rec ln_weakening_st (t:st_term) (i j:int)
   : Lemma
@@ -415,9 +418,6 @@ let rec ln_weakening_st (t:st_term) (i j:int)
     | Tm_Rewrite { t1; t2 } ->
       ln_weakening t1 i j;
       ln_weakening t2 i j
-
-    | Tm_Rename { pairs } ->
-      ln_weakening_pairs pairs i j
 
     | Tm_WithLocal { initializer; body } ->
       ln_weakening initializer i j;
@@ -539,6 +539,9 @@ let open_proof_hint_ln_inv (ht:proof_hint_type) (x:term { ln x }) (i:index)
     | FOLD { p }
     | UNFOLD { p } ->
       open_term_ln_inv' p x i
+    | RENAME { pairs; goal } ->
+      open_term_ln_inv_pairs pairs x i;
+      open_term_ln_inv_opt' goal x i
 
 #push-options "--z3rlimit_factor 2 --fuel 2 --ifuel 2"
 let rec open_term_ln_inv_st' (t:st_term)
@@ -604,9 +607,6 @@ let rec open_term_ln_inv_st' (t:st_term)
     | Tm_Rewrite { t1; t2 } ->
       open_term_ln_inv' t1 x i;
       open_term_ln_inv' t2 x i
-
-    | Tm_Rename { pairs } ->
-      open_term_ln_inv_pairs pairs x i
 
     | Tm_WithLocal { binder; initializer; body } ->
       open_term_ln_inv' binder.binder_ty x i;
@@ -727,6 +727,9 @@ let close_proof_hint_ln (ht:proof_hint_type) (v:var) (i:index)
     | FOLD { p }
     | UNFOLD { p } ->
       close_term_ln' p v i
+    | RENAME { pairs; goal } ->
+      close_term_ln_pairs pairs v i;
+      close_term_ln_opt' goal v i
 
 let rec close_st_term_ln' (t:st_term) (x:var) (i:index)
   : Lemma
@@ -789,9 +792,6 @@ let rec close_st_term_ln' (t:st_term) (x:var) (i:index)
     | Tm_Rewrite { t1; t2 } ->
       close_term_ln' t1 x i;
       close_term_ln' t2 x i
-
-    | Tm_Rename { pairs } ->
-      close_term_ln_pairs pairs x i
       
     | Tm_WithLocal { binder; initializer; body } ->
       close_term_ln' binder.binder_ty x i;

--- a/share/steel/examples/pulse/ZetaHashAccumulator.fst
+++ b/share/steel/examples/pulse/ZetaHashAccumulator.fst
@@ -227,7 +227,7 @@ fn package_core (acc:hash_value_buf) (ctr:ref U32.t)
           pure (h == mk_ha_core acc ctr)
 {
    let core = mk_ha_core acc ctr;
-   rename acc as core.acc, ctr as core.ctr;
+   rewrite each acc as core.acc, ctr as core.ctr;
    fold_ha_val_core core;
    core
 }
@@ -292,7 +292,7 @@ fn package (acc:hash_value_buf) (ctr:ref U32.t) (tmp:hash_value_buf) (dummy:dumm
           pure (h == mk_ha (mk_ha_core acc ctr) tmp dummy)
 {
    let ha = mk_ha (mk_ha_core acc ctr) tmp dummy;
-   rename acc as ha.core.acc, ctr as ha.core.ctr,
+   rewrite each acc as ha.core.acc, ctr as ha.core.ctr,
           tmp as ha.tmp, dummy as ha.dummy;
    fold_ha_val ha;
    ha
@@ -470,10 +470,10 @@ fn add (ha:ha) (input:hashable_buffer) (l:SZ.t)
    let ha' = package_core ha.tmp ctr;
    let v = aggregate ha.core ha';
    with w. unfold (ha_val_core ha' w);
-   rename ha'.acc as ha.tmp;
+   rewrite each ha'.acc as ha.tmp;
    with w. unfold (ha_val_core ha.core w);
    fold_ha_val ha;
-   rename ha'.ctr as ctr;
+   rewrite each ha'.ctr as ctr;
    v
 }
 ```

--- a/share/steel/examples/pulse/ZetaHashAccumulator.fst
+++ b/share/steel/examples/pulse/ZetaHashAccumulator.fst
@@ -451,6 +451,7 @@ fn compare (b1 b2:ha)
 //    the hash of the input
 // And then aggregate these two ha_cores into the first one
 // And then to repackage it as an ha
+#push-options "--debug ZetaHashAccumulator --print_implicits --debug_level with_binders"
 ```pulse
 fn add (ha:ha) (input:hashable_buffer) (l:SZ.t)
        (#s:(s:erased bytes {SZ.v l <= Seq.length s /\  SZ.v l <= blake2_max_input_length}))
@@ -469,18 +470,10 @@ fn add (ha:ha) (input:hashable_buffer) (l:SZ.t)
    let ha' = package_core ha.tmp ctr;
    let v = aggregate ha.core ha';
    with w. unfold (ha_val_core ha' w);
-   // would be nice to write this as
-   // rename ha'.acc as ha.tmp
-   // Or, at least, `with w. rewrite ... `
-   // Rather than having to write an assert and then a rewrite
-   with w. assert (A.pts_to ha'.acc w);
-   rewrite (A.pts_to ha'.acc w)
-        as (A.pts_to ha.tmp w); 
+   rename ha'.acc as ha.tmp;
    with w. unfold (ha_val_core ha.core w);
    fold_ha_val ha;
-   with w. assert (pts_to ha'.ctr w);
-   rewrite (pts_to ha'.ctr w)
-        as (pts_to ctr w);
+   rename ha'.ctr as ctr;
    v
 }
 ```

--- a/share/steel/examples/pulse/ZetaHashAccumulator.fst
+++ b/share/steel/examples/pulse/ZetaHashAccumulator.fst
@@ -227,13 +227,7 @@ fn package_core (acc:hash_value_buf) (ctr:ref U32.t)
           pure (h == mk_ha_core acc ctr)
 {
    let core = mk_ha_core acc ctr;
-   // It would be nice to have a "rename" primitive
-   // So we could write something like
-   // rename acc as core.acc, ctr as core.ctr;
-   rewrite (A.pts_to acc vacc)
-        as  (A.pts_to core.acc vacc);    
-   rewrite (pts_to ctr 'vctr)
-        as  (pts_to core.ctr 'vctr);
+   rename acc as core.acc, ctr as core.ctr;
    fold_ha_val_core core;
    core
 }
@@ -298,14 +292,8 @@ fn package (acc:hash_value_buf) (ctr:ref U32.t) (tmp:hash_value_buf) (dummy:dumm
           pure (h == mk_ha (mk_ha_core acc ctr) tmp dummy)
 {
    let ha = mk_ha (mk_ha_core acc ctr) tmp dummy;
-   rewrite (A.pts_to acc vacc)
-        as  (A.pts_to ha.core.acc vacc);    
-   rewrite (pts_to ctr 'vctr)
-        as  (pts_to ha.core.ctr 'vctr);
-   rewrite (A.pts_to tmp vtmp)
-        as  (A.pts_to ha.tmp vtmp);
-   rewrite (A.pts_to dummy (Seq.create 1 0uy))
-        as  (A.pts_to ha.dummy (Seq.create 1 0uy));
+   rename acc as ha.core.acc, ctr as ha.core.ctr,
+          tmp as ha.tmp, dummy as ha.dummy;
    fold_ha_val ha;
    ha
 }

--- a/share/steel/examples/pulse/bug-reports/Records.fst
+++ b/share/steel/examples/pulse/bug-reports/Records.fst
@@ -95,6 +95,24 @@ fn alloc_rec_alt (v1 v2:U8.t)
   r
 }
 ```
+
+//Here's yet another way, a bit more explicit
+```pulse
+fn alloc_rec_alt_alt (v1 v2:U8.t)
+  requires emp
+  returns r:rec2
+  ensures rec_perm r (mk_rec_repr v1 v2)
+{
+  let r1 = alloc v1;
+  let r2 = alloc v2; 
+  let r = mk_rec2 r1 r2;
+  with w1 w2.
+    rewrite each r1 as r.r1, r2 as r.r2 in 
+      (R.pts_to r1 w1 ** R.pts_to r2 w2);
+  fold_rec_perm r;
+  r
+}
+```
 //Some alternate ways to do it, useful test cases
 
 // helpers 
@@ -160,10 +178,9 @@ fn explicit_unfold_slightly_better_witness_taking_and_fold (r:rec2) (#v:Ghost.er
         R.pts_to r.r2 v.v2);
 
   r.r2 := 0uy;
-  with v2_. assert (R.pts_to r.r2 v2_);
-
-  rewrite (R.pts_to r.r1 v.v1 **
-           R.pts_to r.r2 v2_)
+  with v2_. 
+   rewrite (R.pts_to r.r1 v.v1 **
+            R.pts_to r.r2 v2_)
     as    (rec_perm r (rec_repr_with_v2 v v2_));
 
   ()

--- a/share/steel/examples/pulse/bug-reports/Records.fst
+++ b/share/steel/examples/pulse/bug-reports/Records.fst
@@ -80,6 +80,21 @@ fn alloc_rec (v1 v2:U8.t)
 }
 ```
 
+//Here's another more compact way, using rename
+```pulse
+fn alloc_rec_alt (v1 v2:U8.t)
+  requires emp
+  returns r:rec2
+  ensures rec_perm r (mk_rec_repr v1 v2)
+{
+  let r1 = alloc v1;
+  let r2 = alloc v2; 
+  let r = mk_rec2 r1 r2;
+  rename r1 as r.r1, r2 as r.r2;
+  fold_rec_perm r;
+  r
+}
+```
 //Some alternate ways to do it, useful test cases
 
 // helpers 

--- a/share/steel/examples/pulse/bug-reports/Records.fst
+++ b/share/steel/examples/pulse/bug-reports/Records.fst
@@ -90,7 +90,7 @@ fn alloc_rec_alt (v1 v2:U8.t)
   let r1 = alloc v1;
   let r2 = alloc v2; 
   let r = mk_rec2 r1 r2;
-  rename r1 as r.r1, r2 as r.r2;
+  rewrite each r1 as r.r1, r2 as r.r2;
   fold_rec_perm r;
   r
 }

--- a/src/ocaml/plugin/PulseSyntaxWrapper.ml
+++ b/src/ocaml/plugin/PulseSyntaxWrapper.ml
@@ -154,6 +154,9 @@ let tm_par p1 p2 q1 q2 b1 b2 r : st_term =
 let tm_rewrite p1 p2 r : st_term =
   PSB.(with_range (tm_rewrite p1 p2) r)
 
+let tm_rename ps r : st_term = failwith ""
+(*  PSB.(with_range (tm_rename ps) r) *)
+
 let tm_admit r : st_term =
   PSB.(with_range (tm_admit STT u_zero (tm_unknown r) None) r)
   

--- a/src/ocaml/plugin/PulseSyntaxWrapper.ml
+++ b/src/ocaml/plugin/PulseSyntaxWrapper.ml
@@ -142,7 +142,7 @@ let mk_assert_hint_type vp = PSB.mk_assert_hint_type vp
 let mk_unfold_hint_type names vp = PSB.mk_unfold_hint_type names vp
 let mk_fold_hint_type names vp = PSB.mk_fold_hint_type names vp
 let mk_rename_hint_type pairs goal = PSB.mk_rename_hint_type pairs goal
-
+let mk_rewrite_hint_type p1 p2 = PSB.mk_rewrite_hint_type p1 p2
 
 let tm_proof_hint_with_binders (ht:_) (binders: binder list)  (s:st_term) r : st_term =
   PSB.(with_range (Tm_ProofHintWithBinders { hint_type=ht;

--- a/src/ocaml/plugin/PulseSyntaxWrapper.ml
+++ b/src/ocaml/plugin/PulseSyntaxWrapper.ml
@@ -136,17 +136,18 @@ let trans_ns = function
   | None -> None
   | Some l -> Some (List.map FStar_Ident.string_of_lid l)
 
-let trans_hint_type (ht:PulseSugar.hint_type) =
-  match ht with
-  | PulseSugar.ASSERT -> Pulse_Syntax_Base.ASSERT
-  | PulseSugar.UNFOLD ns -> Pulse_Syntax_Base.UNFOLD (trans_ns ns)
-  | PulseSugar.FOLD ns -> Pulse_Syntax_Base.FOLD (trans_ns ns)
+type hint_type = Pulse_Syntax_Base.proof_hint_type
 
-let tm_proof_hint_with_binders (ht:PulseSugar.hint_type) (binders: binder list) (p:term) (s:st_term) r : st_term =
-  PSB.(with_range (Tm_ProofHintWithBinders { hint_type=trans_hint_type ht;
-                                            binders;
-                                            v=p;
-                                            t3=s }) r)
+let mk_assert_hint_type vp = PSB.mk_assert_hint_type vp
+let mk_unfold_hint_type names vp = PSB.mk_unfold_hint_type names vp
+let mk_fold_hint_type names vp = PSB.mk_fold_hint_type names vp
+let mk_rename_hint_type pairs goal = PSB.mk_rename_hint_type pairs goal
+
+
+let tm_proof_hint_with_binders (ht:_) (binders: binder list)  (s:st_term) r : st_term =
+  PSB.(with_range (Tm_ProofHintWithBinders { hint_type=ht;
+                                             binders;
+                                             t3=s }) r)
 
 let tm_par p1 p2 q1 q2 b1 b2 r : st_term =
   PSB.(with_range (tm_par p1 b1 q1 p2 b2 q2) r)
@@ -220,3 +221,4 @@ let bvs_as_subst bvs =
     [] bvs
 let subst_term s t = Pulse_Syntax_Naming.subst_term t s
 let subst_st_term s t = Pulse_Syntax_Naming.subst_st_term t s
+let subst_proof_hint s t = Pulse_Syntax_Naming.subst_proof_hint t s

--- a/src/ocaml/plugin/Pulse_Parser.ml
+++ b/src/ocaml/plugin/Pulse_Parser.ml
@@ -15,6 +15,7 @@ let rewrite_token (tok:FP.token)
     | IDENT "while" -> PP.WHILE
     | IDENT "fn" -> PP.FN
     | IDENT "parallel" -> PP.PARALLEL
+    | IDENT "rename" -> PP.RENAME
     | IDENT "rewrite" -> PP.REWRITE
     | IDENT "fold" -> PP.FOLD
     | IDENT "atomic" -> PP.ATOMIC

--- a/src/ocaml/plugin/Pulse_Parser.ml
+++ b/src/ocaml/plugin/Pulse_Parser.ml
@@ -15,7 +15,7 @@ let rewrite_token (tok:FP.token)
     | IDENT "while" -> PP.WHILE
     | IDENT "fn" -> PP.FN
     | IDENT "parallel" -> PP.PARALLEL
-    | IDENT "rename" -> PP.RENAME
+    | IDENT "each" -> PP.EACH
     | IDENT "rewrite" -> PP.REWRITE
     | IDENT "fold" -> PP.FOLD
     | IDENT "atomic" -> PP.ATOMIC

--- a/src/ocaml/plugin/generated/PulseDesugar.ml
+++ b/src/ocaml/plugin/generated/PulseDesugar.ml
@@ -768,6 +768,16 @@ let (desugar_hint_type :
                     let uu___2 =
                       PulseSyntaxWrapper.mk_rename_hint_type pairs1 goal1 in
                     return uu___2))
+      | PulseSugar.REWRITE (t1, t2) ->
+          let uu___ = desugar_vprop env t1 in
+          op_let_Question uu___
+            (fun t11 ->
+               let uu___1 = desugar_vprop env t2 in
+               op_let_Question uu___1
+                 (fun t21 ->
+                    let uu___2 =
+                      PulseSyntaxWrapper.mk_rewrite_hint_type t11 t21 in
+                    return uu___2))
 let (desugar_datacon : env_t -> FStar_Ident.lid -> PulseSyntaxWrapper.fv err)
   =
   fun env ->

--- a/src/ocaml/plugin/generated/PulseDesugar.ml
+++ b/src/ocaml/plugin/generated/PulseDesugar.ml
@@ -975,6 +975,23 @@ let rec (desugar_stmt :
                       PulseSyntaxWrapper.tm_rewrite p11 p21
                         s.PulseSugar.range1 in
                     return uu___2))
+      | PulseSugar.Rename { PulseSugar.pairs = pairs;_} ->
+          let uu___ =
+            map_err
+              (fun uu___1 ->
+                 match uu___1 with
+                 | (x, y) ->
+                     let uu___2 = desugar_term env x in
+                     op_let_Question uu___2
+                       (fun x1 ->
+                          let uu___3 = desugar_term env y in
+                          op_let_Question uu___3 (fun y1 -> return (x1, y1))))
+              pairs in
+          op_let_Question uu___
+            (fun pairs1 ->
+               let uu___1 =
+                 PulseSyntaxWrapper.tm_rename pairs1 s.PulseSugar.range1 in
+               return uu___1)
       | PulseSugar.LetBinding uu___ ->
           fail "Terminal let binding" s.PulseSugar.range1
 and (desugar_branch :
@@ -2065,6 +2082,7 @@ let rec (transform_stmt_with_reads :
                     return (p3, [], m)))
       | PulseSugar.Introduce uu___ -> return (p, [], m)
       | PulseSugar.Rewrite uu___ -> return (p, [], m)
+      | PulseSugar.Rename uu___ -> return (p, [], m)
       | PulseSugar.ProofHintWithBinders uu___ -> return (p, [], m)
 and (transform_stmt : menv -> PulseSugar.stmt -> PulseSugar.stmt err) =
   fun m ->

--- a/src/ocaml/plugin/generated/PulseDesugar.ml
+++ b/src/ocaml/plugin/generated/PulseDesugar.ml
@@ -712,18 +712,62 @@ let (resolve_names :
           let uu___ = map_err (resolve_lid env) ns1 in
           op_let_Question uu___
             (fun ns2 -> return (FStar_Pervasives_Native.Some ns2))
-let (resolve_hint_type :
-  env_t -> PulseSugar.hint_type -> PulseSugar.hint_type err) =
+let (desugar_hint_type :
+  env_t -> PulseSugar.hint_type -> PulseSyntaxWrapper.hint_type err) =
   fun env ->
     fun ht ->
       match ht with
-      | PulseSugar.ASSERT -> return PulseSugar.ASSERT
-      | PulseSugar.UNFOLD ns ->
-          let uu___ = resolve_names env ns in
-          op_let_Question uu___ (fun ns1 -> return (PulseSugar.UNFOLD ns1))
-      | PulseSugar.FOLD ns ->
-          let uu___ = resolve_names env ns in
-          op_let_Question uu___ (fun ns1 -> return (PulseSugar.FOLD ns1))
+      | PulseSugar.ASSERT vp ->
+          let uu___ = desugar_vprop env vp in
+          op_let_Question uu___
+            (fun vp1 ->
+               let uu___1 = PulseSyntaxWrapper.mk_assert_hint_type vp1 in
+               return uu___1)
+      | PulseSugar.UNFOLD (ns, vp) ->
+          let uu___ = desugar_vprop env vp in
+          op_let_Question uu___
+            (fun vp1 ->
+               let uu___1 = resolve_names env ns in
+               op_let_Question uu___1
+                 (fun ns1 ->
+                    let ns2 =
+                      FStar_Compiler_Util.map_opt ns1
+                        (FStar_Compiler_List.map FStar_Ident.string_of_lid) in
+                    let uu___2 =
+                      PulseSyntaxWrapper.mk_unfold_hint_type ns2 vp1 in
+                    return uu___2))
+      | PulseSugar.FOLD (ns, vp) ->
+          let uu___ = desugar_vprop env vp in
+          op_let_Question uu___
+            (fun vp1 ->
+               let uu___1 = resolve_names env ns in
+               op_let_Question uu___1
+                 (fun ns1 ->
+                    let ns2 =
+                      FStar_Compiler_Util.map_opt ns1
+                        (FStar_Compiler_List.map FStar_Ident.string_of_lid) in
+                    let uu___2 = PulseSyntaxWrapper.mk_fold_hint_type ns2 vp1 in
+                    return uu___2))
+      | PulseSugar.RENAME (pairs, goal) ->
+          let uu___ =
+            map_err
+              (fun uu___1 ->
+                 match uu___1 with
+                 | (t1, t2) ->
+                     let uu___2 = desugar_term env t1 in
+                     op_let_Question uu___2
+                       (fun t11 ->
+                          let uu___3 = desugar_term env t2 in
+                          op_let_Question uu___3
+                            (fun t21 -> return (t11, t21)))) pairs in
+          op_let_Question uu___
+            (fun pairs1 ->
+               let uu___1 = map_err_opt (desugar_vprop env) goal in
+               op_let_Question uu___1
+                 (fun goal1 ->
+                    let uu___2 =
+                      PulseSyntaxWrapper.mk_rename_hint_type pairs1 goal1 in
+                    return uu___2))
 let (desugar_datacon : env_t -> FStar_Ident.lid -> PulseSyntaxWrapper.fv err)
   =
   fun env ->
@@ -827,11 +871,11 @@ let rec (desugar_stmt :
             PulseSugar.s2 = s2;_}
           -> desugar_bind env lb s2 s.PulseSugar.range1
       | PulseSugar.ProofHintWithBinders uu___ ->
-          desugar_assert_with_binders env s FStar_Pervasives_Native.None
+          desugar_proof_hint_with_binders env s FStar_Pervasives_Native.None
             s.PulseSugar.range1
       | PulseSugar.Sequence { PulseSugar.s1 = s1; PulseSugar.s2 = s2;_} when
           PulseSugar.uu___is_ProofHintWithBinders s1.PulseSugar.s ->
-          desugar_assert_with_binders env s1
+          desugar_proof_hint_with_binders env s1
             (FStar_Pervasives_Native.Some s2) s.PulseSugar.range1
       | PulseSugar.Sequence { PulseSugar.s1 = s1; PulseSugar.s2 = s2;_} ->
           desugar_sequence env s1 s2 s.PulseSugar.range1
@@ -975,23 +1019,6 @@ let rec (desugar_stmt :
                       PulseSyntaxWrapper.tm_rewrite p11 p21
                         s.PulseSugar.range1 in
                     return uu___2))
-      | PulseSugar.Rename { PulseSugar.pairs = pairs;_} ->
-          let uu___ =
-            map_err
-              (fun uu___1 ->
-                 match uu___1 with
-                 | (x, y) ->
-                     let uu___2 = desugar_term env x in
-                     op_let_Question uu___2
-                       (fun x1 ->
-                          let uu___3 = desugar_term env y in
-                          op_let_Question uu___3 (fun y1 -> return (x1, y1))))
-              pairs in
-          op_let_Question uu___
-            (fun pairs1 ->
-               let uu___1 =
-                 PulseSyntaxWrapper.tm_rename pairs1 s.PulseSugar.range1 in
-               return uu___1)
       | PulseSugar.LetBinding uu___ ->
           fail "Terminal let binding" s.PulseSugar.range1
 and (desugar_branch :
@@ -1174,7 +1201,7 @@ and (desugar_sequence :
                       let uu___3 = PulseSyntaxWrapper.tm_unknown r in
                       PulseSyntaxWrapper.mk_binder uu___2 uu___3 in
                     let uu___2 = mk_bind annot s11 s21 r in return uu___2))
-and (desugar_assert_with_binders :
+and (desugar_proof_hint_with_binders :
   env_t ->
     PulseSugar.stmt ->
       PulseSugar.stmt FStar_Pervasives_Native.option ->
@@ -1186,8 +1213,7 @@ and (desugar_assert_with_binders :
         fun r ->
           match s1.PulseSugar.s with
           | PulseSugar.ProofHintWithBinders
-              { PulseSugar.hint_type = hint_type; PulseSugar.binders1 = bs;
-                PulseSugar.vprop1 = v;_}
+              { PulseSugar.hint_type = hint_type; PulseSugar.binders1 = bs;_}
               ->
               let uu___ = desugar_binders env bs in
               op_let_Question uu___
@@ -1197,9 +1223,9 @@ and (desugar_assert_with_binders :
                        let vars =
                          FStar_Compiler_List.map
                            (fun bv -> bv.FStar_Syntax_Syntax.index) bvs in
-                       let uu___2 = desugar_vprop env1 v in
+                       let uu___2 = desugar_hint_type env1 hint_type in
                        op_let_Question uu___2
-                         (fun v1 ->
+                         (fun ht ->
                             let uu___3 =
                               match k with
                               | FStar_Pervasives_Native.None ->
@@ -1221,19 +1247,15 @@ and (desugar_assert_with_binders :
                                    PulseSyntaxWrapper.bvs_as_subst vars in
                                  let s21 =
                                    PulseSyntaxWrapper.subst_st_term sub s2 in
-                                 let v2 =
-                                   PulseSyntaxWrapper.subst_term sub v1 in
+                                 let ht1 =
+                                   PulseSyntaxWrapper.subst_proof_hint sub ht in
                                  let uu___4 =
-                                   resolve_hint_type env1 hint_type in
-                                 op_let_Question uu___4
-                                   (fun ht ->
-                                      let uu___5 =
-                                        let uu___6 =
-                                          PulseSyntaxWrapper.close_binders
-                                            binders1 vars in
-                                        PulseSyntaxWrapper.tm_proof_hint_with_binders
-                                          ht uu___6 v2 s21 r in
-                                      return uu___5))))
+                                   let uu___5 =
+                                     PulseSyntaxWrapper.close_binders
+                                       binders1 vars in
+                                   PulseSyntaxWrapper.tm_proof_hint_with_binders
+                                     ht1 uu___5 s21 r in
+                                 return uu___4)))
           | uu___ ->
               fail "Expected ProofHintWithBinders" s1.PulseSugar.range1
 and (desugar_binders :
@@ -2082,7 +2104,6 @@ let rec (transform_stmt_with_reads :
                     return (p3, [], m)))
       | PulseSugar.Introduce uu___ -> return (p, [], m)
       | PulseSugar.Rewrite uu___ -> return (p, [], m)
-      | PulseSugar.Rename uu___ -> return (p, [], m)
       | PulseSugar.ProofHintWithBinders uu___ -> return (p, [], m)
 and (transform_stmt : menv -> PulseSugar.stmt -> PulseSugar.stmt err) =
   fun m ->

--- a/src/ocaml/plugin/generated/PulseSugar.ml
+++ b/src/ocaml/plugin/generated/PulseSugar.ml
@@ -136,6 +136,7 @@ type hint_type =
   vprop) 
   | RENAME of ((FStar_Parser_AST.term * FStar_Parser_AST.term) Prims.list *
   vprop FStar_Pervasives_Native.option) 
+  | REWRITE of (vprop * vprop) 
 let (uu___is_ASSERT : hint_type -> Prims.bool) =
   fun projectee -> match projectee with | ASSERT _0 -> true | uu___ -> false
 let (__proj__ASSERT__item___0 : hint_type -> vprop) =
@@ -159,6 +160,10 @@ let (__proj__RENAME__item___0 :
     ((FStar_Parser_AST.term * FStar_Parser_AST.term) Prims.list * vprop
       FStar_Pervasives_Native.option))
   = fun projectee -> match projectee with | RENAME _0 -> _0
+let (uu___is_REWRITE : hint_type -> Prims.bool) =
+  fun projectee -> match projectee with | REWRITE _0 -> true | uu___ -> false
+let (__proj__REWRITE__item___0 : hint_type -> (vprop * vprop)) =
+  fun projectee -> match projectee with | REWRITE _0 -> _0
 type stmt'__Expr__payload = {
   e: FStar_Parser_AST.term }
 and stmt'__Assignment__payload =

--- a/src/ocaml/plugin/generated/PulseSugar.ml
+++ b/src/ocaml/plugin/generated/PulseSugar.ml
@@ -129,21 +129,36 @@ let (uu___is_PatConstructor : pat -> Prims.bool) =
 let (__proj__PatConstructor__item___0 : pat -> pat__PatConstructor__payload)
   = fun projectee -> match projectee with | PatConstructor _0 -> _0
 type hint_type =
-  | ASSERT 
-  | UNFOLD of FStar_Ident.lident Prims.list FStar_Pervasives_Native.option 
-  | FOLD of FStar_Ident.lident Prims.list FStar_Pervasives_Native.option 
+  | ASSERT of vprop 
+  | UNFOLD of (FStar_Ident.lident Prims.list FStar_Pervasives_Native.option *
+  vprop) 
+  | FOLD of (FStar_Ident.lident Prims.list FStar_Pervasives_Native.option *
+  vprop) 
+  | RENAME of ((FStar_Parser_AST.term * FStar_Parser_AST.term) Prims.list *
+  vprop FStar_Pervasives_Native.option) 
 let (uu___is_ASSERT : hint_type -> Prims.bool) =
-  fun projectee -> match projectee with | ASSERT -> true | uu___ -> false
+  fun projectee -> match projectee with | ASSERT _0 -> true | uu___ -> false
+let (__proj__ASSERT__item___0 : hint_type -> vprop) =
+  fun projectee -> match projectee with | ASSERT _0 -> _0
 let (uu___is_UNFOLD : hint_type -> Prims.bool) =
   fun projectee -> match projectee with | UNFOLD _0 -> true | uu___ -> false
 let (__proj__UNFOLD__item___0 :
-  hint_type -> FStar_Ident.lident Prims.list FStar_Pervasives_Native.option)
+  hint_type ->
+    (FStar_Ident.lident Prims.list FStar_Pervasives_Native.option * vprop))
   = fun projectee -> match projectee with | UNFOLD _0 -> _0
 let (uu___is_FOLD : hint_type -> Prims.bool) =
   fun projectee -> match projectee with | FOLD _0 -> true | uu___ -> false
 let (__proj__FOLD__item___0 :
-  hint_type -> FStar_Ident.lident Prims.list FStar_Pervasives_Native.option)
+  hint_type ->
+    (FStar_Ident.lident Prims.list FStar_Pervasives_Native.option * vprop))
   = fun projectee -> match projectee with | FOLD _0 -> _0
+let (uu___is_RENAME : hint_type -> Prims.bool) =
+  fun projectee -> match projectee with | RENAME _0 -> true | uu___ -> false
+let (__proj__RENAME__item___0 :
+  hint_type ->
+    ((FStar_Parser_AST.term * FStar_Parser_AST.term) Prims.list * vprop
+      FStar_Pervasives_Native.option))
+  = fun projectee -> match projectee with | RENAME _0 -> _0
 type stmt'__Expr__payload = {
   e: FStar_Parser_AST.term }
 and stmt'__Assignment__payload =
@@ -198,14 +213,10 @@ and stmt'__Parallel__payload =
 and stmt'__Rewrite__payload = {
   p11: vprop ;
   p21: vprop }
-and stmt'__Rename__payload =
-  {
-  pairs: (FStar_Parser_AST.term * FStar_Parser_AST.term) Prims.list }
 and stmt'__ProofHintWithBinders__payload =
   {
   hint_type: hint_type ;
-  binders1: binders ;
-  vprop1: vprop }
+  binders1: binders }
 and stmt' =
   | Open of FStar_Ident.lident 
   | Expr of stmt'__Expr__payload 
@@ -220,7 +231,6 @@ and stmt' =
   | Sequence of stmt'__Sequence__payload 
   | Parallel of stmt'__Parallel__payload 
   | Rewrite of stmt'__Rewrite__payload 
-  | Rename of stmt'__Rename__payload 
   | ProofHintWithBinders of stmt'__ProofHintWithBinders__payload 
 and stmt = {
   s: stmt' ;
@@ -360,25 +370,15 @@ let (__proj__Mkstmt'__Rewrite__payload__item__p1 :
 let (__proj__Mkstmt'__Rewrite__payload__item__p2 :
   stmt'__Rewrite__payload -> vprop) =
   fun projectee -> match projectee with | { p11 = p1; p21 = p2;_} -> p2
-let (__proj__Mkstmt'__Rename__payload__item__pairs :
-  stmt'__Rename__payload ->
-    (FStar_Parser_AST.term * FStar_Parser_AST.term) Prims.list)
-  = fun projectee -> match projectee with | { pairs;_} -> pairs
 let (__proj__Mkstmt'__ProofHintWithBinders__payload__item__hint_type :
   stmt'__ProofHintWithBinders__payload -> hint_type) =
   fun projectee ->
     match projectee with
-    | { hint_type = hint_type1; binders1; vprop1;_} -> hint_type1
+    | { hint_type = hint_type1; binders1;_} -> hint_type1
 let (__proj__Mkstmt'__ProofHintWithBinders__payload__item__binders :
   stmt'__ProofHintWithBinders__payload -> binders) =
   fun projectee ->
-    match projectee with
-    | { hint_type = hint_type1; binders1; vprop1;_} -> binders1
-let (__proj__Mkstmt'__ProofHintWithBinders__payload__item__vprop :
-  stmt'__ProofHintWithBinders__payload -> vprop) =
-  fun projectee ->
-    match projectee with
-    | { hint_type = hint_type1; binders1; vprop1;_} -> vprop1
+    match projectee with | { hint_type = hint_type1; binders1;_} -> binders1
 let (uu___is_Open : stmt' -> Prims.bool) =
   fun projectee -> match projectee with | Open _0 -> true | uu___ -> false
 let (__proj__Open__item___0 : stmt' -> FStar_Ident.lident) =
@@ -438,10 +438,6 @@ let (uu___is_Rewrite : stmt' -> Prims.bool) =
   fun projectee -> match projectee with | Rewrite _0 -> true | uu___ -> false
 let (__proj__Rewrite__item___0 : stmt' -> stmt'__Rewrite__payload) =
   fun projectee -> match projectee with | Rewrite _0 -> _0
-let (uu___is_Rename : stmt' -> Prims.bool) =
-  fun projectee -> match projectee with | Rename _0 -> true | uu___ -> false
-let (__proj__Rename__item___0 : stmt' -> stmt'__Rename__payload) =
-  fun projectee -> match projectee with | Rename _0 -> _0
 let (uu___is_ProofHintWithBinders : stmt' -> Prims.bool) =
   fun projectee ->
     match projectee with | ProofHintWithBinders _0 -> true | uu___ -> false
@@ -574,11 +570,5 @@ let (mk_par : vprop -> vprop -> vprop -> vprop -> stmt -> stmt -> stmt') =
         fun q2 -> fun b1 -> fun b2 -> Parallel { p1; p2; q1; q2; b1; b2 }
 let (mk_rewrite : vprop -> vprop -> stmt') =
   fun p1 -> fun p2 -> Rewrite { p11 = p1; p21 = p2 }
-let (mk_rename :
-  (FStar_Parser_AST.term * FStar_Parser_AST.term) Prims.list -> stmt') =
-  fun pairs -> Rename { pairs }
-let (mk_proof_hint_with_binders : hint_type -> binders -> vprop -> stmt') =
-  fun ht ->
-    fun bs ->
-      fun p ->
-        ProofHintWithBinders { hint_type = ht; binders1 = bs; vprop1 = p }
+let (mk_proof_hint_with_binders : hint_type -> binders -> stmt') =
+  fun ht -> fun bs -> ProofHintWithBinders { hint_type = ht; binders1 = bs }

--- a/src/ocaml/plugin/generated/PulseSugar.ml
+++ b/src/ocaml/plugin/generated/PulseSugar.ml
@@ -198,6 +198,9 @@ and stmt'__Parallel__payload =
 and stmt'__Rewrite__payload = {
   p11: vprop ;
   p21: vprop }
+and stmt'__Rename__payload =
+  {
+  pairs: (FStar_Parser_AST.term * FStar_Parser_AST.term) Prims.list }
 and stmt'__ProofHintWithBinders__payload =
   {
   hint_type: hint_type ;
@@ -217,6 +220,7 @@ and stmt' =
   | Sequence of stmt'__Sequence__payload 
   | Parallel of stmt'__Parallel__payload 
   | Rewrite of stmt'__Rewrite__payload 
+  | Rename of stmt'__Rename__payload 
   | ProofHintWithBinders of stmt'__ProofHintWithBinders__payload 
 and stmt = {
   s: stmt' ;
@@ -356,6 +360,10 @@ let (__proj__Mkstmt'__Rewrite__payload__item__p1 :
 let (__proj__Mkstmt'__Rewrite__payload__item__p2 :
   stmt'__Rewrite__payload -> vprop) =
   fun projectee -> match projectee with | { p11 = p1; p21 = p2;_} -> p2
+let (__proj__Mkstmt'__Rename__payload__item__pairs :
+  stmt'__Rename__payload ->
+    (FStar_Parser_AST.term * FStar_Parser_AST.term) Prims.list)
+  = fun projectee -> match projectee with | { pairs;_} -> pairs
 let (__proj__Mkstmt'__ProofHintWithBinders__payload__item__hint_type :
   stmt'__ProofHintWithBinders__payload -> hint_type) =
   fun projectee ->
@@ -430,6 +438,10 @@ let (uu___is_Rewrite : stmt' -> Prims.bool) =
   fun projectee -> match projectee with | Rewrite _0 -> true | uu___ -> false
 let (__proj__Rewrite__item___0 : stmt' -> stmt'__Rewrite__payload) =
   fun projectee -> match projectee with | Rewrite _0 -> _0
+let (uu___is_Rename : stmt' -> Prims.bool) =
+  fun projectee -> match projectee with | Rename _0 -> true | uu___ -> false
+let (__proj__Rename__item___0 : stmt' -> stmt'__Rename__payload) =
+  fun projectee -> match projectee with | Rename _0 -> _0
 let (uu___is_ProofHintWithBinders : stmt' -> Prims.bool) =
   fun projectee ->
     match projectee with | ProofHintWithBinders _0 -> true | uu___ -> false
@@ -562,6 +574,9 @@ let (mk_par : vprop -> vprop -> vprop -> vprop -> stmt -> stmt -> stmt') =
         fun q2 -> fun b1 -> fun b2 -> Parallel { p1; p2; q1; q2; b1; b2 }
 let (mk_rewrite : vprop -> vprop -> stmt') =
   fun p1 -> fun p2 -> Rewrite { p11 = p1; p21 = p2 }
+let (mk_rename :
+  (FStar_Parser_AST.term * FStar_Parser_AST.term) Prims.list -> stmt') =
+  fun pairs -> Rename { pairs }
 let (mk_proof_hint_with_binders : hint_type -> binders -> vprop -> stmt') =
   fun ht ->
     fun bs ->

--- a/src/ocaml/plugin/generated/Pulse_Checker.ml
+++ b/src/ocaml/plugin/generated/Pulse_Checker.ml
@@ -182,14 +182,14 @@ let (instantiate_unknown_witnesses :
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.fst" (Prims.of_int (74))
-                 (Prims.of_int (28)) (Prims.of_int (98)) (Prims.of_int (10)))))
+                 (Prims.of_int (28)) (Prims.of_int (100)) (Prims.of_int (10)))))
         (FStar_Tactics_Effect.lift_div_tac
            (fun uu___ -> t.Pulse_Syntax_Base.term1))
         (fun uu___ ->
            (fun uu___ ->
               match uu___ with
               | Pulse_Syntax_Base.Tm_IntroExists
-                  { Pulse_Syntax_Base.p2 = p;
+                  { Pulse_Syntax_Base.p5 = p;
                     Pulse_Syntax_Base.witnesses = ws;_}
                   ->
                   Obj.magic
@@ -203,7 +203,7 @@ let (instantiate_unknown_witnesses :
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Checker.fst"
                                 (Prims.of_int (76)) (Prims.of_int (52))
-                                (Prims.of_int (98)) (Prims.of_int (10)))))
+                                (Prims.of_int (100)) (Prims.of_int (10)))))
                        (Obj.magic (gen_names_for_unknowns g p ws))
                        (fun uu___1 ->
                           FStar_Tactics_Effect.lift_div_tac
@@ -229,8 +229,6 @@ let (instantiate_unknown_witnesses :
                                                                = hint_type;
                                                              Pulse_Syntax_Base.binders
                                                                = binders;
-                                                             Pulse_Syntax_Base.v
-                                                               = v;
                                                              Pulse_Syntax_Base.t3
                                                                = t1;_}
                                                            ->
@@ -251,8 +249,6 @@ let (instantiate_unknown_witnesses :
                                                                     = ppname
                                                                     } ::
                                                                     binders);
-                                                                    Pulse_Syntax_Base.v
-                                                                    = v;
                                                                     Pulse_Syntax_Base.t3
                                                                     = t1
                                                                   });
@@ -268,18 +264,20 @@ let (instantiate_unknown_witnesses :
                                                     {
                                                       Pulse_Syntax_Base.hint_type
                                                         =
-                                                        Pulse_Syntax_Base.ASSERT;
+                                                        (Pulse_Syntax_Base.ASSERT
+                                                           {
+                                                             Pulse_Syntax_Base.p
+                                                               = opened_p
+                                                           });
                                                       Pulse_Syntax_Base.binders
                                                         = [];
-                                                      Pulse_Syntax_Base.v =
-                                                        opened_p;
                                                       Pulse_Syntax_Base.t3 =
                                                         {
                                                           Pulse_Syntax_Base.term1
                                                             =
                                                             (Pulse_Syntax_Base.Tm_IntroExists
                                                                {
-                                                                 Pulse_Syntax_Base.p2
+                                                                 Pulse_Syntax_Base.p5
                                                                    = p;
                                                                  Pulse_Syntax_Base.witnesses
                                                                    = new_ws
@@ -325,7 +323,7 @@ let rec (transform_to_unary_intro_exists :
                                    Pulse_Typing.wr
                                      (Pulse_Syntax_Base.Tm_IntroExists
                                         {
-                                          Pulse_Syntax_Base.p2 = t;
+                                          Pulse_Syntax_Base.p5 = t;
                                           Pulse_Syntax_Base.witnesses = [w]
                                         })))
                          else
@@ -344,17 +342,17 @@ let rec (transform_to_unary_intro_exists :
                                   (Obj.magic
                                      (FStar_Range.mk_range
                                         "Pulse.Checker.fst"
-                                        (Prims.of_int (112))
+                                        (Prims.of_int (114))
                                         (Prims.of_int (17))
-                                        (Prims.of_int (112))
+                                        (Prims.of_int (114))
                                         (Prims.of_int (43)))))
                                (FStar_Sealed.seal
                                   (Obj.magic
                                      (FStar_Range.mk_range
                                         "Pulse.Checker.fst"
-                                        (Prims.of_int (112))
+                                        (Prims.of_int (114))
                                         (Prims.of_int (46))
-                                        (Prims.of_int (118))
+                                        (Prims.of_int (120))
                                         (Prims.of_int (32)))))
                                (FStar_Tactics_Effect.lift_div_tac
                                   (fun uu___ ->
@@ -369,17 +367,17 @@ let rec (transform_to_unary_intro_exists :
                                              (Obj.magic
                                                 (FStar_Range.mk_range
                                                    "Pulse.Checker.fst"
-                                                   (Prims.of_int (113))
+                                                   (Prims.of_int (115))
                                                    (Prims.of_int (15))
-                                                   (Prims.of_int (113))
+                                                   (Prims.of_int (115))
                                                    (Prims.of_int (56)))))
                                           (FStar_Sealed.seal
                                              (Obj.magic
                                                 (FStar_Range.mk_range
                                                    "Pulse.Checker.fst"
-                                                   (Prims.of_int (116))
-                                                   (Prims.of_int (6))
                                                    (Prims.of_int (118))
+                                                   (Prims.of_int (6))
+                                                   (Prims.of_int (120))
                                                    (Prims.of_int (32)))))
                                           (Obj.magic
                                              (transform_to_unary_intro_exists
@@ -401,7 +399,7 @@ let rec (transform_to_unary_intro_exists :
                                                            (Pulse_Typing.wr
                                                               (Pulse_Syntax_Base.Tm_IntroExists
                                                                  {
-                                                                   Pulse_Syntax_Base.p2
+                                                                   Pulse_Syntax_Base.p5
                                                                     = t;
                                                                    Pulse_Syntax_Base.witnesses
                                                                     = 
@@ -425,13 +423,13 @@ let rec (check : Pulse_Checker_Base.check_t) =
                 (FStar_Sealed.seal
                    (Obj.magic
                       (FStar_Range.mk_range "Pulse.Checker.fst"
-                         (Prims.of_int (137)) (Prims.of_int (4))
-                         (Prims.of_int (137)) (Prims.of_int (55)))))
+                         (Prims.of_int (139)) (Prims.of_int (4))
+                         (Prims.of_int (139)) (Prims.of_int (55)))))
                 (FStar_Sealed.seal
                    (Obj.magic
                       (FStar_Range.mk_range "Pulse.Checker.fst"
-                         (Prims.of_int (129)) (Prims.of_int (60))
-                         (Prims.of_int (245)) (Prims.of_int (50)))))
+                         (Prims.of_int (131)) (Prims.of_int (60))
+                         (Prims.of_int (247)) (Prims.of_int (50)))))
                 (Obj.magic
                    (Pulse_Checker_Prover_ElimPure.elim_pure g0 pre0 ()))
                 (fun uu___ ->
@@ -445,17 +443,17 @@ let rec (check : Pulse_Checker_Base.check_t) =
                                   (Obj.magic
                                      (FStar_Range.mk_range
                                         "Pulse.Checker.fst"
-                                        (Prims.of_int (139))
+                                        (Prims.of_int (141))
                                         (Prims.of_int (44))
-                                        (Prims.of_int (241))
+                                        (Prims.of_int (243))
                                         (Prims.of_int (48)))))
                                (FStar_Sealed.seal
                                   (Obj.magic
                                      (FStar_Range.mk_range
                                         "Pulse.Checker.fst"
-                                        (Prims.of_int (242))
+                                        (Prims.of_int (244))
                                         (Prims.of_int (4))
-                                        (Prims.of_int (245))
+                                        (Prims.of_int (247))
                                         (Prims.of_int (50)))))
                                (Obj.magic
                                   (FStar_Tactics_Effect.tac_bind
@@ -463,17 +461,17 @@ let rec (check : Pulse_Checker_Base.check_t) =
                                         (Obj.magic
                                            (FStar_Range.mk_range
                                               "Pulse.Checker.fst"
-                                              (Prims.of_int (140))
+                                              (Prims.of_int (142))
                                               (Prims.of_int (12))
-                                              (Prims.of_int (140))
+                                              (Prims.of_int (142))
                                               (Prims.of_int (55)))))
                                      (FStar_Sealed.seal
                                         (Obj.magic
                                            (FStar_Range.mk_range
                                               "Pulse.Checker.fst"
-                                              (Prims.of_int (141))
+                                              (Prims.of_int (143))
                                               (Prims.of_int (4))
-                                              (Prims.of_int (241))
+                                              (Prims.of_int (243))
                                               (Prims.of_int (48)))))
                                      (FStar_Tactics_Effect.lift_div_tac
                                         (fun uu___1 ->
@@ -513,7 +511,7 @@ let rec (check : Pulse_Checker_Base.check_t) =
                                                        g1 pre () post_hint
                                                        res_ppname t))
                                            | Pulse_Syntax_Base.Tm_IntroExists
-                                               { Pulse_Syntax_Base.p2 = p;
+                                               { Pulse_Syntax_Base.p5 = p;
                                                  Pulse_Syntax_Base.witnesses
                                                    = witnesses;_}
                                                ->
@@ -524,17 +522,17 @@ let rec (check : Pulse_Checker_Base.check_t) =
                                                           (Obj.magic
                                                              (FStar_Range.mk_range
                                                                 "Pulse.Checker.fst"
-                                                                (Prims.of_int (154))
+                                                                (Prims.of_int (156))
                                                                 (Prims.of_int (13))
-                                                                (Prims.of_int (154))
+                                                                (Prims.of_int (156))
                                                                 (Prims.of_int (46)))))
                                                        (FStar_Sealed.seal
                                                           (Obj.magic
                                                              (FStar_Range.mk_range
                                                                 "Pulse.Checker.fst"
-                                                                (Prims.of_int (154))
+                                                                (Prims.of_int (156))
                                                                 (Prims.of_int (6))
-                                                                (Prims.of_int (164))
+                                                                (Prims.of_int (166))
                                                                 (Prims.of_int (57)))))
                                                        (Obj.magic
                                                           (instantiate_unknown_witnesses
@@ -578,17 +576,17 @@ let rec (check : Pulse_Checker_Base.check_t) =
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (163))
+                                                                    (Prims.of_int (165))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (163))
+                                                                    (Prims.of_int (165))
                                                                     (Prims.of_int (64)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (164))
+                                                                    (Prims.of_int (166))
                                                                     (Prims.of_int (11))
-                                                                    (Prims.of_int (164))
+                                                                    (Prims.of_int (166))
                                                                     (Prims.of_int (56)))))
                                                                     (Obj.magic
                                                                     (transform_to_unary_intro_exists
@@ -634,17 +632,17 @@ let rec (check : Pulse_Checker_Base.check_t) =
                                                           (Obj.magic
                                                              (FStar_Range.mk_range
                                                                 "Pulse.Checker.fst"
-                                                                (Prims.of_int (173))
+                                                                (Prims.of_int (175))
                                                                 (Prims.of_int (8))
-                                                                (Prims.of_int (189))
+                                                                (Prims.of_int (191))
                                                                 (Prims.of_int (97)))))
                                                        (FStar_Sealed.seal
                                                           (Obj.magic
                                                              (FStar_Range.mk_range
                                                                 "Pulse.Checker.fst"
-                                                                (Prims.of_int (190))
+                                                                (Prims.of_int (192))
                                                                 (Prims.of_int (8))
-                                                                (Prims.of_int (193))
+                                                                (Prims.of_int (195))
                                                                 (Prims.of_int (29)))))
                                                        (match (post_if,
                                                                 post_hint)
@@ -682,18 +680,18 @@ let rec (check : Pulse_Checker_Base.check_t) =
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (179))
+                                                                    (Prims.of_int (181))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (184))
+                                                                    (Prims.of_int (186))
                                                                     (Prims.of_int (37)))))
                                                                     (
                                                                     FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (178))
+                                                                    (Prims.of_int (180))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (184))
+                                                                    (Prims.of_int (186))
                                                                     (Prims.of_int (37)))))
                                                                     (
                                                                     Obj.magic
@@ -702,17 +700,17 @@ let rec (check : Pulse_Checker_Base.check_t) =
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (184))
+                                                                    (Prims.of_int (186))
                                                                     (Prims.of_int (16))
-                                                                    (Prims.of_int (184))
+                                                                    (Prims.of_int (186))
                                                                     (Prims.of_int (36)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (179))
+                                                                    (Prims.of_int (181))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (184))
+                                                                    (Prims.of_int (186))
                                                                     (Prims.of_int (37)))))
                                                                     (Obj.magic
                                                                     (Pulse_Syntax_Printer.term_to_string
@@ -727,17 +725,17 @@ let rec (check : Pulse_Checker_Base.check_t) =
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (179))
+                                                                    (Prims.of_int (181))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (184))
+                                                                    (Prims.of_int (186))
                                                                     (Prims.of_int (37)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (179))
+                                                                    (Prims.of_int (181))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (184))
+                                                                    (Prims.of_int (186))
                                                                     (Prims.of_int (37)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -745,9 +743,9 @@ let rec (check : Pulse_Checker_Base.check_t) =
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (183))
+                                                                    (Prims.of_int (185))
                                                                     (Prims.of_int (16))
-                                                                    (Prims.of_int (183))
+                                                                    (Prims.of_int (185))
                                                                     (Prims.of_int (58)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -811,17 +809,17 @@ let rec (check : Pulse_Checker_Base.check_t) =
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (192))
+                                                                    (Prims.of_int (194))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (192))
+                                                                    (Prims.of_int (194))
                                                                     (Prims.of_int (63)))))
                                                                   (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (190))
+                                                                    (Prims.of_int (192))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (193))
+                                                                    (Prims.of_int (195))
                                                                     (Prims.of_int (29)))))
                                                                   (Obj.magic
                                                                     (Pulse_Checker_If.check
@@ -868,17 +866,17 @@ let rec (check : Pulse_Checker_Base.check_t) =
                                                           (Obj.magic
                                                              (FStar_Range.mk_range
                                                                 "Pulse.Checker.fst"
-                                                                (Prims.of_int (201))
+                                                                (Prims.of_int (203))
                                                                 (Prims.of_int (8))
-                                                                (Prims.of_int (217))
+                                                                (Prims.of_int (219))
                                                                 (Prims.of_int (97)))))
                                                        (FStar_Sealed.seal
                                                           (Obj.magic
                                                              (FStar_Range.mk_range
                                                                 "Pulse.Checker.fst"
-                                                                (Prims.of_int (218))
+                                                                (Prims.of_int (220))
                                                                 (Prims.of_int (8))
-                                                                (Prims.of_int (221))
+                                                                (Prims.of_int (223))
                                                                 (Prims.of_int (30)))))
                                                        (match (post_match,
                                                                 post_hint)
@@ -916,18 +914,18 @@ let rec (check : Pulse_Checker_Base.check_t) =
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (207))
+                                                                    (Prims.of_int (209))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (212))
+                                                                    (Prims.of_int (214))
                                                                     (Prims.of_int (37)))))
                                                                     (
                                                                     FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (206))
+                                                                    (Prims.of_int (208))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (212))
+                                                                    (Prims.of_int (214))
                                                                     (Prims.of_int (37)))))
                                                                     (
                                                                     Obj.magic
@@ -936,17 +934,17 @@ let rec (check : Pulse_Checker_Base.check_t) =
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (212))
+                                                                    (Prims.of_int (214))
                                                                     (Prims.of_int (16))
-                                                                    (Prims.of_int (212))
+                                                                    (Prims.of_int (214))
                                                                     (Prims.of_int (36)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (207))
+                                                                    (Prims.of_int (209))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (212))
+                                                                    (Prims.of_int (214))
                                                                     (Prims.of_int (37)))))
                                                                     (Obj.magic
                                                                     (Pulse_Syntax_Printer.term_to_string
@@ -961,17 +959,17 @@ let rec (check : Pulse_Checker_Base.check_t) =
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (207))
+                                                                    (Prims.of_int (209))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (212))
+                                                                    (Prims.of_int (214))
                                                                     (Prims.of_int (37)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (207))
+                                                                    (Prims.of_int (209))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (212))
+                                                                    (Prims.of_int (214))
                                                                     (Prims.of_int (37)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -979,9 +977,9 @@ let rec (check : Pulse_Checker_Base.check_t) =
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (211))
+                                                                    (Prims.of_int (213))
                                                                     (Prims.of_int (16))
-                                                                    (Prims.of_int (211))
+                                                                    (Prims.of_int (213))
                                                                     (Prims.of_int (58)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -1045,17 +1043,17 @@ let rec (check : Pulse_Checker_Base.check_t) =
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (220))
+                                                                    (Prims.of_int (222))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (220))
+                                                                    (Prims.of_int (222))
                                                                     (Prims.of_int (65)))))
                                                                   (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (218))
+                                                                    (Prims.of_int (220))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (221))
+                                                                    (Prims.of_int (223))
                                                                     (Prims.of_int (30)))))
                                                                   (Obj.magic
                                                                     (Pulse_Checker_Match.check

--- a/src/ocaml/plugin/generated/Pulse_Checker_AssertWithBinders.ml
+++ b/src/ocaml/plugin/generated/Pulse_Checker_AssertWithBinders.ml
@@ -1689,6 +1689,225 @@ let (check_unfoldable :
                                   (FStar_Pervasives_Native.Some
                                      (v.Pulse_Syntax_Base.range1)) uu___1))
                             uu___1)))) uu___1 uu___
+let (rewrite_one :
+  (Pulse_Syntax_Base.term * Pulse_Syntax_Base.term) ->
+    Pulse_Syntax_Base.term -> Pulse_Syntax_Base.term)
+  = fun p -> fun t -> t
+let (rewrite_all :
+  (Pulse_Syntax_Base.term * Pulse_Syntax_Base.term) Prims.list ->
+    Pulse_Syntax_Base.term ->
+      Pulse_Syntax_Base.term FStar_Pervasives_Native.option)
+  =
+  fun p ->
+    fun t ->
+      let rec as_subst p1 out =
+        match p1 with
+        | [] -> FStar_Pervasives_Native.Some out
+        | (e1, e2)::p2 ->
+            (match e1.Pulse_Syntax_Base.t with
+             | Pulse_Syntax_Base.Tm_FStar e11 ->
+                 (match FStar_Reflection_V2_Builtins.inspect_ln e11 with
+                  | FStar_Reflection_V2_Data.Tv_Var n ->
+                      let nv = FStar_Reflection_V2_Builtins.inspect_namedv n in
+                      as_subst p2
+                        ((Pulse_Syntax_Naming.NT
+                            ((nv.FStar_Reflection_V2_Data.uniq), e2)) :: out)
+                  | uu___ -> FStar_Pervasives_Native.None)
+             | uu___ -> FStar_Pervasives_Native.None) in
+      match as_subst p [] with
+      | FStar_Pervasives_Native.Some s ->
+          FStar_Pervasives_Native.Some (Pulse_Syntax_Naming.subst_term t s)
+      | uu___ -> FStar_Pervasives_Native.None
+let rec (check_renaming :
+  Pulse_Typing_Env.env ->
+    Pulse_Syntax_Base.term ->
+      unit ->
+        unit Pulse_Typing.post_hint_opt ->
+          Pulse_Syntax_Base.ppname ->
+            Pulse_Syntax_Base.st_term ->
+              (Pulse_Syntax_Base.st_term, unit) FStar_Tactics_Effect.tac_repr)
+  =
+  fun g ->
+    fun pre ->
+      fun pre_typing ->
+        fun post_hint ->
+          fun res_ppname ->
+            fun st ->
+              FStar_Tactics_Effect.tac_bind
+                (FStar_Sealed.seal
+                   (Obj.magic
+                      (FStar_Range.mk_range
+                         "Pulse.Checker.AssertWithBinders.fst"
+                         (Prims.of_int (169)) (Prims.of_int (35))
+                         (Prims.of_int (169)) (Prims.of_int (42)))))
+                (FStar_Sealed.seal
+                   (Obj.magic
+                      (FStar_Range.mk_range
+                         "Pulse.Checker.AssertWithBinders.fst"
+                         (Prims.of_int (169)) Prims.int_one
+                         (Prims.of_int (197)) (Prims.of_int (3)))))
+                (FStar_Tactics_Effect.lift_div_tac
+                   (fun uu___ -> st.Pulse_Syntax_Base.term1))
+                (fun uu___ ->
+                   (fun uu___ ->
+                      match uu___ with
+                      | Pulse_Syntax_Base.Tm_ProofHintWithBinders ht ->
+                          Obj.magic
+                            (FStar_Tactics_Effect.tac_bind
+                               (FStar_Sealed.seal
+                                  (Obj.magic
+                                     (FStar_Range.mk_range
+                                        "Pulse.Checker.AssertWithBinders.fst"
+                                        (Prims.of_int (170))
+                                        (Prims.of_int (65))
+                                        (Prims.of_int (170))
+                                        (Prims.of_int (67)))))
+                               (FStar_Sealed.seal
+                                  (Obj.magic
+                                     (FStar_Range.mk_range
+                                        "Pulse.Checker.AssertWithBinders.fst"
+                                        (Prims.of_int (169))
+                                        (Prims.of_int (45))
+                                        (Prims.of_int (197))
+                                        (Prims.of_int (3)))))
+                               (FStar_Tactics_Effect.lift_div_tac
+                                  (fun uu___1 -> ht))
+                               (fun uu___1 ->
+                                  (fun uu___1 ->
+                                     match uu___1 with
+                                     | {
+                                         Pulse_Syntax_Base.hint_type =
+                                           Pulse_Syntax_Base.RENAME
+                                           { Pulse_Syntax_Base.pairs = pairs;
+                                             Pulse_Syntax_Base.goal = goal;_};
+                                         Pulse_Syntax_Base.binders = bs;
+                                         Pulse_Syntax_Base.t3 = body;_} ->
+                                         (match (bs, goal) with
+                                          | (uu___2::uu___3,
+                                             FStar_Pervasives_Native.None) ->
+                                              Obj.magic
+                                                (Obj.repr
+                                                   (Pulse_Typing_Env.fail g
+                                                      (FStar_Pervasives_Native.Some
+                                                         (st.Pulse_Syntax_Base.range2))
+                                                      "A renaming with binders must have a goal (with xs. rename ... in goal)"))
+                                          | (uu___2::uu___3,
+                                             FStar_Pervasives_Native.Some
+                                             goal1) ->
+                                              Obj.magic
+                                                (Obj.repr
+                                                   (FStar_Tactics_Effect.lift_div_tac
+                                                      (fun uu___4 ->
+                                                         {
+                                                           Pulse_Syntax_Base.term1
+                                                             =
+                                                             (Pulse_Syntax_Base.Tm_ProofHintWithBinders
+                                                                {
+                                                                  Pulse_Syntax_Base.hint_type
+                                                                    =
+                                                                    (
+                                                                    Pulse_Syntax_Base.ASSERT
+                                                                    {
+                                                                    Pulse_Syntax_Base.p
+                                                                    = goal1
+                                                                    });
+                                                                  Pulse_Syntax_Base.binders
+                                                                    = bs;
+                                                                  Pulse_Syntax_Base.t3
+                                                                    =
+                                                                    {
+                                                                    Pulse_Syntax_Base.term1
+                                                                    =
+                                                                    (Pulse_Syntax_Base.Tm_ProofHintWithBinders
+                                                                    {
+                                                                    Pulse_Syntax_Base.hint_type
+                                                                    =
+                                                                    (ht.Pulse_Syntax_Base.hint_type);
+                                                                    Pulse_Syntax_Base.binders
+                                                                    = [];
+                                                                    Pulse_Syntax_Base.t3
+                                                                    =
+                                                                    (ht.Pulse_Syntax_Base.t3)
+                                                                    });
+                                                                    Pulse_Syntax_Base.range2
+                                                                    =
+                                                                    (st.Pulse_Syntax_Base.range2)
+                                                                    }
+                                                                });
+                                                           Pulse_Syntax_Base.range2
+                                                             =
+                                                             (st.Pulse_Syntax_Base.range2)
+                                                         })))
+                                          | ([],
+                                             FStar_Pervasives_Native.None) ->
+                                              Obj.magic
+                                                (Obj.repr
+                                                   (check_renaming g pre ()
+                                                      post_hint res_ppname
+                                                      {
+                                                        Pulse_Syntax_Base.term1
+                                                          =
+                                                          (Pulse_Syntax_Base.Tm_ProofHintWithBinders
+                                                             {
+                                                               Pulse_Syntax_Base.hint_type
+                                                                 =
+                                                                 (Pulse_Syntax_Base.RENAME
+                                                                    {
+                                                                    Pulse_Syntax_Base.pairs
+                                                                    = pairs;
+                                                                    Pulse_Syntax_Base.goal
+                                                                    =
+                                                                    (FStar_Pervasives_Native.Some
+                                                                    pre)
+                                                                    });
+                                                               Pulse_Syntax_Base.binders
+                                                                 =
+                                                                 (ht.Pulse_Syntax_Base.binders);
+                                                               Pulse_Syntax_Base.t3
+                                                                 =
+                                                                 (ht.Pulse_Syntax_Base.t3)
+                                                             });
+                                                        Pulse_Syntax_Base.range2
+                                                          =
+                                                          (st.Pulse_Syntax_Base.range2)
+                                                      }))
+                                          | ([], FStar_Pervasives_Native.Some
+                                             goal1) ->
+                                              Obj.magic
+                                                (Obj.repr
+                                                   (match rewrite_all pairs
+                                                            goal1
+                                                    with
+                                                    | FStar_Pervasives_Native.Some
+                                                        goal' ->
+                                                        Obj.repr
+                                                          (FStar_Tactics_Effect.lift_div_tac
+                                                             (fun uu___2 ->
+                                                                {
+                                                                  Pulse_Syntax_Base.term1
+                                                                    =
+                                                                    (
+                                                                    Pulse_Syntax_Base.Tm_Rewrite
+                                                                    {
+                                                                    Pulse_Syntax_Base.t1
+                                                                    = goal1;
+                                                                    Pulse_Syntax_Base.t2
+                                                                    = goal'
+                                                                    });
+                                                                  Pulse_Syntax_Base.range2
+                                                                    =
+                                                                    (
+                                                                    st.Pulse_Syntax_Base.range2)
+                                                                }))
+                                                    | FStar_Pervasives_Native.None
+                                                        ->
+                                                        Obj.repr
+                                                          (Pulse_Typing_Env.fail
+                                                             g
+                                                             (FStar_Pervasives_Native.Some
+                                                                (st.Pulse_Syntax_Base.range2))
+                                                             "Failed to rewrite the goal with the given renaming pairs")))))
+                                    uu___1))) uu___)
 let (check :
   Pulse_Typing_Env.env ->
     Pulse_Syntax_Base.term ->
@@ -1712,14 +1931,14 @@ let (check :
                      (Obj.magic
                         (FStar_Range.mk_range
                            "Pulse.Checker.AssertWithBinders.fst"
-                           (Prims.of_int (145)) (Prims.of_int (10))
-                           (Prims.of_int (145)) (Prims.of_int (48)))))
+                           (Prims.of_int (211)) (Prims.of_int (10))
+                           (Prims.of_int (211)) (Prims.of_int (48)))))
                   (FStar_Sealed.seal
                      (Obj.magic
                         (FStar_Range.mk_range
                            "Pulse.Checker.AssertWithBinders.fst"
-                           (Prims.of_int (145)) (Prims.of_int (51))
-                           (Prims.of_int (191)) (Prims.of_int (50)))))
+                           (Prims.of_int (211)) (Prims.of_int (51))
+                           (Prims.of_int (262)) (Prims.of_int (50)))))
                   (FStar_Tactics_Effect.lift_div_tac
                      (fun uu___ ->
                         Pulse_Typing_Env.push_context g "check_assert"
@@ -1732,17 +1951,17 @@ let (check :
                                 (Obj.magic
                                    (FStar_Range.mk_range
                                       "Pulse.Checker.AssertWithBinders.fst"
-                                      (Prims.of_int (147))
-                                      (Prims.of_int (69))
-                                      (Prims.of_int (147))
-                                      (Prims.of_int (76)))))
+                                      (Prims.of_int (213))
+                                      (Prims.of_int (66))
+                                      (Prims.of_int (213))
+                                      (Prims.of_int (73)))))
                              (FStar_Sealed.seal
                                 (Obj.magic
                                    (FStar_Range.mk_range
                                       "Pulse.Checker.AssertWithBinders.fst"
-                                      (Prims.of_int (145))
+                                      (Prims.of_int (211))
                                       (Prims.of_int (51))
-                                      (Prims.of_int (191))
+                                      (Prims.of_int (262))
                                       (Prims.of_int (50)))))
                              (FStar_Tactics_Effect.lift_div_tac
                                 (fun uu___ -> st.Pulse_Syntax_Base.term1))
@@ -1754,68 +1973,79 @@ let (check :
                                          Pulse_Syntax_Base.hint_type =
                                            hint_type;
                                          Pulse_Syntax_Base.binders = bs;
-                                         Pulse_Syntax_Base.v = v;
                                          Pulse_Syntax_Base.t3 = body;_}
                                        ->
-                                       Obj.magic
-                                         (FStar_Tactics_Effect.tac_bind
-                                            (FStar_Sealed.seal
-                                               (Obj.magic
-                                                  (FStar_Range.mk_range
-                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                     (Prims.of_int (149))
-                                                     (Prims.of_int (11))
-                                                     (Prims.of_int (149))
-                                                     (Prims.of_int (36)))))
-                                            (FStar_Sealed.seal
-                                               (Obj.magic
-                                                  (FStar_Range.mk_range
-                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                     (Prims.of_int (149))
-                                                     (Prims.of_int (39))
-                                                     (Prims.of_int (191))
-                                                     (Prims.of_int (50)))))
-                                            (Obj.magic
-                                               (infer_binder_types g1 bs v))
-                                            (fun uu___1 ->
-                                               (fun bs1 ->
-                                                  Obj.magic
-                                                    (FStar_Tactics_Effect.tac_bind
-                                                       (FStar_Sealed.seal
-                                                          (Obj.magic
-                                                             (FStar_Range.mk_range
-                                                                "Pulse.Checker.AssertWithBinders.fst"
-                                                                (Prims.of_int (151))
-                                                                (Prims.of_int (41))
-                                                                (Prims.of_int (151))
-                                                                (Prims.of_int (88)))))
-                                                       (FStar_Sealed.seal
-                                                          (Obj.magic
-                                                             (FStar_Range.mk_range
-                                                                "Pulse.Checker.AssertWithBinders.fst"
-                                                                (Prims.of_int (149))
-                                                                (Prims.of_int (39))
-                                                                (Prims.of_int (191))
-                                                                (Prims.of_int (50)))))
+                                       (match hint_type with
+                                        | Pulse_Syntax_Base.RENAME
+                                            {
+                                              Pulse_Syntax_Base.pairs = pairs;
+                                              Pulse_Syntax_Base.goal = goal;_}
+                                            ->
+                                            Obj.magic
+                                              (Obj.repr
+                                                 (FStar_Tactics_V2_Derived.fail
+                                                    "Renaming not yet handled"))
+                                        | Pulse_Syntax_Base.ASSERT
+                                            { Pulse_Syntax_Base.p = v;_} ->
+                                            Obj.magic
+                                              (Obj.repr
+                                                 (FStar_Tactics_Effect.tac_bind
+                                                    (FStar_Sealed.seal
                                                        (Obj.magic
-                                                          (open_binders g1
-                                                             bs1
-                                                             (Pulse_Typing_Env.mk_env
-                                                                (Pulse_Typing_Env.fstar_env
-                                                                   g1)) v
-                                                             body))
-                                                       (fun uu___1 ->
-                                                          (fun uu___1 ->
-                                                             match uu___1
-                                                             with
-                                                             | FStar_Pervasives.Mkdtuple3
-                                                                 (uvs,
-                                                                  v_opened,
-                                                                  body_opened)
-                                                                 ->
-                                                                 (match hint_type
-                                                                  with
-                                                                  | Pulse_Syntax_Base.ASSERT
+                                                          (FStar_Range.mk_range
+                                                             "Pulse.Checker.AssertWithBinders.fst"
+                                                             (Prims.of_int (221))
+                                                             (Prims.of_int (13))
+                                                             (Prims.of_int (221))
+                                                             (Prims.of_int (38)))))
+                                                    (FStar_Sealed.seal
+                                                       (Obj.magic
+                                                          (FStar_Range.mk_range
+                                                             "Pulse.Checker.AssertWithBinders.fst"
+                                                             (Prims.of_int (221))
+                                                             (Prims.of_int (41))
+                                                             (Prims.of_int (228))
+                                                             (Prims.of_int (52)))))
+                                                    (Obj.magic
+                                                       (infer_binder_types g1
+                                                          bs v))
+                                                    (fun uu___1 ->
+                                                       (fun bs1 ->
+                                                          Obj.magic
+                                                            (FStar_Tactics_Effect.tac_bind
+                                                               (FStar_Sealed.seal
+                                                                  (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.AssertWithBinders.fst"
+                                                                    (Prims.of_int (222))
+                                                                    (Prims.of_int (43))
+                                                                    (Prims.of_int (222))
+                                                                    (Prims.of_int (90)))))
+                                                               (FStar_Sealed.seal
+                                                                  (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.AssertWithBinders.fst"
+                                                                    (Prims.of_int (221))
+                                                                    (Prims.of_int (41))
+                                                                    (Prims.of_int (228))
+                                                                    (Prims.of_int (52)))))
+                                                               (Obj.magic
+                                                                  (open_binders
+                                                                    g1 bs1
+                                                                    (Pulse_Typing_Env.mk_env
+                                                                    (Pulse_Typing_Env.fstar_env
+                                                                    g1)) v
+                                                                    body))
+                                                               (fun uu___1 ->
+                                                                  (fun uu___1
+                                                                    ->
+                                                                    match uu___1
+                                                                    with
+                                                                    | 
+                                                                    FStar_Pervasives.Mkdtuple3
+                                                                    (uvs,
+                                                                    v_opened,
+                                                                    body_opened)
                                                                     ->
                                                                     Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1823,17 +2053,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (155))
+                                                                    (Prims.of_int (223))
                                                                     (Prims.of_int (18))
-                                                                    (Prims.of_int (155))
+                                                                    (Prims.of_int (223))
                                                                     (Prims.of_int (39)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (154))
-                                                                    (Prims.of_int (13))
-                                                                    (Prims.of_int (160))
+                                                                    (Prims.of_int (222))
+                                                                    (Prims.of_int (93))
+                                                                    (Prims.of_int (228))
                                                                     (Prims.of_int (52)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -1855,17 +2085,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (156))
+                                                                    (Prims.of_int (224))
                                                                     (Prims.of_int (21))
-                                                                    (Prims.of_int (156))
+                                                                    (Prims.of_int (224))
                                                                     (Prims.of_int (54)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (155))
+                                                                    (Prims.of_int (223))
                                                                     (Prims.of_int (42))
-                                                                    (Prims.of_int (160))
+                                                                    (Prims.of_int (228))
                                                                     (Prims.of_int (52)))))
                                                                     (Obj.magic
                                                                     (Pulse_Checker_Pure.check_vprop
@@ -1888,17 +2118,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (157))
+                                                                    (Prims.of_int (225))
                                                                     (Prims.of_int (39))
-                                                                    (Prims.of_int (157))
+                                                                    (Prims.of_int (225))
                                                                     (Prims.of_int (68)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (156))
+                                                                    (Prims.of_int (224))
                                                                     (Prims.of_int (57))
-                                                                    (Prims.of_int (160))
+                                                                    (Prims.of_int (228))
                                                                     (Prims.of_int (52)))))
                                                                     (Obj.magic
                                                                     (Pulse_Checker_Prover.prove
@@ -1923,17 +2153,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (159))
+                                                                    (Prims.of_int (227))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (159))
+                                                                    (Prims.of_int (227))
                                                                     (Prims.of_int (117)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (157))
+                                                                    (Prims.of_int (225))
                                                                     (Prims.of_int (71))
-                                                                    (Prims.of_int (160))
+                                                                    (Prims.of_int (228))
                                                                     (Prims.of_int (52)))))
                                                                     (Obj.magic
                                                                     (check1
@@ -1974,65 +2204,74 @@ let (check :
                                                                     k_frame k))))))
                                                                     uu___4)))
                                                                     uu___3)))
-                                                                    uu___2))
-                                                                  | uu___2 ->
-                                                                    Obj.magic
-                                                                    (FStar_Tactics_Effect.tac_bind
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
+                                                                    uu___2)))
+                                                                    uu___1)))
+                                                         uu___1)))
+                                        | Pulse_Syntax_Base.UNFOLD
+                                            {
+                                              Pulse_Syntax_Base.names1 =
+                                                names;
+                                              Pulse_Syntax_Base.p2 = v;_}
+                                            ->
+                                            Obj.magic
+                                              (Obj.repr
+                                                 (FStar_Tactics_Effect.tac_bind
+                                                    (FStar_Sealed.seal
+                                                       (Obj.magic
+                                                          (FStar_Range.mk_range
+                                                             "Pulse.Checker.AssertWithBinders.fst"
+                                                             (Prims.of_int (233))
+                                                             (Prims.of_int (13))
+                                                             (Prims.of_int (233))
+                                                             (Prims.of_int (38)))))
+                                                    (FStar_Sealed.seal
+                                                       (Obj.magic
+                                                          (FStar_Range.mk_range
+                                                             "Pulse.Checker.AssertWithBinders.fst"
+                                                             (Prims.of_int (233))
+                                                             (Prims.of_int (41))
+                                                             (Prims.of_int (262))
+                                                             (Prims.of_int (50)))))
+                                                    (Obj.magic
+                                                       (infer_binder_types g1
+                                                          bs v))
+                                                    (fun uu___1 ->
+                                                       (fun bs1 ->
+                                                          Obj.magic
+                                                            (FStar_Tactics_Effect.tac_bind
+                                                               (FStar_Sealed.seal
+                                                                  (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (163))
-                                                                    (Prims.of_int (4))
-                                                                    (Prims.of_int (163))
-                                                                    (Prims.of_int (24)))))
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
+                                                                    (Prims.of_int (234))
+                                                                    (Prims.of_int (43))
+                                                                    (Prims.of_int (234))
+                                                                    (Prims.of_int (90)))))
+                                                               (FStar_Sealed.seal
+                                                                  (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (163))
-                                                                    (Prims.of_int (25))
-                                                                    (Prims.of_int (191))
+                                                                    (Prims.of_int (233))
+                                                                    (Prims.of_int (41))
+                                                                    (Prims.of_int (262))
                                                                     (Prims.of_int (50)))))
-                                                                    (Obj.magic
-                                                                    (check_unfoldable
-                                                                    g1 v))
-                                                                    (fun
-                                                                    uu___3 ->
-                                                                    (fun
-                                                                    uu___3 ->
-                                                                    Obj.magic
-                                                                    (FStar_Tactics_Effect.tac_bind
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (164))
-                                                                    (Prims.of_int (22))
-                                                                    (Prims.of_int (164))
-                                                                    (Prims.of_int (77)))))
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (163))
-                                                                    (Prims.of_int (25))
-                                                                    (Prims.of_int (191))
-                                                                    (Prims.of_int (50)))))
-                                                                    (Obj.magic
-                                                                    (Pulse_Checker_Pure.instantiate_term_implicits
-                                                                    (Pulse_Typing_Env.push_env
-                                                                    g1 uvs)
-                                                                    v_opened))
-                                                                    (fun
-                                                                    uu___4 ->
-                                                                    (fun
-                                                                    uu___4 ->
-                                                                    match uu___4
+                                                               (Obj.magic
+                                                                  (open_binders
+                                                                    g1 bs1
+                                                                    (Pulse_Typing_Env.mk_env
+                                                                    (Pulse_Typing_Env.fstar_env
+                                                                    g1)) v
+                                                                    body))
+                                                               (fun uu___1 ->
+                                                                  (fun uu___1
+                                                                    ->
+                                                                    match uu___1
                                                                     with
                                                                     | 
-                                                                    (v_opened1,
-                                                                    uu___5)
+                                                                    FStar_Pervasives.Mkdtuple3
+                                                                    (uvs,
+                                                                    v_opened,
+                                                                    body_opened)
                                                                     ->
                                                                     Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -2040,40 +2279,98 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (166))
-                                                                    (Prims.of_int (6))
-                                                                    (Prims.of_int (172))
-                                                                    (Prims.of_int (16)))))
+                                                                    (Prims.of_int (235))
+                                                                    (Prims.of_int (4))
+                                                                    (Prims.of_int (235))
+                                                                    (Prims.of_int (24)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (164))
-                                                                    (Prims.of_int (80))
-                                                                    (Prims.of_int (191))
+                                                                    (Prims.of_int (235))
+                                                                    (Prims.of_int (25))
+                                                                    (Prims.of_int (262))
                                                                     (Prims.of_int (50)))))
-                                                                    (match hint_type
-                                                                    with
-                                                                    | 
-                                                                    Pulse_Syntax_Base.UNFOLD
-                                                                    uu___6 ->
+                                                                    (Obj.magic
+                                                                    (check_unfoldable
+                                                                    g1 v))
+                                                                    (fun
+                                                                    uu___2 ->
+                                                                    (fun
+                                                                    uu___2 ->
                                                                     Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (169))
+                                                                    (Prims.of_int (236))
+                                                                    (Prims.of_int (22))
+                                                                    (Prims.of_int (236))
+                                                                    (Prims.of_int (77)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.AssertWithBinders.fst"
+                                                                    (Prims.of_int (235))
+                                                                    (Prims.of_int (25))
+                                                                    (Prims.of_int (262))
+                                                                    (Prims.of_int (50)))))
+                                                                    (Obj.magic
+                                                                    (Pulse_Checker_Pure.instantiate_term_implicits
+                                                                    (Pulse_Typing_Env.push_env
+                                                                    g1 uvs)
+                                                                    v_opened))
+                                                                    (fun
+                                                                    uu___3 ->
+                                                                    (fun
+                                                                    uu___3 ->
+                                                                    match uu___3
+                                                                    with
+                                                                    | 
+                                                                    (v_opened1,
+                                                                    uu___4)
+                                                                    ->
+                                                                    Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.AssertWithBinders.fst"
+                                                                    (Prims.of_int (238))
+                                                                    (Prims.of_int (6))
+                                                                    (Prims.of_int (244))
+                                                                    (Prims.of_int (16)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.AssertWithBinders.fst"
+                                                                    (Prims.of_int (236))
+                                                                    (Prims.of_int (80))
+                                                                    (Prims.of_int (262))
+                                                                    (Prims.of_int (50)))))
+                                                                    (match hint_type
+                                                                    with
+                                                                    | 
+                                                                    Pulse_Syntax_Base.UNFOLD
+                                                                    uu___5 ->
+                                                                    Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.AssertWithBinders.fst"
+                                                                    (Prims.of_int (241))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (169))
+                                                                    (Prims.of_int (241))
                                                                     (Prims.of_int (50)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (168))
+                                                                    (Prims.of_int (240))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (169))
+                                                                    (Prims.of_int (241))
                                                                     (Prims.of_int (50)))))
                                                                     (Obj.magic
                                                                     (unfold_defs
@@ -2082,32 +2379,37 @@ let (check :
                                                                     FStar_Pervasives_Native.None
                                                                     v_opened1))
                                                                     (fun
-                                                                    uu___7 ->
+                                                                    uu___6 ->
                                                                     FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
-                                                                    uu___8 ->
+                                                                    uu___7 ->
                                                                     (v_opened1,
-                                                                    uu___7))))
+                                                                    uu___6))))
                                                                     | 
                                                                     Pulse_Syntax_Base.FOLD
-                                                                    ns ->
+                                                                    {
+                                                                    Pulse_Syntax_Base.names
+                                                                    = ns;
+                                                                    Pulse_Syntax_Base.p1
+                                                                    = uu___5;_}
+                                                                    ->
                                                                     Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (171))
+                                                                    (Prims.of_int (243))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (171))
+                                                                    (Prims.of_int (243))
                                                                     (Prims.of_int (48)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (171))
+                                                                    (Prims.of_int (243))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (172))
+                                                                    (Prims.of_int (244))
                                                                     (Prims.of_int (16)))))
                                                                     (Obj.magic
                                                                     (unfold_defs
@@ -2123,10 +2425,10 @@ let (check :
                                                                     (uu___6,
                                                                     v_opened1)))))
                                                                     (fun
-                                                                    uu___6 ->
+                                                                    uu___5 ->
                                                                     (fun
-                                                                    uu___6 ->
-                                                                    match uu___6
+                                                                    uu___5 ->
+                                                                    match uu___5
                                                                     with
                                                                     | 
                                                                     (lhs,
@@ -2137,26 +2439,26 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (173))
+                                                                    (Prims.of_int (245))
                                                                     (Prims.of_int (17))
-                                                                    (Prims.of_int (173))
+                                                                    (Prims.of_int (245))
                                                                     (Prims.of_int (37)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (173))
+                                                                    (Prims.of_int (245))
                                                                     (Prims.of_int (40))
-                                                                    (Prims.of_int (191))
+                                                                    (Prims.of_int (262))
                                                                     (Prims.of_int (50)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
-                                                                    uu___7 ->
+                                                                    uu___6 ->
                                                                     FStar_List_Tot_Base.rev
                                                                     (Pulse_Typing_Env.bindings
                                                                     uvs)))
                                                                     (fun
-                                                                    uu___7 ->
+                                                                    uu___6 ->
                                                                     (fun
                                                                     uvs_bs ->
                                                                     Obj.magic
@@ -2165,21 +2467,21 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (174))
+                                                                    (Prims.of_int (246))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (174))
+                                                                    (Prims.of_int (246))
                                                                     (Prims.of_int (69)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (173))
+                                                                    (Prims.of_int (245))
                                                                     (Prims.of_int (40))
-                                                                    (Prims.of_int (191))
+                                                                    (Prims.of_int (262))
                                                                     (Prims.of_int (50)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
-                                                                    uu___7 ->
+                                                                    uu___6 ->
                                                                     ((close_binders
                                                                     uvs_bs
                                                                     lhs),
@@ -2187,10 +2489,10 @@ let (check :
                                                                     uvs_bs
                                                                     rhs))))
                                                                     (fun
-                                                                    uu___7 ->
+                                                                    uu___6 ->
                                                                     (fun
-                                                                    uu___7 ->
-                                                                    match uu___7
+                                                                    uu___6 ->
+                                                                    match uu___6
                                                                     with
                                                                     | 
                                                                     (lhs1,
@@ -2201,21 +2503,21 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (175))
+                                                                    (Prims.of_int (247))
                                                                     (Prims.of_int (15))
-                                                                    (Prims.of_int (177))
+                                                                    (Prims.of_int (249))
                                                                     (Prims.of_int (31)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (177))
+                                                                    (Prims.of_int (249))
                                                                     (Prims.of_int (36))
-                                                                    (Prims.of_int (191))
+                                                                    (Prims.of_int (262))
                                                                     (Prims.of_int (50)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
-                                                                    uu___8 ->
+                                                                    uu___7 ->
                                                                     {
                                                                     Pulse_Syntax_Base.term1
                                                                     =
@@ -2231,7 +2533,7 @@ let (check :
                                                                     (st.Pulse_Syntax_Base.range2)
                                                                     }))
                                                                     (fun
-                                                                    uu___8 ->
+                                                                    uu___7 ->
                                                                     (fun rw
                                                                     ->
                                                                     Obj.magic
@@ -2240,21 +2542,21 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (178))
+                                                                    (Prims.of_int (250))
                                                                     (Prims.of_int (15))
-                                                                    (Prims.of_int (180))
+                                                                    (Prims.of_int (252))
                                                                     (Prims.of_int (31)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (180))
+                                                                    (Prims.of_int (252))
                                                                     (Prims.of_int (36))
-                                                                    (Prims.of_int (191))
+                                                                    (Prims.of_int (262))
                                                                     (Prims.of_int (50)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
-                                                                    uu___8 ->
+                                                                    uu___7 ->
                                                                     {
                                                                     Pulse_Syntax_Base.term1
                                                                     =
@@ -2280,7 +2582,7 @@ let (check :
                                                                     (st.Pulse_Syntax_Base.range2)
                                                                     }))
                                                                     (fun
-                                                                    uu___8 ->
+                                                                    uu___7 ->
                                                                     (fun st1
                                                                     ->
                                                                     Obj.magic
@@ -2289,27 +2591,27 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (183))
+                                                                    (Prims.of_int (255))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (190))
+                                                                    (Prims.of_int (261))
                                                                     (Prims.of_int (28)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (191))
+                                                                    (Prims.of_int (262))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (191))
+                                                                    (Prims.of_int (262))
                                                                     (Prims.of_int (50)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
-                                                                    uu___8 ->
+                                                                    uu___7 ->
                                                                     match bs1
                                                                     with
                                                                     | 
                                                                     [] -> st1
                                                                     | 
-                                                                    uu___9 ->
+                                                                    uu___8 ->
                                                                     {
                                                                     Pulse_Syntax_Base.term1
                                                                     =
@@ -2317,11 +2619,13 @@ let (check :
                                                                     {
                                                                     Pulse_Syntax_Base.hint_type
                                                                     =
-                                                                    Pulse_Syntax_Base.ASSERT;
+                                                                    (Pulse_Syntax_Base.ASSERT
+                                                                    {
+                                                                    Pulse_Syntax_Base.p
+                                                                    = lhs1
+                                                                    });
                                                                     Pulse_Syntax_Base.binders
                                                                     = bs1;
-                                                                    Pulse_Syntax_Base.v
-                                                                    = lhs1;
                                                                     Pulse_Syntax_Base.t3
                                                                     = st1
                                                                     });
@@ -2330,7 +2634,7 @@ let (check :
                                                                     (st1.Pulse_Syntax_Base.range2)
                                                                     }))
                                                                     (fun
-                                                                    uu___8 ->
+                                                                    uu___7 ->
                                                                     (fun st2
                                                                     ->
                                                                     Obj.magic
@@ -2339,13 +2643,459 @@ let (check :
                                                                     post_hint
                                                                     res_ppname
                                                                     st2))
-                                                                    uu___8)))
-                                                                    uu___8)))
-                                                                    uu___8)))
+                                                                    uu___7)))
                                                                     uu___7)))
                                                                     uu___7)))
                                                                     uu___6)))
-                                                                    uu___4)))
-                                                                    uu___3))))
-                                                            uu___1))) uu___1)))
-                                  uu___))) uu___)
+                                                                    uu___6)))
+                                                                    uu___5)))
+                                                                    uu___3)))
+                                                                    uu___2)))
+                                                                    uu___1)))
+                                                         uu___1)))
+                                        | Pulse_Syntax_Base.FOLD
+                                            {
+                                              Pulse_Syntax_Base.names = names;
+                                              Pulse_Syntax_Base.p1 = v;_}
+                                            ->
+                                            Obj.magic
+                                              (Obj.repr
+                                                 (FStar_Tactics_Effect.tac_bind
+                                                    (FStar_Sealed.seal
+                                                       (Obj.magic
+                                                          (FStar_Range.mk_range
+                                                             "Pulse.Checker.AssertWithBinders.fst"
+                                                             (Prims.of_int (233))
+                                                             (Prims.of_int (13))
+                                                             (Prims.of_int (233))
+                                                             (Prims.of_int (38)))))
+                                                    (FStar_Sealed.seal
+                                                       (Obj.magic
+                                                          (FStar_Range.mk_range
+                                                             "Pulse.Checker.AssertWithBinders.fst"
+                                                             (Prims.of_int (233))
+                                                             (Prims.of_int (41))
+                                                             (Prims.of_int (262))
+                                                             (Prims.of_int (50)))))
+                                                    (Obj.magic
+                                                       (infer_binder_types g1
+                                                          bs v))
+                                                    (fun uu___1 ->
+                                                       (fun bs1 ->
+                                                          Obj.magic
+                                                            (FStar_Tactics_Effect.tac_bind
+                                                               (FStar_Sealed.seal
+                                                                  (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.AssertWithBinders.fst"
+                                                                    (Prims.of_int (234))
+                                                                    (Prims.of_int (43))
+                                                                    (Prims.of_int (234))
+                                                                    (Prims.of_int (90)))))
+                                                               (FStar_Sealed.seal
+                                                                  (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.AssertWithBinders.fst"
+                                                                    (Prims.of_int (233))
+                                                                    (Prims.of_int (41))
+                                                                    (Prims.of_int (262))
+                                                                    (Prims.of_int (50)))))
+                                                               (Obj.magic
+                                                                  (open_binders
+                                                                    g1 bs1
+                                                                    (Pulse_Typing_Env.mk_env
+                                                                    (Pulse_Typing_Env.fstar_env
+                                                                    g1)) v
+                                                                    body))
+                                                               (fun uu___1 ->
+                                                                  (fun uu___1
+                                                                    ->
+                                                                    match uu___1
+                                                                    with
+                                                                    | 
+                                                                    FStar_Pervasives.Mkdtuple3
+                                                                    (uvs,
+                                                                    v_opened,
+                                                                    body_opened)
+                                                                    ->
+                                                                    Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.AssertWithBinders.fst"
+                                                                    (Prims.of_int (235))
+                                                                    (Prims.of_int (4))
+                                                                    (Prims.of_int (235))
+                                                                    (Prims.of_int (24)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.AssertWithBinders.fst"
+                                                                    (Prims.of_int (235))
+                                                                    (Prims.of_int (25))
+                                                                    (Prims.of_int (262))
+                                                                    (Prims.of_int (50)))))
+                                                                    (Obj.magic
+                                                                    (check_unfoldable
+                                                                    g1 v))
+                                                                    (fun
+                                                                    uu___2 ->
+                                                                    (fun
+                                                                    uu___2 ->
+                                                                    Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.AssertWithBinders.fst"
+                                                                    (Prims.of_int (236))
+                                                                    (Prims.of_int (22))
+                                                                    (Prims.of_int (236))
+                                                                    (Prims.of_int (77)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.AssertWithBinders.fst"
+                                                                    (Prims.of_int (235))
+                                                                    (Prims.of_int (25))
+                                                                    (Prims.of_int (262))
+                                                                    (Prims.of_int (50)))))
+                                                                    (Obj.magic
+                                                                    (Pulse_Checker_Pure.instantiate_term_implicits
+                                                                    (Pulse_Typing_Env.push_env
+                                                                    g1 uvs)
+                                                                    v_opened))
+                                                                    (fun
+                                                                    uu___3 ->
+                                                                    (fun
+                                                                    uu___3 ->
+                                                                    match uu___3
+                                                                    with
+                                                                    | 
+                                                                    (v_opened1,
+                                                                    uu___4)
+                                                                    ->
+                                                                    Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.AssertWithBinders.fst"
+                                                                    (Prims.of_int (238))
+                                                                    (Prims.of_int (6))
+                                                                    (Prims.of_int (244))
+                                                                    (Prims.of_int (16)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.AssertWithBinders.fst"
+                                                                    (Prims.of_int (236))
+                                                                    (Prims.of_int (80))
+                                                                    (Prims.of_int (262))
+                                                                    (Prims.of_int (50)))))
+                                                                    (match hint_type
+                                                                    with
+                                                                    | 
+                                                                    Pulse_Syntax_Base.UNFOLD
+                                                                    uu___5 ->
+                                                                    Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.AssertWithBinders.fst"
+                                                                    (Prims.of_int (241))
+                                                                    (Prims.of_int (8))
+                                                                    (Prims.of_int (241))
+                                                                    (Prims.of_int (50)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.AssertWithBinders.fst"
+                                                                    (Prims.of_int (240))
+                                                                    (Prims.of_int (8))
+                                                                    (Prims.of_int (241))
+                                                                    (Prims.of_int (50)))))
+                                                                    (Obj.magic
+                                                                    (unfold_defs
+                                                                    (Pulse_Typing_Env.push_env
+                                                                    g1 uvs)
+                                                                    FStar_Pervasives_Native.None
+                                                                    v_opened1))
+                                                                    (fun
+                                                                    uu___6 ->
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___7 ->
+                                                                    (v_opened1,
+                                                                    uu___6))))
+                                                                    | 
+                                                                    Pulse_Syntax_Base.FOLD
+                                                                    {
+                                                                    Pulse_Syntax_Base.names
+                                                                    = ns;
+                                                                    Pulse_Syntax_Base.p1
+                                                                    = uu___5;_}
+                                                                    ->
+                                                                    Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.AssertWithBinders.fst"
+                                                                    (Prims.of_int (243))
+                                                                    (Prims.of_int (8))
+                                                                    (Prims.of_int (243))
+                                                                    (Prims.of_int (48)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.AssertWithBinders.fst"
+                                                                    (Prims.of_int (243))
+                                                                    (Prims.of_int (8))
+                                                                    (Prims.of_int (244))
+                                                                    (Prims.of_int (16)))))
+                                                                    (Obj.magic
+                                                                    (unfold_defs
+                                                                    (Pulse_Typing_Env.push_env
+                                                                    g1 uvs)
+                                                                    ns
+                                                                    v_opened1))
+                                                                    (fun
+                                                                    uu___6 ->
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___7 ->
+                                                                    (uu___6,
+                                                                    v_opened1)))))
+                                                                    (fun
+                                                                    uu___5 ->
+                                                                    (fun
+                                                                    uu___5 ->
+                                                                    match uu___5
+                                                                    with
+                                                                    | 
+                                                                    (lhs,
+                                                                    rhs) ->
+                                                                    Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.AssertWithBinders.fst"
+                                                                    (Prims.of_int (245))
+                                                                    (Prims.of_int (17))
+                                                                    (Prims.of_int (245))
+                                                                    (Prims.of_int (37)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.AssertWithBinders.fst"
+                                                                    (Prims.of_int (245))
+                                                                    (Prims.of_int (40))
+                                                                    (Prims.of_int (262))
+                                                                    (Prims.of_int (50)))))
+                                                                    (FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___6 ->
+                                                                    FStar_List_Tot_Base.rev
+                                                                    (Pulse_Typing_Env.bindings
+                                                                    uvs)))
+                                                                    (fun
+                                                                    uu___6 ->
+                                                                    (fun
+                                                                    uvs_bs ->
+                                                                    Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.AssertWithBinders.fst"
+                                                                    (Prims.of_int (246))
+                                                                    (Prims.of_int (19))
+                                                                    (Prims.of_int (246))
+                                                                    (Prims.of_int (69)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.AssertWithBinders.fst"
+                                                                    (Prims.of_int (245))
+                                                                    (Prims.of_int (40))
+                                                                    (Prims.of_int (262))
+                                                                    (Prims.of_int (50)))))
+                                                                    (FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___6 ->
+                                                                    ((close_binders
+                                                                    uvs_bs
+                                                                    lhs),
+                                                                    (close_binders
+                                                                    uvs_bs
+                                                                    rhs))))
+                                                                    (fun
+                                                                    uu___6 ->
+                                                                    (fun
+                                                                    uu___6 ->
+                                                                    match uu___6
+                                                                    with
+                                                                    | 
+                                                                    (lhs1,
+                                                                    rhs1) ->
+                                                                    Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.AssertWithBinders.fst"
+                                                                    (Prims.of_int (247))
+                                                                    (Prims.of_int (15))
+                                                                    (Prims.of_int (249))
+                                                                    (Prims.of_int (31)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.AssertWithBinders.fst"
+                                                                    (Prims.of_int (249))
+                                                                    (Prims.of_int (36))
+                                                                    (Prims.of_int (262))
+                                                                    (Prims.of_int (50)))))
+                                                                    (FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___7 ->
+                                                                    {
+                                                                    Pulse_Syntax_Base.term1
+                                                                    =
+                                                                    (Pulse_Syntax_Base.Tm_Rewrite
+                                                                    {
+                                                                    Pulse_Syntax_Base.t1
+                                                                    = lhs1;
+                                                                    Pulse_Syntax_Base.t2
+                                                                    = rhs1
+                                                                    });
+                                                                    Pulse_Syntax_Base.range2
+                                                                    =
+                                                                    (st.Pulse_Syntax_Base.range2)
+                                                                    }))
+                                                                    (fun
+                                                                    uu___7 ->
+                                                                    (fun rw
+                                                                    ->
+                                                                    Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.AssertWithBinders.fst"
+                                                                    (Prims.of_int (250))
+                                                                    (Prims.of_int (15))
+                                                                    (Prims.of_int (252))
+                                                                    (Prims.of_int (31)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.AssertWithBinders.fst"
+                                                                    (Prims.of_int (252))
+                                                                    (Prims.of_int (36))
+                                                                    (Prims.of_int (262))
+                                                                    (Prims.of_int (50)))))
+                                                                    (FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___7 ->
+                                                                    {
+                                                                    Pulse_Syntax_Base.term1
+                                                                    =
+                                                                    (Pulse_Syntax_Base.Tm_Bind
+                                                                    {
+                                                                    Pulse_Syntax_Base.binder
+                                                                    =
+                                                                    (Pulse_Typing.as_binder
+                                                                    (Pulse_Syntax_Base.tm_fstar
+                                                                    (FStar_Reflection_V2_Builtins.pack_ln
+                                                                    (FStar_Reflection_V2_Data.Tv_FVar
+                                                                    (FStar_Reflection_V2_Builtins.pack_fv
+                                                                    ["Prims";
+                                                                    "unit"])))
+                                                                    st.Pulse_Syntax_Base.range2));
+                                                                    Pulse_Syntax_Base.head1
+                                                                    = rw;
+                                                                    Pulse_Syntax_Base.body1
+                                                                    = body
+                                                                    });
+                                                                    Pulse_Syntax_Base.range2
+                                                                    =
+                                                                    (st.Pulse_Syntax_Base.range2)
+                                                                    }))
+                                                                    (fun
+                                                                    uu___7 ->
+                                                                    (fun st1
+                                                                    ->
+                                                                    Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.AssertWithBinders.fst"
+                                                                    (Prims.of_int (255))
+                                                                    (Prims.of_int (6))
+                                                                    (Prims.of_int (261))
+                                                                    (Prims.of_int (28)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.AssertWithBinders.fst"
+                                                                    (Prims.of_int (262))
+                                                                    (Prims.of_int (4))
+                                                                    (Prims.of_int (262))
+                                                                    (Prims.of_int (50)))))
+                                                                    (FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___7 ->
+                                                                    match bs1
+                                                                    with
+                                                                    | 
+                                                                    [] -> st1
+                                                                    | 
+                                                                    uu___8 ->
+                                                                    {
+                                                                    Pulse_Syntax_Base.term1
+                                                                    =
+                                                                    (Pulse_Syntax_Base.Tm_ProofHintWithBinders
+                                                                    {
+                                                                    Pulse_Syntax_Base.hint_type
+                                                                    =
+                                                                    (Pulse_Syntax_Base.ASSERT
+                                                                    {
+                                                                    Pulse_Syntax_Base.p
+                                                                    = lhs1
+                                                                    });
+                                                                    Pulse_Syntax_Base.binders
+                                                                    = bs1;
+                                                                    Pulse_Syntax_Base.t3
+                                                                    = st1
+                                                                    });
+                                                                    Pulse_Syntax_Base.range2
+                                                                    =
+                                                                    (st1.Pulse_Syntax_Base.range2)
+                                                                    }))
+                                                                    (fun
+                                                                    uu___7 ->
+                                                                    (fun st2
+                                                                    ->
+                                                                    Obj.magic
+                                                                    (check1
+                                                                    g1 pre ()
+                                                                    post_hint
+                                                                    res_ppname
+                                                                    st2))
+                                                                    uu___7)))
+                                                                    uu___7)))
+                                                                    uu___7)))
+                                                                    uu___6)))
+                                                                    uu___6)))
+                                                                    uu___5)))
+                                                                    uu___3)))
+                                                                    uu___2)))
+                                                                    uu___1)))
+                                                         uu___1))))) uu___)))
+                       uu___)

--- a/src/ocaml/plugin/generated/Pulse_Checker_AssertWithBinders.ml
+++ b/src/ocaml/plugin/generated/Pulse_Checker_AssertWithBinders.ml
@@ -1693,31 +1693,872 @@ let (rewrite_one :
   (Pulse_Syntax_Base.term * Pulse_Syntax_Base.term) ->
     Pulse_Syntax_Base.term -> Pulse_Syntax_Base.term)
   = fun p -> fun t -> t
-let (rewrite_all :
-  (Pulse_Syntax_Base.term * Pulse_Syntax_Base.term) Prims.list ->
+let (visit_and_rewrite :
+  (FStar_Reflection_Types.term * FStar_Reflection_Types.term) Prims.list ->
     Pulse_Syntax_Base.term ->
-      Pulse_Syntax_Base.term FStar_Pervasives_Native.option)
+      (Pulse_Syntax_Base.term, unit) FStar_Tactics_Effect.tac_repr)
   =
   fun p ->
     fun t ->
-      let rec as_subst p1 out =
-        match p1 with
-        | [] -> FStar_Pervasives_Native.Some out
-        | (e1, e2)::p2 ->
-            (match e1.Pulse_Syntax_Base.t with
-             | Pulse_Syntax_Base.Tm_FStar e11 ->
-                 (match FStar_Reflection_V2_Builtins.inspect_ln e11 with
-                  | FStar_Reflection_V2_Data.Tv_Var n ->
-                      let nv = FStar_Reflection_V2_Builtins.inspect_namedv n in
-                      as_subst p2
-                        ((Pulse_Syntax_Naming.NT
-                            ((nv.FStar_Reflection_V2_Data.uniq), e2)) :: out)
-                  | uu___ -> FStar_Pervasives_Native.None)
-             | uu___ -> FStar_Pervasives_Native.None) in
-      match as_subst p [] with
-      | FStar_Pervasives_Native.Some s ->
-          FStar_Pervasives_Native.Some (Pulse_Syntax_Naming.subst_term t s)
-      | uu___ -> FStar_Pervasives_Native.None
+      FStar_Tactics_Effect.tac_bind
+        (FStar_Sealed.seal
+           (Obj.magic
+              (FStar_Range.mk_range "Pulse.Checker.AssertWithBinders.fst"
+                 (Prims.of_int (138)) (Prims.of_int (4)) (Prims.of_int (140))
+                 (Prims.of_int (24)))))
+        (FStar_Sealed.seal
+           (Obj.magic
+              (FStar_Range.mk_range "Pulse.Checker.AssertWithBinders.fst"
+                 (Prims.of_int (141)) (Prims.of_int (4)) (Prims.of_int (158))
+                 (Prims.of_int (7)))))
+        (FStar_Tactics_Effect.lift_div_tac
+           (fun uu___1 ->
+              fun uu___ ->
+                (fun uu___ ->
+                   fun t1 ->
+                     Obj.magic
+                       (FStar_Tactics_Effect.lift_div_tac
+                          (fun uu___1 ->
+                             match FStar_List_Tot_Base.tryFind
+                                     (fun uu___2 ->
+                                        match uu___2 with
+                                        | (x, uu___3) ->
+                                            FStar_Reflection_V2_TermEq.term_eq
+                                              x t1) p
+                             with
+                             | FStar_Pervasives_Native.None -> t1
+                             | FStar_Pervasives_Native.Some (uu___2, t') ->
+                                 t'))) uu___1 uu___))
+        (fun uu___ ->
+           (fun visitor ->
+              let rec aux uu___ =
+                (fun t1 ->
+                   match t1.Pulse_Syntax_Base.t with
+                   | Pulse_Syntax_Base.Tm_Emp ->
+                       Obj.magic
+                         (Obj.repr
+                            (FStar_Tactics_Effect.lift_div_tac
+                               (fun uu___ -> t1)))
+                   | Pulse_Syntax_Base.Tm_VProp ->
+                       Obj.magic
+                         (Obj.repr
+                            (FStar_Tactics_Effect.lift_div_tac
+                               (fun uu___ -> t1)))
+                   | Pulse_Syntax_Base.Tm_Inames ->
+                       Obj.magic
+                         (Obj.repr
+                            (FStar_Tactics_Effect.lift_div_tac
+                               (fun uu___ -> t1)))
+                   | Pulse_Syntax_Base.Tm_EmpInames ->
+                       Obj.magic
+                         (Obj.repr
+                            (FStar_Tactics_Effect.lift_div_tac
+                               (fun uu___ -> t1)))
+                   | Pulse_Syntax_Base.Tm_Unknown ->
+                       Obj.magic
+                         (Obj.repr
+                            (FStar_Tactics_Effect.lift_div_tac
+                               (fun uu___ -> t1)))
+                   | Pulse_Syntax_Base.Tm_Pure p1 ->
+                       Obj.magic
+                         (Obj.repr
+                            (FStar_Tactics_Effect.tac_bind
+                               (FStar_Sealed.seal
+                                  (Obj.magic
+                                     (FStar_Range.mk_range
+                                        "Pulse.Checker.AssertWithBinders.fst"
+                                        (Prims.of_int (149))
+                                        (Prims.of_int (32))
+                                        (Prims.of_int (149))
+                                        (Prims.of_int (47)))))
+                               (FStar_Sealed.seal
+                                  (Obj.magic
+                                     (FStar_Range.mk_range
+                                        "Pulse.Checker.AssertWithBinders.fst"
+                                        (Prims.of_int (149))
+                                        (Prims.of_int (21))
+                                        (Prims.of_int (149))
+                                        (Prims.of_int (47)))))
+                               (Obj.magic
+                                  (FStar_Tactics_Effect.tac_bind
+                                     (FStar_Sealed.seal
+                                        (Obj.magic
+                                           (FStar_Range.mk_range
+                                              "Pulse.Checker.AssertWithBinders.fst"
+                                              (Prims.of_int (149))
+                                              (Prims.of_int (40))
+                                              (Prims.of_int (149))
+                                              (Prims.of_int (47)))))
+                                     (FStar_Sealed.seal
+                                        (Obj.magic
+                                           (FStar_Range.mk_range
+                                              "Pulse.Checker.AssertWithBinders.fst"
+                                              (Prims.of_int (149))
+                                              (Prims.of_int (32))
+                                              (Prims.of_int (149))
+                                              (Prims.of_int (47)))))
+                                     (Obj.magic (aux p1))
+                                     (fun uu___ ->
+                                        FStar_Tactics_Effect.lift_div_tac
+                                          (fun uu___1 ->
+                                             Pulse_Syntax_Base.Tm_Pure uu___))))
+                               (fun uu___ ->
+                                  FStar_Tactics_Effect.lift_div_tac
+                                    (fun uu___1 ->
+                                       {
+                                         Pulse_Syntax_Base.t = uu___;
+                                         Pulse_Syntax_Base.range1 =
+                                           (t1.Pulse_Syntax_Base.range1)
+                                       }))))
+                   | Pulse_Syntax_Base.Tm_Star (l, r) ->
+                       Obj.magic
+                         (Obj.repr
+                            (FStar_Tactics_Effect.tac_bind
+                               (FStar_Sealed.seal
+                                  (Obj.magic
+                                     (FStar_Range.mk_range
+                                        "Pulse.Checker.AssertWithBinders.fst"
+                                        (Prims.of_int (150))
+                                        (Prims.of_int (35))
+                                        (Prims.of_int (150))
+                                        (Prims.of_int (58)))))
+                               (FStar_Sealed.seal
+                                  (Obj.magic
+                                     (FStar_Range.mk_range
+                                        "Pulse.Checker.AssertWithBinders.fst"
+                                        (Prims.of_int (150))
+                                        (Prims.of_int (24))
+                                        (Prims.of_int (150))
+                                        (Prims.of_int (58)))))
+                               (Obj.magic
+                                  (FStar_Tactics_Effect.tac_bind
+                                     (FStar_Sealed.seal
+                                        (Obj.magic
+                                           (FStar_Range.mk_range
+                                              "Pulse.Checker.AssertWithBinders.fst"
+                                              (Prims.of_int (150))
+                                              (Prims.of_int (43))
+                                              (Prims.of_int (150))
+                                              (Prims.of_int (50)))))
+                                     (FStar_Sealed.seal
+                                        (Obj.magic
+                                           (FStar_Range.mk_range
+                                              "Pulse.Checker.AssertWithBinders.fst"
+                                              (Prims.of_int (150))
+                                              (Prims.of_int (35))
+                                              (Prims.of_int (150))
+                                              (Prims.of_int (58)))))
+                                     (Obj.magic (aux l))
+                                     (fun uu___ ->
+                                        (fun uu___ ->
+                                           Obj.magic
+                                             (FStar_Tactics_Effect.tac_bind
+                                                (FStar_Sealed.seal
+                                                   (Obj.magic
+                                                      (FStar_Range.mk_range
+                                                         "Pulse.Checker.AssertWithBinders.fst"
+                                                         (Prims.of_int (150))
+                                                         (Prims.of_int (51))
+                                                         (Prims.of_int (150))
+                                                         (Prims.of_int (58)))))
+                                                (FStar_Sealed.seal
+                                                   (Obj.magic
+                                                      (FStar_Range.mk_range
+                                                         "Pulse.Checker.AssertWithBinders.fst"
+                                                         (Prims.of_int (150))
+                                                         (Prims.of_int (35))
+                                                         (Prims.of_int (150))
+                                                         (Prims.of_int (58)))))
+                                                (Obj.magic (aux r))
+                                                (fun uu___1 ->
+                                                   FStar_Tactics_Effect.lift_div_tac
+                                                     (fun uu___2 ->
+                                                        Pulse_Syntax_Base.Tm_Star
+                                                          (uu___, uu___1)))))
+                                          uu___)))
+                               (fun uu___ ->
+                                  FStar_Tactics_Effect.lift_div_tac
+                                    (fun uu___1 ->
+                                       {
+                                         Pulse_Syntax_Base.t = uu___;
+                                         Pulse_Syntax_Base.range1 =
+                                           (t1.Pulse_Syntax_Base.range1)
+                                       }))))
+                   | Pulse_Syntax_Base.Tm_ExistsSL (u, b, body) ->
+                       Obj.magic
+                         (Obj.repr
+                            (FStar_Tactics_Effect.tac_bind
+                               (FStar_Sealed.seal
+                                  (Obj.magic
+                                     (FStar_Range.mk_range
+                                        "Pulse.Checker.AssertWithBinders.fst"
+                                        (Prims.of_int (151))
+                                        (Prims.of_int (43))
+                                        (Prims.of_int (151))
+                                        (Prims.of_int (103)))))
+                               (FStar_Sealed.seal
+                                  (Obj.magic
+                                     (FStar_Range.mk_range
+                                        "Pulse.Checker.AssertWithBinders.fst"
+                                        (Prims.of_int (151))
+                                        (Prims.of_int (32))
+                                        (Prims.of_int (151))
+                                        (Prims.of_int (103)))))
+                               (Obj.magic
+                                  (FStar_Tactics_Effect.tac_bind
+                                     (FStar_Sealed.seal
+                                        (Obj.magic
+                                           (FStar_Range.mk_range
+                                              "Pulse.Checker.AssertWithBinders.fst"
+                                              (Prims.of_int (151))
+                                              (Prims.of_int (59))
+                                              (Prims.of_int (151))
+                                              (Prims.of_int (91)))))
+                                     (FStar_Sealed.seal
+                                        (Obj.magic
+                                           (FStar_Range.mk_range
+                                              "Pulse.Checker.AssertWithBinders.fst"
+                                              (Prims.of_int (151))
+                                              (Prims.of_int (43))
+                                              (Prims.of_int (151))
+                                              (Prims.of_int (103)))))
+                                     (Obj.magic
+                                        (FStar_Tactics_Effect.tac_bind
+                                           (FStar_Sealed.seal
+                                              (Obj.magic
+                                                 (FStar_Range.mk_range
+                                                    "Pulse.Checker.AssertWithBinders.fst"
+                                                    (Prims.of_int (151))
+                                                    (Prims.of_int (76))
+                                                    (Prims.of_int (151))
+                                                    (Prims.of_int (91)))))
+                                           (FStar_Sealed.seal
+                                              (Obj.magic
+                                                 (FStar_Range.mk_range
+                                                    "Pulse.Checker.AssertWithBinders.fst"
+                                                    (Prims.of_int (151))
+                                                    (Prims.of_int (59))
+                                                    (Prims.of_int (151))
+                                                    (Prims.of_int (91)))))
+                                           (Obj.magic
+                                              (aux
+                                                 b.Pulse_Syntax_Base.binder_ty))
+                                           (fun uu___ ->
+                                              FStar_Tactics_Effect.lift_div_tac
+                                                (fun uu___1 ->
+                                                   {
+                                                     Pulse_Syntax_Base.binder_ty
+                                                       = uu___;
+                                                     Pulse_Syntax_Base.binder_ppname
+                                                       =
+                                                       (b.Pulse_Syntax_Base.binder_ppname)
+                                                   }))))
+                                     (fun uu___ ->
+                                        (fun uu___ ->
+                                           Obj.magic
+                                             (FStar_Tactics_Effect.tac_bind
+                                                (FStar_Sealed.seal
+                                                   (Obj.magic
+                                                      (FStar_Range.mk_range
+                                                         "Pulse.Checker.AssertWithBinders.fst"
+                                                         (Prims.of_int (151))
+                                                         (Prims.of_int (93))
+                                                         (Prims.of_int (151))
+                                                         (Prims.of_int (103)))))
+                                                (FStar_Sealed.seal
+                                                   (Obj.magic
+                                                      (FStar_Range.mk_range
+                                                         "Pulse.Checker.AssertWithBinders.fst"
+                                                         (Prims.of_int (151))
+                                                         (Prims.of_int (43))
+                                                         (Prims.of_int (151))
+                                                         (Prims.of_int (103)))))
+                                                (Obj.magic (aux body))
+                                                (fun uu___1 ->
+                                                   FStar_Tactics_Effect.lift_div_tac
+                                                     (fun uu___2 ->
+                                                        Pulse_Syntax_Base.Tm_ExistsSL
+                                                          (u, uu___, uu___1)))))
+                                          uu___)))
+                               (fun uu___ ->
+                                  FStar_Tactics_Effect.lift_div_tac
+                                    (fun uu___1 ->
+                                       {
+                                         Pulse_Syntax_Base.t = uu___;
+                                         Pulse_Syntax_Base.range1 =
+                                           (t1.Pulse_Syntax_Base.range1)
+                                       }))))
+                   | Pulse_Syntax_Base.Tm_ForallSL (u, b, body) ->
+                       Obj.magic
+                         (Obj.repr
+                            (FStar_Tactics_Effect.tac_bind
+                               (FStar_Sealed.seal
+                                  (Obj.magic
+                                     (FStar_Range.mk_range
+                                        "Pulse.Checker.AssertWithBinders.fst"
+                                        (Prims.of_int (152))
+                                        (Prims.of_int (43))
+                                        (Prims.of_int (152))
+                                        (Prims.of_int (103)))))
+                               (FStar_Sealed.seal
+                                  (Obj.magic
+                                     (FStar_Range.mk_range
+                                        "Pulse.Checker.AssertWithBinders.fst"
+                                        (Prims.of_int (152))
+                                        (Prims.of_int (32))
+                                        (Prims.of_int (152))
+                                        (Prims.of_int (103)))))
+                               (Obj.magic
+                                  (FStar_Tactics_Effect.tac_bind
+                                     (FStar_Sealed.seal
+                                        (Obj.magic
+                                           (FStar_Range.mk_range
+                                              "Pulse.Checker.AssertWithBinders.fst"
+                                              (Prims.of_int (152))
+                                              (Prims.of_int (59))
+                                              (Prims.of_int (152))
+                                              (Prims.of_int (91)))))
+                                     (FStar_Sealed.seal
+                                        (Obj.magic
+                                           (FStar_Range.mk_range
+                                              "Pulse.Checker.AssertWithBinders.fst"
+                                              (Prims.of_int (152))
+                                              (Prims.of_int (43))
+                                              (Prims.of_int (152))
+                                              (Prims.of_int (103)))))
+                                     (Obj.magic
+                                        (FStar_Tactics_Effect.tac_bind
+                                           (FStar_Sealed.seal
+                                              (Obj.magic
+                                                 (FStar_Range.mk_range
+                                                    "Pulse.Checker.AssertWithBinders.fst"
+                                                    (Prims.of_int (152))
+                                                    (Prims.of_int (76))
+                                                    (Prims.of_int (152))
+                                                    (Prims.of_int (91)))))
+                                           (FStar_Sealed.seal
+                                              (Obj.magic
+                                                 (FStar_Range.mk_range
+                                                    "Pulse.Checker.AssertWithBinders.fst"
+                                                    (Prims.of_int (152))
+                                                    (Prims.of_int (59))
+                                                    (Prims.of_int (152))
+                                                    (Prims.of_int (91)))))
+                                           (Obj.magic
+                                              (aux
+                                                 b.Pulse_Syntax_Base.binder_ty))
+                                           (fun uu___ ->
+                                              FStar_Tactics_Effect.lift_div_tac
+                                                (fun uu___1 ->
+                                                   {
+                                                     Pulse_Syntax_Base.binder_ty
+                                                       = uu___;
+                                                     Pulse_Syntax_Base.binder_ppname
+                                                       =
+                                                       (b.Pulse_Syntax_Base.binder_ppname)
+                                                   }))))
+                                     (fun uu___ ->
+                                        (fun uu___ ->
+                                           Obj.magic
+                                             (FStar_Tactics_Effect.tac_bind
+                                                (FStar_Sealed.seal
+                                                   (Obj.magic
+                                                      (FStar_Range.mk_range
+                                                         "Pulse.Checker.AssertWithBinders.fst"
+                                                         (Prims.of_int (152))
+                                                         (Prims.of_int (93))
+                                                         (Prims.of_int (152))
+                                                         (Prims.of_int (103)))))
+                                                (FStar_Sealed.seal
+                                                   (Obj.magic
+                                                      (FStar_Range.mk_range
+                                                         "Pulse.Checker.AssertWithBinders.fst"
+                                                         (Prims.of_int (152))
+                                                         (Prims.of_int (43))
+                                                         (Prims.of_int (152))
+                                                         (Prims.of_int (103)))))
+                                                (Obj.magic (aux body))
+                                                (fun uu___1 ->
+                                                   FStar_Tactics_Effect.lift_div_tac
+                                                     (fun uu___2 ->
+                                                        Pulse_Syntax_Base.Tm_ForallSL
+                                                          (u, uu___, uu___1)))))
+                                          uu___)))
+                               (fun uu___ ->
+                                  FStar_Tactics_Effect.lift_div_tac
+                                    (fun uu___1 ->
+                                       {
+                                         Pulse_Syntax_Base.t = uu___;
+                                         Pulse_Syntax_Base.range1 =
+                                           (t1.Pulse_Syntax_Base.range1)
+                                       }))))
+                   | Pulse_Syntax_Base.Tm_FStar h ->
+                       Obj.magic
+                         (Obj.repr
+                            (FStar_Tactics_Effect.tac_bind
+                               (FStar_Sealed.seal
+                                  (Obj.magic
+                                     (FStar_Range.mk_range
+                                        "Pulse.Checker.AssertWithBinders.fst"
+                                        (Prims.of_int (154))
+                                        (Prims.of_int (14))
+                                        (Prims.of_int (154))
+                                        (Prims.of_int (52)))))
+                               (FStar_Sealed.seal
+                                  (Obj.magic
+                                     (FStar_Range.mk_range
+                                        "Pulse.Checker.AssertWithBinders.fst"
+                                        (Prims.of_int (156))
+                                        (Prims.of_int (8))
+                                        (Prims.of_int (156))
+                                        (Prims.of_int (27)))))
+                               (Obj.magic
+                                  (FStar_Tactics_Visit.visit_tm visitor h))
+                               (fun h1 ->
+                                  FStar_Tactics_Effect.lift_div_tac
+                                    (fun uu___ ->
+                                       {
+                                         Pulse_Syntax_Base.t =
+                                           (Pulse_Syntax_Base.Tm_FStar h1);
+                                         Pulse_Syntax_Base.range1 =
+                                           (t1.Pulse_Syntax_Base.range1)
+                                       }))))) uu___ in
+              Obj.magic (aux t)) uu___)
+let (visit_and_rewrite_conjuncts :
+  (FStar_Reflection_Types.term * FStar_Reflection_Types.term) Prims.list ->
+    Pulse_Syntax_Base.term ->
+      ((Pulse_Syntax_Base.term * Pulse_Syntax_Base.term), unit)
+        FStar_Tactics_Effect.tac_repr)
+  =
+  fun p ->
+    fun t ->
+      FStar_Tactics_Effect.tac_bind
+        (FStar_Sealed.seal
+           (Obj.magic
+              (FStar_Range.mk_range "Pulse.Checker.AssertWithBinders.fst"
+                 (Prims.of_int (161)) (Prims.of_int (12))
+                 (Prims.of_int (161)) (Prims.of_int (52)))))
+        (FStar_Sealed.seal
+           (Obj.magic
+              (FStar_Range.mk_range "Pulse.Checker.AssertWithBinders.fst"
+                 (Prims.of_int (161)) (Prims.of_int (55))
+                 (Prims.of_int (174)) (Prims.of_int (10)))))
+        (FStar_Tactics_Effect.lift_div_tac
+           (fun uu___ -> Pulse_Typing_Combinators.vprop_as_list t))
+        (fun uu___ ->
+           (fun tms ->
+              Obj.magic
+                (FStar_Tactics_Effect.tac_bind
+                   (FStar_Sealed.seal
+                      (Obj.magic
+                         (FStar_Range.mk_range
+                            "Pulse.Checker.AssertWithBinders.fst"
+                            (Prims.of_int (163)) (Prims.of_int (4))
+                            (Prims.of_int (169)) (Prims.of_int (5)))))
+                   (FStar_Sealed.seal
+                      (Obj.magic
+                         (FStar_Range.mk_range
+                            "Pulse.Checker.AssertWithBinders.fst"
+                            (Prims.of_int (170)) (Prims.of_int (4))
+                            (Prims.of_int (174)) (Prims.of_int (10)))))
+                   (Obj.magic
+                      (FStar_Tactics_Effect.tac_bind
+                         (FStar_Sealed.seal
+                            (Obj.magic
+                               (FStar_Range.mk_range
+                                  "Pulse.Checker.AssertWithBinders.fst"
+                                  (Prims.of_int (163)) (Prims.of_int (14))
+                                  (Prims.of_int (169)) (Prims.of_int (5)))))
+                         (FStar_Sealed.seal
+                            (Obj.magic
+                               (FStar_Range.mk_range
+                                  "Pulse.Checker.AssertWithBinders.fst"
+                                  (Prims.of_int (163)) (Prims.of_int (4))
+                                  (Prims.of_int (169)) (Prims.of_int (5)))))
+                         (Obj.magic
+                            (FStar_Tactics_Util.map
+                               (fun t1 ->
+                                  FStar_Tactics_Effect.tac_bind
+                                    (FStar_Sealed.seal
+                                       (Obj.magic
+                                          (FStar_Range.mk_range
+                                             "Pulse.Checker.AssertWithBinders.fst"
+                                             (Prims.of_int (166))
+                                             (Prims.of_int (18))
+                                             (Prims.of_int (166))
+                                             (Prims.of_int (39)))))
+                                    (FStar_Sealed.seal
+                                       (Obj.magic
+                                          (FStar_Range.mk_range
+                                             "Pulse.Checker.AssertWithBinders.fst"
+                                             (Prims.of_int (167))
+                                             (Prims.of_int (10))
+                                             (Prims.of_int (167))
+                                             (Prims.of_int (44)))))
+                                    (Obj.magic (visit_and_rewrite p t1))
+                                    (fun s ->
+                                       FStar_Tactics_Effect.lift_div_tac
+                                         (fun uu___ ->
+                                            if Pulse_Syntax_Base.eq_tm s t1
+                                            then []
+                                            else [(t1, s)]))) tms))
+                         (fun uu___ ->
+                            FStar_Tactics_Effect.lift_div_tac
+                              (fun uu___1 ->
+                                 FStar_List_Tot_Base.flatten uu___))))
+                   (fun tms1 ->
+                      FStar_Tactics_Effect.lift_div_tac
+                        (fun uu___ ->
+                           match FStar_List_Tot_Base.unzip tms1 with
+                           | (lhs, rhs) ->
+                               ((Pulse_Typing_Combinators.list_as_vprop lhs),
+                                 (Pulse_Typing_Combinators.list_as_vprop rhs))))))
+             uu___)
+let rec (as_subst :
+  (Pulse_Syntax_Base.term * Pulse_Syntax_Base.term) Prims.list ->
+    Pulse_Syntax_Naming.subst_elt Prims.list ->
+      Pulse_Syntax_Naming.subst_elt Prims.list FStar_Pervasives_Native.option)
+  =
+  fun p ->
+    fun out ->
+      match p with
+      | [] -> FStar_Pervasives_Native.Some out
+      | (e1, e2)::p1 ->
+          (match e1.Pulse_Syntax_Base.t with
+           | Pulse_Syntax_Base.Tm_FStar e11 ->
+               (match FStar_Reflection_V2_Builtins.inspect_ln e11 with
+                | FStar_Reflection_V2_Data.Tv_Var n ->
+                    let nv = FStar_Reflection_V2_Builtins.inspect_namedv n in
+                    as_subst p1
+                      ((Pulse_Syntax_Naming.NT
+                          ((nv.FStar_Reflection_V2_Data.uniq), e2)) :: out)
+                | uu___ -> FStar_Pervasives_Native.None)
+           | uu___ -> FStar_Pervasives_Native.None)
+let (rewrite_all :
+  Pulse_Typing_Env.env ->
+    (Pulse_Syntax_Base.term * Pulse_Syntax_Base.term) Prims.list ->
+      Pulse_Syntax_Base.term ->
+        ((Pulse_Syntax_Base.term * Pulse_Syntax_Base.term), unit)
+          FStar_Tactics_Effect.tac_repr)
+  =
+  fun uu___2 ->
+    fun uu___1 ->
+      fun uu___ ->
+        (fun g ->
+           fun p ->
+             fun t ->
+               match as_subst p [] with
+               | FStar_Pervasives_Native.Some s ->
+                   Obj.magic
+                     (Obj.repr
+                        (FStar_Tactics_Effect.lift_div_tac
+                           (fun uu___ ->
+                              (t, (Pulse_Syntax_Naming.subst_term t s)))))
+               | uu___ ->
+                   Obj.magic
+                     (Obj.repr
+                        (FStar_Tactics_Effect.tac_bind
+                           (FStar_Sealed.seal
+                              (Obj.magic
+                                 (FStar_Range.mk_range
+                                    "Pulse.Checker.AssertWithBinders.fst"
+                                    (Prims.of_int (200)) (Prims.of_int (6))
+                                    (Prims.of_int (204)) (Prims.of_int (9)))))
+                           (FStar_Sealed.seal
+                              (Obj.magic
+                                 (FStar_Range.mk_range
+                                    "Pulse.Checker.AssertWithBinders.fst"
+                                    (Prims.of_int (205)) (Prims.of_int (6))
+                                    (Prims.of_int (208)) (Prims.of_int (12)))))
+                           (Obj.magic
+                              (FStar_Tactics_Util.map
+                                 (fun uu___1 ->
+                                    match uu___1 with
+                                    | (e1, e2) ->
+                                        FStar_Tactics_Effect.tac_bind
+                                          (FStar_Sealed.seal
+                                             (Obj.magic
+                                                (FStar_Range.mk_range
+                                                   "Pulse.Checker.AssertWithBinders.fst"
+                                                   (Prims.of_int (202))
+                                                   (Prims.of_int (10))
+                                                   (Prims.of_int (202))
+                                                   (Prims.of_int (78)))))
+                                          (FStar_Sealed.seal
+                                             (Obj.magic
+                                                (FStar_Range.mk_range
+                                                   "Pulse.Checker.AssertWithBinders.fst"
+                                                   (Prims.of_int (202))
+                                                   (Prims.of_int (10))
+                                                   (Prims.of_int (203))
+                                                   (Prims.of_int (78)))))
+                                          (Obj.magic
+                                             (FStar_Tactics_Effect.tac_bind
+                                                (FStar_Sealed.seal
+                                                   (Obj.magic
+                                                      (FStar_Range.mk_range
+                                                         "Pulse.Checker.AssertWithBinders.fst"
+                                                         (Prims.of_int (202))
+                                                         (Prims.of_int (20))
+                                                         (Prims.of_int (202))
+                                                         (Prims.of_int (78)))))
+                                                (FStar_Sealed.seal
+                                                   (Obj.magic
+                                                      (FStar_Range.mk_range
+                                                         "Pulse.Checker.AssertWithBinders.fst"
+                                                         (Prims.of_int (202))
+                                                         (Prims.of_int (10))
+                                                         (Prims.of_int (202))
+                                                         (Prims.of_int (78)))))
+                                                (Obj.magic
+                                                   (FStar_Tactics_Effect.tac_bind
+                                                      (FStar_Sealed.seal
+                                                         (Obj.magic
+                                                            (FStar_Range.mk_range
+                                                               "Pulse.Checker.AssertWithBinders.fst"
+                                                               (Prims.of_int (202))
+                                                               (Prims.of_int (25))
+                                                               (Prims.of_int (202))
+                                                               (Prims.of_int (77)))))
+                                                      (FStar_Sealed.seal
+                                                         (Obj.magic
+                                                            (FStar_Range.mk_range
+                                                               "Pulse.Checker.AssertWithBinders.fst"
+                                                               (Prims.of_int (202))
+                                                               (Prims.of_int (20))
+                                                               (Prims.of_int (202))
+                                                               (Prims.of_int (78)))))
+                                                      (Obj.magic
+                                                         (Pulse_Checker_Pure.instantiate_term_implicits
+                                                            g e1))
+                                                      (fun uu___2 ->
+                                                         FStar_Tactics_Effect.lift_div_tac
+                                                           (fun uu___3 ->
+                                                              FStar_Pervasives_Native.fst
+                                                                uu___2))))
+                                                (fun uu___2 ->
+                                                   FStar_Tactics_Effect.lift_div_tac
+                                                     (fun uu___3 ->
+                                                        Pulse_Elaborate_Pure.elab_term
+                                                          uu___2))))
+                                          (fun uu___2 ->
+                                             (fun uu___2 ->
+                                                Obj.magic
+                                                  (FStar_Tactics_Effect.tac_bind
+                                                     (FStar_Sealed.seal
+                                                        (Obj.magic
+                                                           (FStar_Range.mk_range
+                                                              "Pulse.Checker.AssertWithBinders.fst"
+                                                              (Prims.of_int (203))
+                                                              (Prims.of_int (10))
+                                                              (Prims.of_int (203))
+                                                              (Prims.of_int (78)))))
+                                                     (FStar_Sealed.seal
+                                                        (Obj.magic
+                                                           (FStar_Range.mk_range
+                                                              "Pulse.Checker.AssertWithBinders.fst"
+                                                              (Prims.of_int (202))
+                                                              (Prims.of_int (10))
+                                                              (Prims.of_int (203))
+                                                              (Prims.of_int (78)))))
+                                                     (Obj.magic
+                                                        (FStar_Tactics_Effect.tac_bind
+                                                           (FStar_Sealed.seal
+                                                              (Obj.magic
+                                                                 (FStar_Range.mk_range
+                                                                    "Pulse.Checker.AssertWithBinders.fst"
+                                                                    (Prims.of_int (203))
+                                                                    (Prims.of_int (20))
+                                                                    (Prims.of_int (203))
+                                                                    (Prims.of_int (78)))))
+                                                           (FStar_Sealed.seal
+                                                              (Obj.magic
+                                                                 (FStar_Range.mk_range
+                                                                    "Pulse.Checker.AssertWithBinders.fst"
+                                                                    (Prims.of_int (203))
+                                                                    (Prims.of_int (10))
+                                                                    (Prims.of_int (203))
+                                                                    (Prims.of_int (78)))))
+                                                           (Obj.magic
+                                                              (FStar_Tactics_Effect.tac_bind
+                                                                 (FStar_Sealed.seal
+                                                                    (
+                                                                    Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.AssertWithBinders.fst"
+                                                                    (Prims.of_int (203))
+                                                                    (Prims.of_int (25))
+                                                                    (Prims.of_int (203))
+                                                                    (Prims.of_int (77)))))
+                                                                 (FStar_Sealed.seal
+                                                                    (
+                                                                    Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.AssertWithBinders.fst"
+                                                                    (Prims.of_int (203))
+                                                                    (Prims.of_int (20))
+                                                                    (Prims.of_int (203))
+                                                                    (Prims.of_int (78)))))
+                                                                 (Obj.magic
+                                                                    (
+                                                                    Pulse_Checker_Pure.instantiate_term_implicits
+                                                                    g e2))
+                                                                 (fun uu___3
+                                                                    ->
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___4 ->
+                                                                    FStar_Pervasives_Native.fst
+                                                                    uu___3))))
+                                                           (fun uu___3 ->
+                                                              FStar_Tactics_Effect.lift_div_tac
+                                                                (fun uu___4
+                                                                   ->
+                                                                   Pulse_Elaborate_Pure.elab_term
+                                                                    uu___3))))
+                                                     (fun uu___3 ->
+                                                        FStar_Tactics_Effect.lift_div_tac
+                                                          (fun uu___4 ->
+                                                             (uu___2, uu___3)))))
+                                               uu___2)) p))
+                           (fun uu___1 ->
+                              (fun p1 ->
+                                 Obj.magic
+                                   (FStar_Tactics_Effect.tac_bind
+                                      (FStar_Sealed.seal
+                                         (Obj.magic
+                                            (FStar_Range.mk_range
+                                               "Pulse.Checker.AssertWithBinders.fst"
+                                               (Prims.of_int (206))
+                                               (Prims.of_int (19))
+                                               (Prims.of_int (206))
+                                               (Prims.of_int (50)))))
+                                      (FStar_Sealed.seal
+                                         (Obj.magic
+                                            (FStar_Range.mk_range
+                                               "Pulse.Checker.AssertWithBinders.fst"
+                                               (Prims.of_int (205))
+                                               (Prims.of_int (6))
+                                               (Prims.of_int (208))
+                                               (Prims.of_int (12)))))
+                                      (Obj.magic
+                                         (visit_and_rewrite_conjuncts p1 t))
+                                      (fun uu___1 ->
+                                         (fun uu___1 ->
+                                            match uu___1 with
+                                            | (lhs, rhs) ->
+                                                Obj.magic
+                                                  (FStar_Tactics_Effect.tac_bind
+                                                     (FStar_Sealed.seal
+                                                        (Obj.magic
+                                                           (FStar_Range.mk_range
+                                                              "Pulse.Checker.AssertWithBinders.fst"
+                                                              (Prims.of_int (207))
+                                                              (Prims.of_int (4))
+                                                              (Prims.of_int (207))
+                                                              (Prims.of_int (106)))))
+                                                     (FStar_Sealed.seal
+                                                        (Obj.magic
+                                                           (FStar_Range.mk_range
+                                                              "Pulse.Checker.AssertWithBinders.fst"
+                                                              (Prims.of_int (208))
+                                                              (Prims.of_int (4))
+                                                              (Prims.of_int (208))
+                                                              (Prims.of_int (12)))))
+                                                     (Obj.magic
+                                                        (debug_log g
+                                                           (fun uu___2 ->
+                                                              FStar_Tactics_Effect.tac_bind
+                                                                (FStar_Sealed.seal
+                                                                   (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.AssertWithBinders.fst"
+                                                                    (Prims.of_int (207))
+                                                                    (Prims.of_int (83))
+                                                                    (Prims.of_int (207))
+                                                                    (Prims.of_int (105)))))
+                                                                (FStar_Sealed.seal
+                                                                   (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.AssertWithBinders.fst"
+                                                                    (Prims.of_int (207))
+                                                                    (Prims.of_int (26))
+                                                                    (Prims.of_int (207))
+                                                                    (Prims.of_int (105)))))
+                                                                (Obj.magic
+                                                                   (Pulse_Syntax_Printer.term_to_string
+                                                                    rhs))
+                                                                (fun uu___3
+                                                                   ->
+                                                                   (fun
+                                                                    uu___3 ->
+                                                                    Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.AssertWithBinders.fst"
+                                                                    (Prims.of_int (207))
+                                                                    (Prims.of_int (26))
+                                                                    (Prims.of_int (207))
+                                                                    (Prims.of_int (105)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.AssertWithBinders.fst"
+                                                                    (Prims.of_int (207))
+                                                                    (Prims.of_int (26))
+                                                                    (Prims.of_int (207))
+                                                                    (Prims.of_int (105)))))
+                                                                    (Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.AssertWithBinders.fst"
+                                                                    (Prims.of_int (207))
+                                                                    (Prims.of_int (60))
+                                                                    (Prims.of_int (207))
+                                                                    (Prims.of_int (82)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "FStar.Printf.fst"
+                                                                    (Prims.of_int (121))
+                                                                    (Prims.of_int (8))
+                                                                    (Prims.of_int (123))
+                                                                    (Prims.of_int (44)))))
+                                                                    (Obj.magic
+                                                                    (Pulse_Syntax_Printer.term_to_string
+                                                                    lhs))
+                                                                    (fun
+                                                                    uu___4 ->
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___5 ->
+                                                                    fun x ->
+                                                                    Prims.strcat
+                                                                    (Prims.strcat
+                                                                    "Rewrote "
+                                                                    (Prims.strcat
+                                                                    uu___4
+                                                                    " to "))
+                                                                    (Prims.strcat
+                                                                    x "")))))
+                                                                    (fun
+                                                                    uu___4 ->
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___5 ->
+                                                                    uu___4
+                                                                    uu___3))))
+                                                                    uu___3))))
+                                                     (fun uu___2 ->
+                                                        FStar_Tactics_Effect.lift_div_tac
+                                                          (fun uu___3 ->
+                                                             (lhs, rhs)))))
+                                           uu___1))) uu___1)))) uu___2 uu___1
+          uu___
 let rec (check_renaming :
   Pulse_Typing_Env.env ->
     Pulse_Syntax_Base.term ->
@@ -1731,12 +2572,12 @@ let rec (check_renaming :
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Checker.AssertWithBinders.fst"
-                   (Prims.of_int (166)) (Prims.of_int (35))
-                   (Prims.of_int (166)) (Prims.of_int (42)))))
+                   (Prims.of_int (219)) (Prims.of_int (35))
+                   (Prims.of_int (219)) (Prims.of_int (42)))))
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Checker.AssertWithBinders.fst"
-                   (Prims.of_int (166)) Prims.int_one (Prims.of_int (195))
+                   (Prims.of_int (219)) Prims.int_one (Prims.of_int (245))
                    (Prims.of_int (3)))))
           (FStar_Tactics_Effect.lift_div_tac
              (fun uu___ -> st.Pulse_Syntax_Base.term1))
@@ -1750,14 +2591,14 @@ let rec (check_renaming :
                             (Obj.magic
                                (FStar_Range.mk_range
                                   "Pulse.Checker.AssertWithBinders.fst"
-                                  (Prims.of_int (167)) (Prims.of_int (65))
-                                  (Prims.of_int (167)) (Prims.of_int (67)))))
+                                  (Prims.of_int (220)) (Prims.of_int (65))
+                                  (Prims.of_int (220)) (Prims.of_int (67)))))
                          (FStar_Sealed.seal
                             (Obj.magic
                                (FStar_Range.mk_range
                                   "Pulse.Checker.AssertWithBinders.fst"
-                                  (Prims.of_int (166)) (Prims.of_int (45))
-                                  (Prims.of_int (195)) (Prims.of_int (3)))))
+                                  (Prims.of_int (219)) (Prims.of_int (45))
+                                  (Prims.of_int (245)) (Prims.of_int (3)))))
                          (FStar_Tactics_Effect.lift_div_tac
                             (fun uu___1 -> ht))
                          (fun uu___1 ->
@@ -1827,53 +2668,40 @@ let rec (check_renaming :
                                     | ([], FStar_Pervasives_Native.None) ->
                                         Obj.magic
                                           (Obj.repr
-                                             (check_renaming g pre
-                                                {
-                                                  Pulse_Syntax_Base.term1 =
-                                                    (Pulse_Syntax_Base.Tm_ProofHintWithBinders
-                                                       {
-                                                         Pulse_Syntax_Base.hint_type
-                                                           =
-                                                           (Pulse_Syntax_Base.RENAME
-                                                              {
-                                                                Pulse_Syntax_Base.pairs
-                                                                  = pairs;
-                                                                Pulse_Syntax_Base.goal
-                                                                  =
-                                                                  (FStar_Pervasives_Native.Some
-                                                                    pre)
-                                                              });
-                                                         Pulse_Syntax_Base.binders
-                                                           =
-                                                           (ht.Pulse_Syntax_Base.binders);
-                                                         Pulse_Syntax_Base.t3
-                                                           =
-                                                           (ht.Pulse_Syntax_Base.t3)
-                                                       });
-                                                  Pulse_Syntax_Base.range2 =
-                                                    (st.Pulse_Syntax_Base.range2)
-                                                }))
-                                    | ([], FStar_Pervasives_Native.Some
-                                       goal1) ->
-                                        Obj.magic
-                                          (Obj.repr
-                                             (match rewrite_all pairs goal1
-                                              with
-                                              | FStar_Pervasives_Native.Some
-                                                  goal' ->
-                                                  Obj.repr
-                                                    (FStar_Tactics_Effect.lift_div_tac
-                                                       (fun uu___2 ->
-                                                          {
-                                                            Pulse_Syntax_Base.term1
-                                                              =
-                                                              (Pulse_Syntax_Base.Tm_Bind
-                                                                 {
-                                                                   Pulse_Syntax_Base.binder
+                                             (FStar_Tactics_Effect.tac_bind
+                                                (FStar_Sealed.seal
+                                                   (Obj.magic
+                                                      (FStar_Range.mk_range
+                                                         "Pulse.Checker.AssertWithBinders.fst"
+                                                         (Prims.of_int (236))
+                                                         (Prims.of_int (19))
+                                                         (Prims.of_int (236))
+                                                         (Prims.of_int (42)))))
+                                                (FStar_Sealed.seal
+                                                   (Obj.magic
+                                                      (FStar_Range.mk_range
+                                                         "Pulse.Checker.AssertWithBinders.fst"
+                                                         (Prims.of_int (234))
+                                                         (Prims.of_int (15))
+                                                         (Prims.of_int (238))
+                                                         (Prims.of_int (77)))))
+                                                (Obj.magic
+                                                   (rewrite_all g pairs pre))
+                                                (fun uu___2 ->
+                                                   FStar_Tactics_Effect.lift_div_tac
+                                                     (fun uu___3 ->
+                                                        match uu___2 with
+                                                        | (lhs, rhs) ->
+                                                            {
+                                                              Pulse_Syntax_Base.term1
+                                                                =
+                                                                (Pulse_Syntax_Base.Tm_Bind
+                                                                   {
+                                                                    Pulse_Syntax_Base.binder
                                                                     =
                                                                     (Pulse_Typing.as_binder
                                                                     Pulse_Typing.tm_unit);
-                                                                   Pulse_Syntax_Base.head1
+                                                                    Pulse_Syntax_Base.head1
                                                                     =
                                                                     {
                                                                     Pulse_Syntax_Base.term1
@@ -1881,29 +2709,115 @@ let rec (check_renaming :
                                                                     (Pulse_Syntax_Base.Tm_Rewrite
                                                                     {
                                                                     Pulse_Syntax_Base.t1
-                                                                    = goal1;
+                                                                    = lhs;
                                                                     Pulse_Syntax_Base.t2
-                                                                    = goal'
+                                                                    = rhs
                                                                     });
                                                                     Pulse_Syntax_Base.range2
                                                                     =
                                                                     (st.Pulse_Syntax_Base.range2)
                                                                     };
-                                                                   Pulse_Syntax_Base.body1
+                                                                    Pulse_Syntax_Base.body1
                                                                     = body
-                                                                 });
-                                                            Pulse_Syntax_Base.range2
-                                                              =
-                                                              (st.Pulse_Syntax_Base.range2)
-                                                          }))
-                                              | FStar_Pervasives_Native.None
-                                                  ->
-                                                  Obj.repr
-                                                    (Pulse_Typing_Env.fail g
-                                                       (FStar_Pervasives_Native.Some
-                                                          (st.Pulse_Syntax_Base.range2))
-                                                       "Failed to rewrite the goal with the given renaming pairs")))))
-                              uu___1))) uu___)
+                                                                   });
+                                                              Pulse_Syntax_Base.range2
+                                                                =
+                                                                (st.Pulse_Syntax_Base.range2)
+                                                            }))))
+                                    | ([], FStar_Pervasives_Native.Some
+                                       goal1) ->
+                                        Obj.magic
+                                          (Obj.repr
+                                             (FStar_Tactics_Effect.tac_bind
+                                                (FStar_Sealed.seal
+                                                   (Obj.magic
+                                                      (FStar_Range.mk_range
+                                                         "Pulse.Checker.AssertWithBinders.fst"
+                                                         (Prims.of_int (241))
+                                                         (Prims.of_int (20))
+                                                         (Prims.of_int (241))
+                                                         (Prims.of_int (56)))))
+                                                (FStar_Sealed.seal
+                                                   (Obj.magic
+                                                      (FStar_Range.mk_range
+                                                         "Pulse.Checker.AssertWithBinders.fst"
+                                                         (Prims.of_int (240))
+                                                         (Prims.of_int (21))
+                                                         (Prims.of_int (245))
+                                                         (Prims.of_int (3)))))
+                                                (Obj.magic
+                                                   (Pulse_Checker_Pure.instantiate_term_implicits
+                                                      g goal1))
+                                                (fun uu___2 ->
+                                                   (fun uu___2 ->
+                                                      match uu___2 with
+                                                      | (goal2, uu___3) ->
+                                                          Obj.magic
+                                                            (FStar_Tactics_Effect.tac_bind
+                                                               (FStar_Sealed.seal
+                                                                  (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.AssertWithBinders.fst"
+                                                                    (Prims.of_int (242))
+                                                                    (Prims.of_int (21))
+                                                                    (Prims.of_int (242))
+                                                                    (Prims.of_int (45)))))
+                                                               (FStar_Sealed.seal
+                                                                  (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.AssertWithBinders.fst"
+                                                                    (Prims.of_int (241))
+                                                                    (Prims.of_int (59))
+                                                                    (Prims.of_int (244))
+                                                                    (Prims.of_int (79)))))
+                                                               (Obj.magic
+                                                                  (rewrite_all
+                                                                    g pairs
+                                                                    goal2))
+                                                               (fun uu___4 ->
+                                                                  FStar_Tactics_Effect.lift_div_tac
+                                                                    (
+                                                                    fun
+                                                                    uu___5 ->
+                                                                    match uu___4
+                                                                    with
+                                                                    | 
+                                                                    (lhs,
+                                                                    rhs) ->
+                                                                    {
+                                                                    Pulse_Syntax_Base.term1
+                                                                    =
+                                                                    (Pulse_Syntax_Base.Tm_Bind
+                                                                    {
+                                                                    Pulse_Syntax_Base.binder
+                                                                    =
+                                                                    (Pulse_Typing.as_binder
+                                                                    Pulse_Typing.tm_unit);
+                                                                    Pulse_Syntax_Base.head1
+                                                                    =
+                                                                    {
+                                                                    Pulse_Syntax_Base.term1
+                                                                    =
+                                                                    (Pulse_Syntax_Base.Tm_Rewrite
+                                                                    {
+                                                                    Pulse_Syntax_Base.t1
+                                                                    = lhs;
+                                                                    Pulse_Syntax_Base.t2
+                                                                    = rhs
+                                                                    });
+                                                                    Pulse_Syntax_Base.range2
+                                                                    =
+                                                                    (st.Pulse_Syntax_Base.range2)
+                                                                    };
+                                                                    Pulse_Syntax_Base.body1
+                                                                    = body
+                                                                    });
+                                                                    Pulse_Syntax_Base.range2
+                                                                    =
+                                                                    (st.Pulse_Syntax_Base.range2)
+                                                                    }))))
+                                                     uu___2))))) uu___1)))
+               uu___)
 let (check :
   Pulse_Typing_Env.env ->
     Pulse_Syntax_Base.term ->
@@ -1927,14 +2841,14 @@ let (check :
                      (Obj.magic
                         (FStar_Range.mk_range
                            "Pulse.Checker.AssertWithBinders.fst"
-                           (Prims.of_int (209)) (Prims.of_int (10))
-                           (Prims.of_int (209)) (Prims.of_int (48)))))
+                           (Prims.of_int (259)) (Prims.of_int (10))
+                           (Prims.of_int (259)) (Prims.of_int (48)))))
                   (FStar_Sealed.seal
                      (Obj.magic
                         (FStar_Range.mk_range
                            "Pulse.Checker.AssertWithBinders.fst"
-                           (Prims.of_int (209)) (Prims.of_int (51))
-                           (Prims.of_int (261)) (Prims.of_int (50)))))
+                           (Prims.of_int (259)) (Prims.of_int (51))
+                           (Prims.of_int (311)) (Prims.of_int (50)))))
                   (FStar_Tactics_Effect.lift_div_tac
                      (fun uu___ ->
                         Pulse_Typing_Env.push_context g "check_assert"
@@ -1947,17 +2861,17 @@ let (check :
                                 (Obj.magic
                                    (FStar_Range.mk_range
                                       "Pulse.Checker.AssertWithBinders.fst"
-                                      (Prims.of_int (211))
+                                      (Prims.of_int (261))
                                       (Prims.of_int (66))
-                                      (Prims.of_int (211))
+                                      (Prims.of_int (261))
                                       (Prims.of_int (73)))))
                              (FStar_Sealed.seal
                                 (Obj.magic
                                    (FStar_Range.mk_range
                                       "Pulse.Checker.AssertWithBinders.fst"
-                                      (Prims.of_int (209))
+                                      (Prims.of_int (259))
                                       (Prims.of_int (51))
-                                      (Prims.of_int (261))
+                                      (Prims.of_int (311))
                                       (Prims.of_int (50)))))
                              (FStar_Tactics_Effect.lift_div_tac
                                 (fun uu___ -> st.Pulse_Syntax_Base.term1))
@@ -1983,17 +2897,17 @@ let (check :
                                                     (Obj.magic
                                                        (FStar_Range.mk_range
                                                           "Pulse.Checker.AssertWithBinders.fst"
-                                                          (Prims.of_int (216))
+                                                          (Prims.of_int (266))
                                                           (Prims.of_int (13))
-                                                          (Prims.of_int (216))
+                                                          (Prims.of_int (266))
                                                           (Prims.of_int (36)))))
                                                  (FStar_Sealed.seal
                                                     (Obj.magic
                                                        (FStar_Range.mk_range
                                                           "Pulse.Checker.AssertWithBinders.fst"
-                                                          (Prims.of_int (217))
+                                                          (Prims.of_int (267))
                                                           (Prims.of_int (4))
-                                                          (Prims.of_int (217))
+                                                          (Prims.of_int (267))
                                                           (Prims.of_int (50)))))
                                                  (Obj.magic
                                                     (check_renaming g1 pre st))
@@ -2012,17 +2926,17 @@ let (check :
                                                     (Obj.magic
                                                        (FStar_Range.mk_range
                                                           "Pulse.Checker.AssertWithBinders.fst"
-                                                          (Prims.of_int (220))
+                                                          (Prims.of_int (270))
                                                           (Prims.of_int (13))
-                                                          (Prims.of_int (220))
+                                                          (Prims.of_int (270))
                                                           (Prims.of_int (38)))))
                                                  (FStar_Sealed.seal
                                                     (Obj.magic
                                                        (FStar_Range.mk_range
                                                           "Pulse.Checker.AssertWithBinders.fst"
-                                                          (Prims.of_int (220))
+                                                          (Prims.of_int (270))
                                                           (Prims.of_int (41))
-                                                          (Prims.of_int (227))
+                                                          (Prims.of_int (277))
                                                           (Prims.of_int (52)))))
                                                  (Obj.magic
                                                     (infer_binder_types g1 bs
@@ -2035,17 +2949,17 @@ let (check :
                                                                (Obj.magic
                                                                   (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (221))
+                                                                    (Prims.of_int (271))
                                                                     (Prims.of_int (43))
-                                                                    (Prims.of_int (221))
+                                                                    (Prims.of_int (271))
                                                                     (Prims.of_int (90)))))
                                                             (FStar_Sealed.seal
                                                                (Obj.magic
                                                                   (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (220))
+                                                                    (Prims.of_int (270))
                                                                     (Prims.of_int (41))
-                                                                    (Prims.of_int (227))
+                                                                    (Prims.of_int (277))
                                                                     (Prims.of_int (52)))))
                                                             (Obj.magic
                                                                (open_binders
@@ -2069,17 +2983,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (222))
+                                                                    (Prims.of_int (272))
                                                                     (Prims.of_int (18))
-                                                                    (Prims.of_int (222))
+                                                                    (Prims.of_int (272))
                                                                     (Prims.of_int (39)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (221))
+                                                                    (Prims.of_int (271))
                                                                     (Prims.of_int (93))
-                                                                    (Prims.of_int (227))
+                                                                    (Prims.of_int (277))
                                                                     (Prims.of_int (52)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -2101,17 +3015,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (223))
+                                                                    (Prims.of_int (273))
                                                                     (Prims.of_int (21))
-                                                                    (Prims.of_int (223))
+                                                                    (Prims.of_int (273))
                                                                     (Prims.of_int (54)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (222))
+                                                                    (Prims.of_int (272))
                                                                     (Prims.of_int (42))
-                                                                    (Prims.of_int (227))
+                                                                    (Prims.of_int (277))
                                                                     (Prims.of_int (52)))))
                                                                     (Obj.magic
                                                                     (Pulse_Checker_Pure.check_vprop
@@ -2134,17 +3048,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (224))
+                                                                    (Prims.of_int (274))
                                                                     (Prims.of_int (39))
-                                                                    (Prims.of_int (224))
+                                                                    (Prims.of_int (274))
                                                                     (Prims.of_int (68)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (223))
+                                                                    (Prims.of_int (273))
                                                                     (Prims.of_int (57))
-                                                                    (Prims.of_int (227))
+                                                                    (Prims.of_int (277))
                                                                     (Prims.of_int (52)))))
                                                                     (Obj.magic
                                                                     (Pulse_Checker_Prover.prove
@@ -2169,17 +3083,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (226))
+                                                                    (Prims.of_int (276))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (226))
+                                                                    (Prims.of_int (276))
                                                                     (Prims.of_int (117)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (224))
+                                                                    (Prims.of_int (274))
                                                                     (Prims.of_int (71))
-                                                                    (Prims.of_int (227))
+                                                                    (Prims.of_int (277))
                                                                     (Prims.of_int (52)))))
                                                                     (Obj.magic
                                                                     (check1
@@ -2235,17 +3149,17 @@ let (check :
                                                     (Obj.magic
                                                        (FStar_Range.mk_range
                                                           "Pulse.Checker.AssertWithBinders.fst"
-                                                          (Prims.of_int (232))
+                                                          (Prims.of_int (282))
                                                           (Prims.of_int (13))
-                                                          (Prims.of_int (232))
+                                                          (Prims.of_int (282))
                                                           (Prims.of_int (38)))))
                                                  (FStar_Sealed.seal
                                                     (Obj.magic
                                                        (FStar_Range.mk_range
                                                           "Pulse.Checker.AssertWithBinders.fst"
-                                                          (Prims.of_int (232))
+                                                          (Prims.of_int (282))
                                                           (Prims.of_int (41))
-                                                          (Prims.of_int (261))
+                                                          (Prims.of_int (311))
                                                           (Prims.of_int (50)))))
                                                  (Obj.magic
                                                     (infer_binder_types g1 bs
@@ -2258,17 +3172,17 @@ let (check :
                                                                (Obj.magic
                                                                   (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (233))
+                                                                    (Prims.of_int (283))
                                                                     (Prims.of_int (43))
-                                                                    (Prims.of_int (233))
+                                                                    (Prims.of_int (283))
                                                                     (Prims.of_int (90)))))
                                                             (FStar_Sealed.seal
                                                                (Obj.magic
                                                                   (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (232))
+                                                                    (Prims.of_int (282))
                                                                     (Prims.of_int (41))
-                                                                    (Prims.of_int (261))
+                                                                    (Prims.of_int (311))
                                                                     (Prims.of_int (50)))))
                                                             (Obj.magic
                                                                (open_binders
@@ -2292,17 +3206,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (234))
+                                                                    (Prims.of_int (284))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (234))
+                                                                    (Prims.of_int (284))
                                                                     (Prims.of_int (24)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (234))
+                                                                    (Prims.of_int (284))
                                                                     (Prims.of_int (25))
-                                                                    (Prims.of_int (261))
+                                                                    (Prims.of_int (311))
                                                                     (Prims.of_int (50)))))
                                                                     (Obj.magic
                                                                     (check_unfoldable
@@ -2317,17 +3231,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (235))
+                                                                    (Prims.of_int (285))
                                                                     (Prims.of_int (22))
-                                                                    (Prims.of_int (235))
+                                                                    (Prims.of_int (285))
                                                                     (Prims.of_int (77)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (234))
+                                                                    (Prims.of_int (284))
                                                                     (Prims.of_int (25))
-                                                                    (Prims.of_int (261))
+                                                                    (Prims.of_int (311))
                                                                     (Prims.of_int (50)))))
                                                                     (Obj.magic
                                                                     (Pulse_Checker_Pure.instantiate_term_implicits
@@ -2350,17 +3264,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (237))
+                                                                    (Prims.of_int (287))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (243))
+                                                                    (Prims.of_int (293))
                                                                     (Prims.of_int (16)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (235))
+                                                                    (Prims.of_int (285))
                                                                     (Prims.of_int (80))
-                                                                    (Prims.of_int (261))
+                                                                    (Prims.of_int (311))
                                                                     (Prims.of_int (50)))))
                                                                     (match hint_type
                                                                     with
@@ -2373,17 +3287,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (240))
+                                                                    (Prims.of_int (290))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (240))
+                                                                    (Prims.of_int (290))
                                                                     (Prims.of_int (50)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (239))
+                                                                    (Prims.of_int (289))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (240))
+                                                                    (Prims.of_int (290))
                                                                     (Prims.of_int (50)))))
                                                                     (Obj.magic
                                                                     (unfold_defs
@@ -2412,17 +3326,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (242))
+                                                                    (Prims.of_int (292))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (242))
+                                                                    (Prims.of_int (292))
                                                                     (Prims.of_int (48)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (242))
+                                                                    (Prims.of_int (292))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (243))
+                                                                    (Prims.of_int (293))
                                                                     (Prims.of_int (16)))))
                                                                     (Obj.magic
                                                                     (unfold_defs
@@ -2452,17 +3366,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (244))
+                                                                    (Prims.of_int (294))
                                                                     (Prims.of_int (17))
-                                                                    (Prims.of_int (244))
+                                                                    (Prims.of_int (294))
                                                                     (Prims.of_int (37)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (244))
+                                                                    (Prims.of_int (294))
                                                                     (Prims.of_int (40))
-                                                                    (Prims.of_int (261))
+                                                                    (Prims.of_int (311))
                                                                     (Prims.of_int (50)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -2480,17 +3394,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (245))
+                                                                    (Prims.of_int (295))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (245))
+                                                                    (Prims.of_int (295))
                                                                     (Prims.of_int (69)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (244))
+                                                                    (Prims.of_int (294))
                                                                     (Prims.of_int (40))
-                                                                    (Prims.of_int (261))
+                                                                    (Prims.of_int (311))
                                                                     (Prims.of_int (50)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -2516,17 +3430,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (246))
+                                                                    (Prims.of_int (296))
                                                                     (Prims.of_int (15))
-                                                                    (Prims.of_int (248))
+                                                                    (Prims.of_int (298))
                                                                     (Prims.of_int (31)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (248))
+                                                                    (Prims.of_int (298))
                                                                     (Prims.of_int (36))
-                                                                    (Prims.of_int (261))
+                                                                    (Prims.of_int (311))
                                                                     (Prims.of_int (50)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -2555,17 +3469,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (249))
+                                                                    (Prims.of_int (299))
                                                                     (Prims.of_int (15))
-                                                                    (Prims.of_int (251))
+                                                                    (Prims.of_int (301))
                                                                     (Prims.of_int (31)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (251))
+                                                                    (Prims.of_int (301))
                                                                     (Prims.of_int (36))
-                                                                    (Prims.of_int (261))
+                                                                    (Prims.of_int (311))
                                                                     (Prims.of_int (50)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -2604,17 +3518,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (254))
+                                                                    (Prims.of_int (304))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (260))
+                                                                    (Prims.of_int (310))
                                                                     (Prims.of_int (28)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (261))
+                                                                    (Prims.of_int (311))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (261))
+                                                                    (Prims.of_int (311))
                                                                     (Prims.of_int (50)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -2677,17 +3591,17 @@ let (check :
                                                     (Obj.magic
                                                        (FStar_Range.mk_range
                                                           "Pulse.Checker.AssertWithBinders.fst"
-                                                          (Prims.of_int (232))
+                                                          (Prims.of_int (282))
                                                           (Prims.of_int (13))
-                                                          (Prims.of_int (232))
+                                                          (Prims.of_int (282))
                                                           (Prims.of_int (38)))))
                                                  (FStar_Sealed.seal
                                                     (Obj.magic
                                                        (FStar_Range.mk_range
                                                           "Pulse.Checker.AssertWithBinders.fst"
-                                                          (Prims.of_int (232))
+                                                          (Prims.of_int (282))
                                                           (Prims.of_int (41))
-                                                          (Prims.of_int (261))
+                                                          (Prims.of_int (311))
                                                           (Prims.of_int (50)))))
                                                  (Obj.magic
                                                     (infer_binder_types g1 bs
@@ -2700,17 +3614,17 @@ let (check :
                                                                (Obj.magic
                                                                   (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (233))
+                                                                    (Prims.of_int (283))
                                                                     (Prims.of_int (43))
-                                                                    (Prims.of_int (233))
+                                                                    (Prims.of_int (283))
                                                                     (Prims.of_int (90)))))
                                                             (FStar_Sealed.seal
                                                                (Obj.magic
                                                                   (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (232))
+                                                                    (Prims.of_int (282))
                                                                     (Prims.of_int (41))
-                                                                    (Prims.of_int (261))
+                                                                    (Prims.of_int (311))
                                                                     (Prims.of_int (50)))))
                                                             (Obj.magic
                                                                (open_binders
@@ -2734,17 +3648,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (234))
+                                                                    (Prims.of_int (284))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (234))
+                                                                    (Prims.of_int (284))
                                                                     (Prims.of_int (24)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (234))
+                                                                    (Prims.of_int (284))
                                                                     (Prims.of_int (25))
-                                                                    (Prims.of_int (261))
+                                                                    (Prims.of_int (311))
                                                                     (Prims.of_int (50)))))
                                                                     (Obj.magic
                                                                     (check_unfoldable
@@ -2759,17 +3673,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (235))
+                                                                    (Prims.of_int (285))
                                                                     (Prims.of_int (22))
-                                                                    (Prims.of_int (235))
+                                                                    (Prims.of_int (285))
                                                                     (Prims.of_int (77)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (234))
+                                                                    (Prims.of_int (284))
                                                                     (Prims.of_int (25))
-                                                                    (Prims.of_int (261))
+                                                                    (Prims.of_int (311))
                                                                     (Prims.of_int (50)))))
                                                                     (Obj.magic
                                                                     (Pulse_Checker_Pure.instantiate_term_implicits
@@ -2792,17 +3706,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (237))
+                                                                    (Prims.of_int (287))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (243))
+                                                                    (Prims.of_int (293))
                                                                     (Prims.of_int (16)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (235))
+                                                                    (Prims.of_int (285))
                                                                     (Prims.of_int (80))
-                                                                    (Prims.of_int (261))
+                                                                    (Prims.of_int (311))
                                                                     (Prims.of_int (50)))))
                                                                     (match hint_type
                                                                     with
@@ -2815,17 +3729,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (240))
+                                                                    (Prims.of_int (290))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (240))
+                                                                    (Prims.of_int (290))
                                                                     (Prims.of_int (50)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (239))
+                                                                    (Prims.of_int (289))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (240))
+                                                                    (Prims.of_int (290))
                                                                     (Prims.of_int (50)))))
                                                                     (Obj.magic
                                                                     (unfold_defs
@@ -2854,17 +3768,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (242))
+                                                                    (Prims.of_int (292))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (242))
+                                                                    (Prims.of_int (292))
                                                                     (Prims.of_int (48)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (242))
+                                                                    (Prims.of_int (292))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (243))
+                                                                    (Prims.of_int (293))
                                                                     (Prims.of_int (16)))))
                                                                     (Obj.magic
                                                                     (unfold_defs
@@ -2894,17 +3808,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (244))
+                                                                    (Prims.of_int (294))
                                                                     (Prims.of_int (17))
-                                                                    (Prims.of_int (244))
+                                                                    (Prims.of_int (294))
                                                                     (Prims.of_int (37)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (244))
+                                                                    (Prims.of_int (294))
                                                                     (Prims.of_int (40))
-                                                                    (Prims.of_int (261))
+                                                                    (Prims.of_int (311))
                                                                     (Prims.of_int (50)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -2922,17 +3836,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (245))
+                                                                    (Prims.of_int (295))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (245))
+                                                                    (Prims.of_int (295))
                                                                     (Prims.of_int (69)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (244))
+                                                                    (Prims.of_int (294))
                                                                     (Prims.of_int (40))
-                                                                    (Prims.of_int (261))
+                                                                    (Prims.of_int (311))
                                                                     (Prims.of_int (50)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -2958,17 +3872,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (246))
+                                                                    (Prims.of_int (296))
                                                                     (Prims.of_int (15))
-                                                                    (Prims.of_int (248))
+                                                                    (Prims.of_int (298))
                                                                     (Prims.of_int (31)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (248))
+                                                                    (Prims.of_int (298))
                                                                     (Prims.of_int (36))
-                                                                    (Prims.of_int (261))
+                                                                    (Prims.of_int (311))
                                                                     (Prims.of_int (50)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -2997,17 +3911,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (249))
+                                                                    (Prims.of_int (299))
                                                                     (Prims.of_int (15))
-                                                                    (Prims.of_int (251))
+                                                                    (Prims.of_int (301))
                                                                     (Prims.of_int (31)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (251))
+                                                                    (Prims.of_int (301))
                                                                     (Prims.of_int (36))
-                                                                    (Prims.of_int (261))
+                                                                    (Prims.of_int (311))
                                                                     (Prims.of_int (50)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -3046,17 +3960,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (254))
+                                                                    (Prims.of_int (304))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (260))
+                                                                    (Prims.of_int (310))
                                                                     (Prims.of_int (28)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (261))
+                                                                    (Prims.of_int (311))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (261))
+                                                                    (Prims.of_int (311))
                                                                     (Prims.of_int (50)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun

--- a/src/ocaml/plugin/generated/Pulse_Checker_AssertWithBinders.ml
+++ b/src/ocaml/plugin/generated/Pulse_Checker_AssertWithBinders.ml
@@ -1721,104 +1721,90 @@ let (rewrite_all :
 let rec (check_renaming :
   Pulse_Typing_Env.env ->
     Pulse_Syntax_Base.term ->
-      unit ->
-        unit Pulse_Typing.post_hint_opt ->
-          Pulse_Syntax_Base.ppname ->
-            Pulse_Syntax_Base.st_term ->
-              (Pulse_Syntax_Base.st_term, unit) FStar_Tactics_Effect.tac_repr)
+      Pulse_Syntax_Base.st_term ->
+        (Pulse_Syntax_Base.st_term, unit) FStar_Tactics_Effect.tac_repr)
   =
   fun g ->
     fun pre ->
-      fun pre_typing ->
-        fun post_hint ->
-          fun res_ppname ->
-            fun st ->
-              FStar_Tactics_Effect.tac_bind
-                (FStar_Sealed.seal
-                   (Obj.magic
-                      (FStar_Range.mk_range
-                         "Pulse.Checker.AssertWithBinders.fst"
-                         (Prims.of_int (169)) (Prims.of_int (35))
-                         (Prims.of_int (169)) (Prims.of_int (42)))))
-                (FStar_Sealed.seal
-                   (Obj.magic
-                      (FStar_Range.mk_range
-                         "Pulse.Checker.AssertWithBinders.fst"
-                         (Prims.of_int (169)) Prims.int_one
-                         (Prims.of_int (197)) (Prims.of_int (3)))))
-                (FStar_Tactics_Effect.lift_div_tac
-                   (fun uu___ -> st.Pulse_Syntax_Base.term1))
-                (fun uu___ ->
-                   (fun uu___ ->
-                      match uu___ with
-                      | Pulse_Syntax_Base.Tm_ProofHintWithBinders ht ->
-                          Obj.magic
-                            (FStar_Tactics_Effect.tac_bind
-                               (FStar_Sealed.seal
-                                  (Obj.magic
-                                     (FStar_Range.mk_range
-                                        "Pulse.Checker.AssertWithBinders.fst"
-                                        (Prims.of_int (170))
-                                        (Prims.of_int (65))
-                                        (Prims.of_int (170))
-                                        (Prims.of_int (67)))))
-                               (FStar_Sealed.seal
-                                  (Obj.magic
-                                     (FStar_Range.mk_range
-                                        "Pulse.Checker.AssertWithBinders.fst"
-                                        (Prims.of_int (169))
-                                        (Prims.of_int (45))
-                                        (Prims.of_int (197))
-                                        (Prims.of_int (3)))))
-                               (FStar_Tactics_Effect.lift_div_tac
-                                  (fun uu___1 -> ht))
-                               (fun uu___1 ->
-                                  (fun uu___1 ->
-                                     match uu___1 with
-                                     | {
-                                         Pulse_Syntax_Base.hint_type =
-                                           Pulse_Syntax_Base.RENAME
-                                           { Pulse_Syntax_Base.pairs = pairs;
-                                             Pulse_Syntax_Base.goal = goal;_};
-                                         Pulse_Syntax_Base.binders = bs;
-                                         Pulse_Syntax_Base.t3 = body;_} ->
-                                         (match (bs, goal) with
-                                          | (uu___2::uu___3,
-                                             FStar_Pervasives_Native.None) ->
-                                              Obj.magic
-                                                (Obj.repr
-                                                   (Pulse_Typing_Env.fail g
-                                                      (FStar_Pervasives_Native.Some
-                                                         (st.Pulse_Syntax_Base.range2))
-                                                      "A renaming with binders must have a goal (with xs. rename ... in goal)"))
-                                          | (uu___2::uu___3,
-                                             FStar_Pervasives_Native.Some
-                                             goal1) ->
-                                              Obj.magic
-                                                (Obj.repr
-                                                   (FStar_Tactics_Effect.lift_div_tac
-                                                      (fun uu___4 ->
-                                                         {
-                                                           Pulse_Syntax_Base.term1
-                                                             =
-                                                             (Pulse_Syntax_Base.Tm_ProofHintWithBinders
-                                                                {
-                                                                  Pulse_Syntax_Base.hint_type
-                                                                    =
-                                                                    (
-                                                                    Pulse_Syntax_Base.ASSERT
-                                                                    {
-                                                                    Pulse_Syntax_Base.p
+      fun st ->
+        FStar_Tactics_Effect.tac_bind
+          (FStar_Sealed.seal
+             (Obj.magic
+                (FStar_Range.mk_range "Pulse.Checker.AssertWithBinders.fst"
+                   (Prims.of_int (166)) (Prims.of_int (35))
+                   (Prims.of_int (166)) (Prims.of_int (42)))))
+          (FStar_Sealed.seal
+             (Obj.magic
+                (FStar_Range.mk_range "Pulse.Checker.AssertWithBinders.fst"
+                   (Prims.of_int (166)) Prims.int_one (Prims.of_int (195))
+                   (Prims.of_int (3)))))
+          (FStar_Tactics_Effect.lift_div_tac
+             (fun uu___ -> st.Pulse_Syntax_Base.term1))
+          (fun uu___ ->
+             (fun uu___ ->
+                match uu___ with
+                | Pulse_Syntax_Base.Tm_ProofHintWithBinders ht ->
+                    Obj.magic
+                      (FStar_Tactics_Effect.tac_bind
+                         (FStar_Sealed.seal
+                            (Obj.magic
+                               (FStar_Range.mk_range
+                                  "Pulse.Checker.AssertWithBinders.fst"
+                                  (Prims.of_int (167)) (Prims.of_int (65))
+                                  (Prims.of_int (167)) (Prims.of_int (67)))))
+                         (FStar_Sealed.seal
+                            (Obj.magic
+                               (FStar_Range.mk_range
+                                  "Pulse.Checker.AssertWithBinders.fst"
+                                  (Prims.of_int (166)) (Prims.of_int (45))
+                                  (Prims.of_int (195)) (Prims.of_int (3)))))
+                         (FStar_Tactics_Effect.lift_div_tac
+                            (fun uu___1 -> ht))
+                         (fun uu___1 ->
+                            (fun uu___1 ->
+                               match uu___1 with
+                               | {
+                                   Pulse_Syntax_Base.hint_type =
+                                     Pulse_Syntax_Base.RENAME
+                                     { Pulse_Syntax_Base.pairs = pairs;
+                                       Pulse_Syntax_Base.goal = goal;_};
+                                   Pulse_Syntax_Base.binders = bs;
+                                   Pulse_Syntax_Base.t3 = body;_} ->
+                                   (match (bs, goal) with
+                                    | (uu___2::uu___3,
+                                       FStar_Pervasives_Native.None) ->
+                                        Obj.magic
+                                          (Obj.repr
+                                             (Pulse_Typing_Env.fail g
+                                                (FStar_Pervasives_Native.Some
+                                                   (st.Pulse_Syntax_Base.range2))
+                                                "A renaming with binders must have a goal (with xs. rename ... in goal)"))
+                                    | (uu___2::uu___3,
+                                       FStar_Pervasives_Native.Some goal1) ->
+                                        Obj.magic
+                                          (Obj.repr
+                                             (FStar_Tactics_Effect.lift_div_tac
+                                                (fun uu___4 ->
+                                                   {
+                                                     Pulse_Syntax_Base.term1
+                                                       =
+                                                       (Pulse_Syntax_Base.Tm_ProofHintWithBinders
+                                                          {
+                                                            Pulse_Syntax_Base.hint_type
+                                                              =
+                                                              (Pulse_Syntax_Base.ASSERT
+                                                                 {
+                                                                   Pulse_Syntax_Base.p
                                                                     = goal1
-                                                                    });
-                                                                  Pulse_Syntax_Base.binders
-                                                                    = bs;
-                                                                  Pulse_Syntax_Base.t3
-                                                                    =
-                                                                    {
-                                                                    Pulse_Syntax_Base.term1
-                                                                    =
-                                                                    (Pulse_Syntax_Base.Tm_ProofHintWithBinders
+                                                                 });
+                                                            Pulse_Syntax_Base.binders
+                                                              = bs;
+                                                            Pulse_Syntax_Base.t3
+                                                              =
+                                                              {
+                                                                Pulse_Syntax_Base.term1
+                                                                  =
+                                                                  (Pulse_Syntax_Base.Tm_ProofHintWithBinders
                                                                     {
                                                                     Pulse_Syntax_Base.hint_type
                                                                     =
@@ -1829,85 +1815,95 @@ let rec (check_renaming :
                                                                     =
                                                                     (ht.Pulse_Syntax_Base.t3)
                                                                     });
-                                                                    Pulse_Syntax_Base.range2
-                                                                    =
-                                                                    (st.Pulse_Syntax_Base.range2)
-                                                                    }
-                                                                });
-                                                           Pulse_Syntax_Base.range2
-                                                             =
-                                                             (st.Pulse_Syntax_Base.range2)
-                                                         })))
-                                          | ([],
-                                             FStar_Pervasives_Native.None) ->
-                                              Obj.magic
-                                                (Obj.repr
-                                                   (check_renaming g pre ()
-                                                      post_hint res_ppname
-                                                      {
-                                                        Pulse_Syntax_Base.term1
-                                                          =
-                                                          (Pulse_Syntax_Base.Tm_ProofHintWithBinders
-                                                             {
-                                                               Pulse_Syntax_Base.hint_type
-                                                                 =
-                                                                 (Pulse_Syntax_Base.RENAME
-                                                                    {
-                                                                    Pulse_Syntax_Base.pairs
-                                                                    = pairs;
-                                                                    Pulse_Syntax_Base.goal
-                                                                    =
-                                                                    (FStar_Pervasives_Native.Some
+                                                                Pulse_Syntax_Base.range2
+                                                                  =
+                                                                  (st.Pulse_Syntax_Base.range2)
+                                                              }
+                                                          });
+                                                     Pulse_Syntax_Base.range2
+                                                       =
+                                                       (st.Pulse_Syntax_Base.range2)
+                                                   })))
+                                    | ([], FStar_Pervasives_Native.None) ->
+                                        Obj.magic
+                                          (Obj.repr
+                                             (check_renaming g pre
+                                                {
+                                                  Pulse_Syntax_Base.term1 =
+                                                    (Pulse_Syntax_Base.Tm_ProofHintWithBinders
+                                                       {
+                                                         Pulse_Syntax_Base.hint_type
+                                                           =
+                                                           (Pulse_Syntax_Base.RENAME
+                                                              {
+                                                                Pulse_Syntax_Base.pairs
+                                                                  = pairs;
+                                                                Pulse_Syntax_Base.goal
+                                                                  =
+                                                                  (FStar_Pervasives_Native.Some
                                                                     pre)
-                                                                    });
-                                                               Pulse_Syntax_Base.binders
-                                                                 =
-                                                                 (ht.Pulse_Syntax_Base.binders);
-                                                               Pulse_Syntax_Base.t3
-                                                                 =
-                                                                 (ht.Pulse_Syntax_Base.t3)
-                                                             });
-                                                        Pulse_Syntax_Base.range2
-                                                          =
-                                                          (st.Pulse_Syntax_Base.range2)
-                                                      }))
-                                          | ([], FStar_Pervasives_Native.Some
-                                             goal1) ->
-                                              Obj.magic
-                                                (Obj.repr
-                                                   (match rewrite_all pairs
-                                                            goal1
-                                                    with
-                                                    | FStar_Pervasives_Native.Some
-                                                        goal' ->
-                                                        Obj.repr
-                                                          (FStar_Tactics_Effect.lift_div_tac
-                                                             (fun uu___2 ->
-                                                                {
-                                                                  Pulse_Syntax_Base.term1
+                                                              });
+                                                         Pulse_Syntax_Base.binders
+                                                           =
+                                                           (ht.Pulse_Syntax_Base.binders);
+                                                         Pulse_Syntax_Base.t3
+                                                           =
+                                                           (ht.Pulse_Syntax_Base.t3)
+                                                       });
+                                                  Pulse_Syntax_Base.range2 =
+                                                    (st.Pulse_Syntax_Base.range2)
+                                                }))
+                                    | ([], FStar_Pervasives_Native.Some
+                                       goal1) ->
+                                        Obj.magic
+                                          (Obj.repr
+                                             (match rewrite_all pairs goal1
+                                              with
+                                              | FStar_Pervasives_Native.Some
+                                                  goal' ->
+                                                  Obj.repr
+                                                    (FStar_Tactics_Effect.lift_div_tac
+                                                       (fun uu___2 ->
+                                                          {
+                                                            Pulse_Syntax_Base.term1
+                                                              =
+                                                              (Pulse_Syntax_Base.Tm_Bind
+                                                                 {
+                                                                   Pulse_Syntax_Base.binder
                                                                     =
-                                                                    (
-                                                                    Pulse_Syntax_Base.Tm_Rewrite
+                                                                    (Pulse_Typing.as_binder
+                                                                    Pulse_Typing.tm_unit);
+                                                                   Pulse_Syntax_Base.head1
+                                                                    =
+                                                                    {
+                                                                    Pulse_Syntax_Base.term1
+                                                                    =
+                                                                    (Pulse_Syntax_Base.Tm_Rewrite
                                                                     {
                                                                     Pulse_Syntax_Base.t1
                                                                     = goal1;
                                                                     Pulse_Syntax_Base.t2
                                                                     = goal'
                                                                     });
-                                                                  Pulse_Syntax_Base.range2
+                                                                    Pulse_Syntax_Base.range2
                                                                     =
-                                                                    (
-                                                                    st.Pulse_Syntax_Base.range2)
-                                                                }))
-                                                    | FStar_Pervasives_Native.None
-                                                        ->
-                                                        Obj.repr
-                                                          (Pulse_Typing_Env.fail
-                                                             g
-                                                             (FStar_Pervasives_Native.Some
-                                                                (st.Pulse_Syntax_Base.range2))
-                                                             "Failed to rewrite the goal with the given renaming pairs")))))
-                                    uu___1))) uu___)
+                                                                    (st.Pulse_Syntax_Base.range2)
+                                                                    };
+                                                                   Pulse_Syntax_Base.body1
+                                                                    = body
+                                                                 });
+                                                            Pulse_Syntax_Base.range2
+                                                              =
+                                                              (st.Pulse_Syntax_Base.range2)
+                                                          }))
+                                              | FStar_Pervasives_Native.None
+                                                  ->
+                                                  Obj.repr
+                                                    (Pulse_Typing_Env.fail g
+                                                       (FStar_Pervasives_Native.Some
+                                                          (st.Pulse_Syntax_Base.range2))
+                                                       "Failed to rewrite the goal with the given renaming pairs")))))
+                              uu___1))) uu___)
 let (check :
   Pulse_Typing_Env.env ->
     Pulse_Syntax_Base.term ->
@@ -1931,14 +1927,14 @@ let (check :
                      (Obj.magic
                         (FStar_Range.mk_range
                            "Pulse.Checker.AssertWithBinders.fst"
-                           (Prims.of_int (211)) (Prims.of_int (10))
-                           (Prims.of_int (211)) (Prims.of_int (48)))))
+                           (Prims.of_int (209)) (Prims.of_int (10))
+                           (Prims.of_int (209)) (Prims.of_int (48)))))
                   (FStar_Sealed.seal
                      (Obj.magic
                         (FStar_Range.mk_range
                            "Pulse.Checker.AssertWithBinders.fst"
-                           (Prims.of_int (211)) (Prims.of_int (51))
-                           (Prims.of_int (262)) (Prims.of_int (50)))))
+                           (Prims.of_int (209)) (Prims.of_int (51))
+                           (Prims.of_int (261)) (Prims.of_int (50)))))
                   (FStar_Tactics_Effect.lift_div_tac
                      (fun uu___ ->
                         Pulse_Typing_Env.push_context g "check_assert"
@@ -1951,17 +1947,17 @@ let (check :
                                 (Obj.magic
                                    (FStar_Range.mk_range
                                       "Pulse.Checker.AssertWithBinders.fst"
-                                      (Prims.of_int (213))
+                                      (Prims.of_int (211))
                                       (Prims.of_int (66))
-                                      (Prims.of_int (213))
+                                      (Prims.of_int (211))
                                       (Prims.of_int (73)))))
                              (FStar_Sealed.seal
                                 (Obj.magic
                                    (FStar_Range.mk_range
                                       "Pulse.Checker.AssertWithBinders.fst"
-                                      (Prims.of_int (211))
+                                      (Prims.of_int (209))
                                       (Prims.of_int (51))
-                                      (Prims.of_int (262))
+                                      (Prims.of_int (261))
                                       (Prims.of_int (50)))))
                              (FStar_Tactics_Effect.lift_div_tac
                                 (fun uu___ -> st.Pulse_Syntax_Base.term1))
@@ -1982,67 +1978,87 @@ let (check :
                                               Pulse_Syntax_Base.goal = goal;_}
                                             ->
                                             Obj.magic
-                                              (Obj.repr
-                                                 (FStar_Tactics_V2_Derived.fail
-                                                    "Renaming not yet handled"))
+                                              (FStar_Tactics_Effect.tac_bind
+                                                 (FStar_Sealed.seal
+                                                    (Obj.magic
+                                                       (FStar_Range.mk_range
+                                                          "Pulse.Checker.AssertWithBinders.fst"
+                                                          (Prims.of_int (216))
+                                                          (Prims.of_int (13))
+                                                          (Prims.of_int (216))
+                                                          (Prims.of_int (36)))))
+                                                 (FStar_Sealed.seal
+                                                    (Obj.magic
+                                                       (FStar_Range.mk_range
+                                                          "Pulse.Checker.AssertWithBinders.fst"
+                                                          (Prims.of_int (217))
+                                                          (Prims.of_int (4))
+                                                          (Prims.of_int (217))
+                                                          (Prims.of_int (50)))))
+                                                 (Obj.magic
+                                                    (check_renaming g1 pre st))
+                                                 (fun uu___1 ->
+                                                    (fun st1 ->
+                                                       Obj.magic
+                                                         (check1 g1 pre ()
+                                                            post_hint
+                                                            res_ppname st1))
+                                                      uu___1))
                                         | Pulse_Syntax_Base.ASSERT
                                             { Pulse_Syntax_Base.p = v;_} ->
                                             Obj.magic
-                                              (Obj.repr
-                                                 (FStar_Tactics_Effect.tac_bind
-                                                    (FStar_Sealed.seal
-                                                       (Obj.magic
-                                                          (FStar_Range.mk_range
-                                                             "Pulse.Checker.AssertWithBinders.fst"
-                                                             (Prims.of_int (221))
-                                                             (Prims.of_int (13))
-                                                             (Prims.of_int (221))
-                                                             (Prims.of_int (38)))))
-                                                    (FStar_Sealed.seal
-                                                       (Obj.magic
-                                                          (FStar_Range.mk_range
-                                                             "Pulse.Checker.AssertWithBinders.fst"
-                                                             (Prims.of_int (221))
-                                                             (Prims.of_int (41))
-                                                             (Prims.of_int (228))
-                                                             (Prims.of_int (52)))))
+                                              (FStar_Tactics_Effect.tac_bind
+                                                 (FStar_Sealed.seal
                                                     (Obj.magic
-                                                       (infer_binder_types g1
-                                                          bs v))
-                                                    (fun uu___1 ->
-                                                       (fun bs1 ->
-                                                          Obj.magic
-                                                            (FStar_Tactics_Effect.tac_bind
-                                                               (FStar_Sealed.seal
-                                                                  (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (222))
-                                                                    (Prims.of_int (43))
-                                                                    (Prims.of_int (222))
-                                                                    (Prims.of_int (90)))))
-                                                               (FStar_Sealed.seal
-                                                                  (Obj.magic
-                                                                    (FStar_Range.mk_range
+                                                       (FStar_Range.mk_range
+                                                          "Pulse.Checker.AssertWithBinders.fst"
+                                                          (Prims.of_int (220))
+                                                          (Prims.of_int (13))
+                                                          (Prims.of_int (220))
+                                                          (Prims.of_int (38)))))
+                                                 (FStar_Sealed.seal
+                                                    (Obj.magic
+                                                       (FStar_Range.mk_range
+                                                          "Pulse.Checker.AssertWithBinders.fst"
+                                                          (Prims.of_int (220))
+                                                          (Prims.of_int (41))
+                                                          (Prims.of_int (227))
+                                                          (Prims.of_int (52)))))
+                                                 (Obj.magic
+                                                    (infer_binder_types g1 bs
+                                                       v))
+                                                 (fun uu___1 ->
+                                                    (fun bs1 ->
+                                                       Obj.magic
+                                                         (FStar_Tactics_Effect.tac_bind
+                                                            (FStar_Sealed.seal
+                                                               (Obj.magic
+                                                                  (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
                                                                     (Prims.of_int (221))
-                                                                    (Prims.of_int (41))
-                                                                    (Prims.of_int (228))
-                                                                    (Prims.of_int (52)))))
+                                                                    (Prims.of_int (43))
+                                                                    (Prims.of_int (221))
+                                                                    (Prims.of_int (90)))))
+                                                            (FStar_Sealed.seal
                                                                (Obj.magic
-                                                                  (open_binders
-                                                                    g1 bs1
-                                                                    (Pulse_Typing_Env.mk_env
+                                                                  (FStar_Range.mk_range
+                                                                    "Pulse.Checker.AssertWithBinders.fst"
+                                                                    (Prims.of_int (220))
+                                                                    (Prims.of_int (41))
+                                                                    (Prims.of_int (227))
+                                                                    (Prims.of_int (52)))))
+                                                            (Obj.magic
+                                                               (open_binders
+                                                                  g1 bs1
+                                                                  (Pulse_Typing_Env.mk_env
                                                                     (Pulse_Typing_Env.fstar_env
                                                                     g1)) v
-                                                                    body))
+                                                                  body))
+                                                            (fun uu___1 ->
                                                                (fun uu___1 ->
-                                                                  (fun uu___1
-                                                                    ->
-                                                                    match uu___1
-                                                                    with
-                                                                    | 
-                                                                    FStar_Pervasives.Mkdtuple3
+                                                                  match uu___1
+                                                                  with
+                                                                  | FStar_Pervasives.Mkdtuple3
                                                                     (uvs,
                                                                     v_opened,
                                                                     body_opened)
@@ -2053,17 +2069,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (223))
+                                                                    (Prims.of_int (222))
                                                                     (Prims.of_int (18))
-                                                                    (Prims.of_int (223))
+                                                                    (Prims.of_int (222))
                                                                     (Prims.of_int (39)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (222))
+                                                                    (Prims.of_int (221))
                                                                     (Prims.of_int (93))
-                                                                    (Prims.of_int (228))
+                                                                    (Prims.of_int (227))
                                                                     (Prims.of_int (52)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -2085,17 +2101,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (224))
+                                                                    (Prims.of_int (223))
                                                                     (Prims.of_int (21))
-                                                                    (Prims.of_int (224))
+                                                                    (Prims.of_int (223))
                                                                     (Prims.of_int (54)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (223))
+                                                                    (Prims.of_int (222))
                                                                     (Prims.of_int (42))
-                                                                    (Prims.of_int (228))
+                                                                    (Prims.of_int (227))
                                                                     (Prims.of_int (52)))))
                                                                     (Obj.magic
                                                                     (Pulse_Checker_Pure.check_vprop
@@ -2118,17 +2134,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (225))
+                                                                    (Prims.of_int (224))
                                                                     (Prims.of_int (39))
-                                                                    (Prims.of_int (225))
+                                                                    (Prims.of_int (224))
                                                                     (Prims.of_int (68)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (224))
+                                                                    (Prims.of_int (223))
                                                                     (Prims.of_int (57))
-                                                                    (Prims.of_int (228))
+                                                                    (Prims.of_int (227))
                                                                     (Prims.of_int (52)))))
                                                                     (Obj.magic
                                                                     (Pulse_Checker_Prover.prove
@@ -2153,17 +2169,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (227))
+                                                                    (Prims.of_int (226))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (227))
+                                                                    (Prims.of_int (226))
                                                                     (Prims.of_int (117)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (225))
+                                                                    (Prims.of_int (224))
                                                                     (Prims.of_int (71))
-                                                                    (Prims.of_int (228))
+                                                                    (Prims.of_int (227))
                                                                     (Prims.of_int (52)))))
                                                                     (Obj.magic
                                                                     (check1
@@ -2205,8 +2221,8 @@ let (check :
                                                                     uu___4)))
                                                                     uu___3)))
                                                                     uu___2)))
-                                                                    uu___1)))
-                                                         uu___1)))
+                                                                 uu___1)))
+                                                      uu___1))
                                         | Pulse_Syntax_Base.UNFOLD
                                             {
                                               Pulse_Syntax_Base.names1 =
@@ -2214,61 +2230,58 @@ let (check :
                                               Pulse_Syntax_Base.p2 = v;_}
                                             ->
                                             Obj.magic
-                                              (Obj.repr
-                                                 (FStar_Tactics_Effect.tac_bind
-                                                    (FStar_Sealed.seal
-                                                       (Obj.magic
-                                                          (FStar_Range.mk_range
-                                                             "Pulse.Checker.AssertWithBinders.fst"
-                                                             (Prims.of_int (233))
-                                                             (Prims.of_int (13))
-                                                             (Prims.of_int (233))
-                                                             (Prims.of_int (38)))))
-                                                    (FStar_Sealed.seal
-                                                       (Obj.magic
-                                                          (FStar_Range.mk_range
-                                                             "Pulse.Checker.AssertWithBinders.fst"
-                                                             (Prims.of_int (233))
-                                                             (Prims.of_int (41))
-                                                             (Prims.of_int (262))
-                                                             (Prims.of_int (50)))))
+                                              (FStar_Tactics_Effect.tac_bind
+                                                 (FStar_Sealed.seal
                                                     (Obj.magic
-                                                       (infer_binder_types g1
-                                                          bs v))
-                                                    (fun uu___1 ->
-                                                       (fun bs1 ->
-                                                          Obj.magic
-                                                            (FStar_Tactics_Effect.tac_bind
-                                                               (FStar_Sealed.seal
-                                                                  (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (234))
-                                                                    (Prims.of_int (43))
-                                                                    (Prims.of_int (234))
-                                                                    (Prims.of_int (90)))))
-                                                               (FStar_Sealed.seal
-                                                                  (Obj.magic
-                                                                    (FStar_Range.mk_range
+                                                       (FStar_Range.mk_range
+                                                          "Pulse.Checker.AssertWithBinders.fst"
+                                                          (Prims.of_int (232))
+                                                          (Prims.of_int (13))
+                                                          (Prims.of_int (232))
+                                                          (Prims.of_int (38)))))
+                                                 (FStar_Sealed.seal
+                                                    (Obj.magic
+                                                       (FStar_Range.mk_range
+                                                          "Pulse.Checker.AssertWithBinders.fst"
+                                                          (Prims.of_int (232))
+                                                          (Prims.of_int (41))
+                                                          (Prims.of_int (261))
+                                                          (Prims.of_int (50)))))
+                                                 (Obj.magic
+                                                    (infer_binder_types g1 bs
+                                                       v))
+                                                 (fun uu___1 ->
+                                                    (fun bs1 ->
+                                                       Obj.magic
+                                                         (FStar_Tactics_Effect.tac_bind
+                                                            (FStar_Sealed.seal
+                                                               (Obj.magic
+                                                                  (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
                                                                     (Prims.of_int (233))
-                                                                    (Prims.of_int (41))
-                                                                    (Prims.of_int (262))
-                                                                    (Prims.of_int (50)))))
+                                                                    (Prims.of_int (43))
+                                                                    (Prims.of_int (233))
+                                                                    (Prims.of_int (90)))))
+                                                            (FStar_Sealed.seal
                                                                (Obj.magic
-                                                                  (open_binders
-                                                                    g1 bs1
-                                                                    (Pulse_Typing_Env.mk_env
+                                                                  (FStar_Range.mk_range
+                                                                    "Pulse.Checker.AssertWithBinders.fst"
+                                                                    (Prims.of_int (232))
+                                                                    (Prims.of_int (41))
+                                                                    (Prims.of_int (261))
+                                                                    (Prims.of_int (50)))))
+                                                            (Obj.magic
+                                                               (open_binders
+                                                                  g1 bs1
+                                                                  (Pulse_Typing_Env.mk_env
                                                                     (Pulse_Typing_Env.fstar_env
                                                                     g1)) v
-                                                                    body))
+                                                                  body))
+                                                            (fun uu___1 ->
                                                                (fun uu___1 ->
-                                                                  (fun uu___1
-                                                                    ->
-                                                                    match uu___1
-                                                                    with
-                                                                    | 
-                                                                    FStar_Pervasives.Mkdtuple3
+                                                                  match uu___1
+                                                                  with
+                                                                  | FStar_Pervasives.Mkdtuple3
                                                                     (uvs,
                                                                     v_opened,
                                                                     body_opened)
@@ -2279,17 +2292,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (235))
+                                                                    (Prims.of_int (234))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (235))
+                                                                    (Prims.of_int (234))
                                                                     (Prims.of_int (24)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (235))
+                                                                    (Prims.of_int (234))
                                                                     (Prims.of_int (25))
-                                                                    (Prims.of_int (262))
+                                                                    (Prims.of_int (261))
                                                                     (Prims.of_int (50)))))
                                                                     (Obj.magic
                                                                     (check_unfoldable
@@ -2304,17 +2317,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (236))
+                                                                    (Prims.of_int (235))
                                                                     (Prims.of_int (22))
-                                                                    (Prims.of_int (236))
+                                                                    (Prims.of_int (235))
                                                                     (Prims.of_int (77)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (235))
+                                                                    (Prims.of_int (234))
                                                                     (Prims.of_int (25))
-                                                                    (Prims.of_int (262))
+                                                                    (Prims.of_int (261))
                                                                     (Prims.of_int (50)))))
                                                                     (Obj.magic
                                                                     (Pulse_Checker_Pure.instantiate_term_implicits
@@ -2337,17 +2350,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (238))
+                                                                    (Prims.of_int (237))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (244))
+                                                                    (Prims.of_int (243))
                                                                     (Prims.of_int (16)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (236))
+                                                                    (Prims.of_int (235))
                                                                     (Prims.of_int (80))
-                                                                    (Prims.of_int (262))
+                                                                    (Prims.of_int (261))
                                                                     (Prims.of_int (50)))))
                                                                     (match hint_type
                                                                     with
@@ -2360,17 +2373,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (241))
+                                                                    (Prims.of_int (240))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (241))
+                                                                    (Prims.of_int (240))
                                                                     (Prims.of_int (50)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (240))
+                                                                    (Prims.of_int (239))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (241))
+                                                                    (Prims.of_int (240))
                                                                     (Prims.of_int (50)))))
                                                                     (Obj.magic
                                                                     (unfold_defs
@@ -2399,17 +2412,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (243))
+                                                                    (Prims.of_int (242))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (243))
+                                                                    (Prims.of_int (242))
                                                                     (Prims.of_int (48)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (243))
+                                                                    (Prims.of_int (242))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (244))
+                                                                    (Prims.of_int (243))
                                                                     (Prims.of_int (16)))))
                                                                     (Obj.magic
                                                                     (unfold_defs
@@ -2439,17 +2452,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (245))
+                                                                    (Prims.of_int (244))
                                                                     (Prims.of_int (17))
-                                                                    (Prims.of_int (245))
+                                                                    (Prims.of_int (244))
                                                                     (Prims.of_int (37)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (245))
+                                                                    (Prims.of_int (244))
                                                                     (Prims.of_int (40))
-                                                                    (Prims.of_int (262))
+                                                                    (Prims.of_int (261))
                                                                     (Prims.of_int (50)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -2467,17 +2480,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (246))
+                                                                    (Prims.of_int (245))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (246))
+                                                                    (Prims.of_int (245))
                                                                     (Prims.of_int (69)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (245))
+                                                                    (Prims.of_int (244))
                                                                     (Prims.of_int (40))
-                                                                    (Prims.of_int (262))
+                                                                    (Prims.of_int (261))
                                                                     (Prims.of_int (50)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -2503,17 +2516,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (247))
+                                                                    (Prims.of_int (246))
                                                                     (Prims.of_int (15))
-                                                                    (Prims.of_int (249))
+                                                                    (Prims.of_int (248))
                                                                     (Prims.of_int (31)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (249))
+                                                                    (Prims.of_int (248))
                                                                     (Prims.of_int (36))
-                                                                    (Prims.of_int (262))
+                                                                    (Prims.of_int (261))
                                                                     (Prims.of_int (50)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -2542,17 +2555,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (250))
+                                                                    (Prims.of_int (249))
                                                                     (Prims.of_int (15))
-                                                                    (Prims.of_int (252))
+                                                                    (Prims.of_int (251))
                                                                     (Prims.of_int (31)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (252))
+                                                                    (Prims.of_int (251))
                                                                     (Prims.of_int (36))
-                                                                    (Prims.of_int (262))
+                                                                    (Prims.of_int (261))
                                                                     (Prims.of_int (50)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -2591,17 +2604,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (255))
+                                                                    (Prims.of_int (254))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (261))
+                                                                    (Prims.of_int (260))
                                                                     (Prims.of_int (28)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (262))
+                                                                    (Prims.of_int (261))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (262))
+                                                                    (Prims.of_int (261))
                                                                     (Prims.of_int (50)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -2651,69 +2664,66 @@ let (check :
                                                                     uu___5)))
                                                                     uu___3)))
                                                                     uu___2)))
-                                                                    uu___1)))
-                                                         uu___1)))
+                                                                 uu___1)))
+                                                      uu___1))
                                         | Pulse_Syntax_Base.FOLD
                                             {
                                               Pulse_Syntax_Base.names = names;
                                               Pulse_Syntax_Base.p1 = v;_}
                                             ->
                                             Obj.magic
-                                              (Obj.repr
-                                                 (FStar_Tactics_Effect.tac_bind
-                                                    (FStar_Sealed.seal
-                                                       (Obj.magic
-                                                          (FStar_Range.mk_range
-                                                             "Pulse.Checker.AssertWithBinders.fst"
-                                                             (Prims.of_int (233))
-                                                             (Prims.of_int (13))
-                                                             (Prims.of_int (233))
-                                                             (Prims.of_int (38)))))
-                                                    (FStar_Sealed.seal
-                                                       (Obj.magic
-                                                          (FStar_Range.mk_range
-                                                             "Pulse.Checker.AssertWithBinders.fst"
-                                                             (Prims.of_int (233))
-                                                             (Prims.of_int (41))
-                                                             (Prims.of_int (262))
-                                                             (Prims.of_int (50)))))
+                                              (FStar_Tactics_Effect.tac_bind
+                                                 (FStar_Sealed.seal
                                                     (Obj.magic
-                                                       (infer_binder_types g1
-                                                          bs v))
-                                                    (fun uu___1 ->
-                                                       (fun bs1 ->
-                                                          Obj.magic
-                                                            (FStar_Tactics_Effect.tac_bind
-                                                               (FStar_Sealed.seal
-                                                                  (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (234))
-                                                                    (Prims.of_int (43))
-                                                                    (Prims.of_int (234))
-                                                                    (Prims.of_int (90)))))
-                                                               (FStar_Sealed.seal
-                                                                  (Obj.magic
-                                                                    (FStar_Range.mk_range
+                                                       (FStar_Range.mk_range
+                                                          "Pulse.Checker.AssertWithBinders.fst"
+                                                          (Prims.of_int (232))
+                                                          (Prims.of_int (13))
+                                                          (Prims.of_int (232))
+                                                          (Prims.of_int (38)))))
+                                                 (FStar_Sealed.seal
+                                                    (Obj.magic
+                                                       (FStar_Range.mk_range
+                                                          "Pulse.Checker.AssertWithBinders.fst"
+                                                          (Prims.of_int (232))
+                                                          (Prims.of_int (41))
+                                                          (Prims.of_int (261))
+                                                          (Prims.of_int (50)))))
+                                                 (Obj.magic
+                                                    (infer_binder_types g1 bs
+                                                       v))
+                                                 (fun uu___1 ->
+                                                    (fun bs1 ->
+                                                       Obj.magic
+                                                         (FStar_Tactics_Effect.tac_bind
+                                                            (FStar_Sealed.seal
+                                                               (Obj.magic
+                                                                  (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
                                                                     (Prims.of_int (233))
-                                                                    (Prims.of_int (41))
-                                                                    (Prims.of_int (262))
-                                                                    (Prims.of_int (50)))))
+                                                                    (Prims.of_int (43))
+                                                                    (Prims.of_int (233))
+                                                                    (Prims.of_int (90)))))
+                                                            (FStar_Sealed.seal
                                                                (Obj.magic
-                                                                  (open_binders
-                                                                    g1 bs1
-                                                                    (Pulse_Typing_Env.mk_env
+                                                                  (FStar_Range.mk_range
+                                                                    "Pulse.Checker.AssertWithBinders.fst"
+                                                                    (Prims.of_int (232))
+                                                                    (Prims.of_int (41))
+                                                                    (Prims.of_int (261))
+                                                                    (Prims.of_int (50)))))
+                                                            (Obj.magic
+                                                               (open_binders
+                                                                  g1 bs1
+                                                                  (Pulse_Typing_Env.mk_env
                                                                     (Pulse_Typing_Env.fstar_env
                                                                     g1)) v
-                                                                    body))
+                                                                  body))
+                                                            (fun uu___1 ->
                                                                (fun uu___1 ->
-                                                                  (fun uu___1
-                                                                    ->
-                                                                    match uu___1
-                                                                    with
-                                                                    | 
-                                                                    FStar_Pervasives.Mkdtuple3
+                                                                  match uu___1
+                                                                  with
+                                                                  | FStar_Pervasives.Mkdtuple3
                                                                     (uvs,
                                                                     v_opened,
                                                                     body_opened)
@@ -2724,17 +2734,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (235))
+                                                                    (Prims.of_int (234))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (235))
+                                                                    (Prims.of_int (234))
                                                                     (Prims.of_int (24)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (235))
+                                                                    (Prims.of_int (234))
                                                                     (Prims.of_int (25))
-                                                                    (Prims.of_int (262))
+                                                                    (Prims.of_int (261))
                                                                     (Prims.of_int (50)))))
                                                                     (Obj.magic
                                                                     (check_unfoldable
@@ -2749,17 +2759,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (236))
+                                                                    (Prims.of_int (235))
                                                                     (Prims.of_int (22))
-                                                                    (Prims.of_int (236))
+                                                                    (Prims.of_int (235))
                                                                     (Prims.of_int (77)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (235))
+                                                                    (Prims.of_int (234))
                                                                     (Prims.of_int (25))
-                                                                    (Prims.of_int (262))
+                                                                    (Prims.of_int (261))
                                                                     (Prims.of_int (50)))))
                                                                     (Obj.magic
                                                                     (Pulse_Checker_Pure.instantiate_term_implicits
@@ -2782,17 +2792,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (238))
+                                                                    (Prims.of_int (237))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (244))
+                                                                    (Prims.of_int (243))
                                                                     (Prims.of_int (16)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (236))
+                                                                    (Prims.of_int (235))
                                                                     (Prims.of_int (80))
-                                                                    (Prims.of_int (262))
+                                                                    (Prims.of_int (261))
                                                                     (Prims.of_int (50)))))
                                                                     (match hint_type
                                                                     with
@@ -2805,17 +2815,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (241))
+                                                                    (Prims.of_int (240))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (241))
+                                                                    (Prims.of_int (240))
                                                                     (Prims.of_int (50)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (240))
+                                                                    (Prims.of_int (239))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (241))
+                                                                    (Prims.of_int (240))
                                                                     (Prims.of_int (50)))))
                                                                     (Obj.magic
                                                                     (unfold_defs
@@ -2844,17 +2854,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (243))
+                                                                    (Prims.of_int (242))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (243))
+                                                                    (Prims.of_int (242))
                                                                     (Prims.of_int (48)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (243))
+                                                                    (Prims.of_int (242))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (244))
+                                                                    (Prims.of_int (243))
                                                                     (Prims.of_int (16)))))
                                                                     (Obj.magic
                                                                     (unfold_defs
@@ -2884,17 +2894,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (245))
+                                                                    (Prims.of_int (244))
                                                                     (Prims.of_int (17))
-                                                                    (Prims.of_int (245))
+                                                                    (Prims.of_int (244))
                                                                     (Prims.of_int (37)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (245))
+                                                                    (Prims.of_int (244))
                                                                     (Prims.of_int (40))
-                                                                    (Prims.of_int (262))
+                                                                    (Prims.of_int (261))
                                                                     (Prims.of_int (50)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -2912,17 +2922,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (246))
+                                                                    (Prims.of_int (245))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (246))
+                                                                    (Prims.of_int (245))
                                                                     (Prims.of_int (69)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (245))
+                                                                    (Prims.of_int (244))
                                                                     (Prims.of_int (40))
-                                                                    (Prims.of_int (262))
+                                                                    (Prims.of_int (261))
                                                                     (Prims.of_int (50)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -2948,17 +2958,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (247))
+                                                                    (Prims.of_int (246))
                                                                     (Prims.of_int (15))
-                                                                    (Prims.of_int (249))
+                                                                    (Prims.of_int (248))
                                                                     (Prims.of_int (31)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (249))
+                                                                    (Prims.of_int (248))
                                                                     (Prims.of_int (36))
-                                                                    (Prims.of_int (262))
+                                                                    (Prims.of_int (261))
                                                                     (Prims.of_int (50)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -2987,17 +2997,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (250))
+                                                                    (Prims.of_int (249))
                                                                     (Prims.of_int (15))
-                                                                    (Prims.of_int (252))
+                                                                    (Prims.of_int (251))
                                                                     (Prims.of_int (31)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (252))
+                                                                    (Prims.of_int (251))
                                                                     (Prims.of_int (36))
-                                                                    (Prims.of_int (262))
+                                                                    (Prims.of_int (261))
                                                                     (Prims.of_int (50)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -3036,17 +3046,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (255))
+                                                                    (Prims.of_int (254))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (261))
+                                                                    (Prims.of_int (260))
                                                                     (Prims.of_int (28)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (262))
+                                                                    (Prims.of_int (261))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (262))
+                                                                    (Prims.of_int (261))
                                                                     (Prims.of_int (50)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -3096,6 +3106,6 @@ let (check :
                                                                     uu___5)))
                                                                     uu___3)))
                                                                     uu___2)))
-                                                                    uu___1)))
-                                                         uu___1))))) uu___)))
+                                                                 uu___1)))
+                                                      uu___1)))) uu___)))
                        uu___)

--- a/src/ocaml/plugin/generated/Pulse_Checker_AssertWithBinders.ml
+++ b/src/ocaml/plugin/generated/Pulse_Checker_AssertWithBinders.ml
@@ -1689,12 +1689,8 @@ let (check_unfoldable :
                                   (FStar_Pervasives_Native.Some
                                      (v.Pulse_Syntax_Base.range1)) uu___1))
                             uu___1)))) uu___1 uu___
-let (rewrite_one :
-  (Pulse_Syntax_Base.term * Pulse_Syntax_Base.term) ->
-    Pulse_Syntax_Base.term -> Pulse_Syntax_Base.term)
-  = fun p -> fun t -> t
 let (visit_and_rewrite :
-  (FStar_Reflection_Types.term * FStar_Reflection_Types.term) Prims.list ->
+  (FStar_Reflection_Types.term * FStar_Reflection_Types.term) ->
     Pulse_Syntax_Base.term ->
       (Pulse_Syntax_Base.term, unit) FStar_Tactics_Effect.tac_repr)
   =
@@ -1704,447 +1700,552 @@ let (visit_and_rewrite :
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.AssertWithBinders.fst"
-                 (Prims.of_int (138)) (Prims.of_int (4)) (Prims.of_int (140))
-                 (Prims.of_int (24)))))
+                 (Prims.of_int (136)) (Prims.of_int (17))
+                 (Prims.of_int (136)) (Prims.of_int (18)))))
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.AssertWithBinders.fst"
-                 (Prims.of_int (141)) (Prims.of_int (4)) (Prims.of_int (158))
-                 (Prims.of_int (7)))))
-        (FStar_Tactics_Effect.lift_div_tac
-           (fun uu___1 ->
-              fun uu___ ->
-                (fun uu___ ->
-                   fun t1 ->
-                     Obj.magic
-                       (FStar_Tactics_Effect.lift_div_tac
-                          (fun uu___1 ->
-                             match FStar_List_Tot_Base.tryFind
-                                     (fun uu___2 ->
-                                        match uu___2 with
-                                        | (x, uu___3) ->
-                                            FStar_Reflection_V2_TermEq.term_eq
-                                              x t1) p
-                             with
-                             | FStar_Pervasives_Native.None -> t1
-                             | FStar_Pervasives_Native.Some (uu___2, t') ->
-                                 t'))) uu___1 uu___))
+                 (Prims.of_int (135)) (Prims.of_int (40))
+                 (Prims.of_int (163)) (Prims.of_int (9)))))
+        (FStar_Tactics_Effect.lift_div_tac (fun uu___ -> p))
         (fun uu___ ->
-           (fun visitor ->
-              let rec aux uu___ =
-                (fun t1 ->
-                   match t1.Pulse_Syntax_Base.t with
-                   | Pulse_Syntax_Base.Tm_Emp ->
-                       Obj.magic
-                         (Obj.repr
-                            (FStar_Tactics_Effect.lift_div_tac
-                               (fun uu___ -> t1)))
-                   | Pulse_Syntax_Base.Tm_VProp ->
-                       Obj.magic
-                         (Obj.repr
-                            (FStar_Tactics_Effect.lift_div_tac
-                               (fun uu___ -> t1)))
-                   | Pulse_Syntax_Base.Tm_Inames ->
-                       Obj.magic
-                         (Obj.repr
-                            (FStar_Tactics_Effect.lift_div_tac
-                               (fun uu___ -> t1)))
-                   | Pulse_Syntax_Base.Tm_EmpInames ->
-                       Obj.magic
-                         (Obj.repr
-                            (FStar_Tactics_Effect.lift_div_tac
-                               (fun uu___ -> t1)))
-                   | Pulse_Syntax_Base.Tm_Unknown ->
-                       Obj.magic
-                         (Obj.repr
-                            (FStar_Tactics_Effect.lift_div_tac
-                               (fun uu___ -> t1)))
-                   | Pulse_Syntax_Base.Tm_Pure p1 ->
-                       Obj.magic
-                         (Obj.repr
-                            (FStar_Tactics_Effect.tac_bind
-                               (FStar_Sealed.seal
-                                  (Obj.magic
-                                     (FStar_Range.mk_range
-                                        "Pulse.Checker.AssertWithBinders.fst"
-                                        (Prims.of_int (149))
-                                        (Prims.of_int (32))
-                                        (Prims.of_int (149))
-                                        (Prims.of_int (47)))))
-                               (FStar_Sealed.seal
-                                  (Obj.magic
-                                     (FStar_Range.mk_range
-                                        "Pulse.Checker.AssertWithBinders.fst"
-                                        (Prims.of_int (149))
-                                        (Prims.of_int (21))
-                                        (Prims.of_int (149))
-                                        (Prims.of_int (47)))))
-                               (Obj.magic
-                                  (FStar_Tactics_Effect.tac_bind
-                                     (FStar_Sealed.seal
-                                        (Obj.magic
-                                           (FStar_Range.mk_range
-                                              "Pulse.Checker.AssertWithBinders.fst"
-                                              (Prims.of_int (149))
-                                              (Prims.of_int (40))
-                                              (Prims.of_int (149))
-                                              (Prims.of_int (47)))))
-                                     (FStar_Sealed.seal
-                                        (Obj.magic
-                                           (FStar_Range.mk_range
-                                              "Pulse.Checker.AssertWithBinders.fst"
-                                              (Prims.of_int (149))
-                                              (Prims.of_int (32))
-                                              (Prims.of_int (149))
-                                              (Prims.of_int (47)))))
-                                     (Obj.magic (aux p1))
-                                     (fun uu___ ->
-                                        FStar_Tactics_Effect.lift_div_tac
-                                          (fun uu___1 ->
-                                             Pulse_Syntax_Base.Tm_Pure uu___))))
-                               (fun uu___ ->
-                                  FStar_Tactics_Effect.lift_div_tac
-                                    (fun uu___1 ->
-                                       {
-                                         Pulse_Syntax_Base.t = uu___;
-                                         Pulse_Syntax_Base.range1 =
-                                           (t1.Pulse_Syntax_Base.range1)
-                                       }))))
-                   | Pulse_Syntax_Base.Tm_Star (l, r) ->
-                       Obj.magic
-                         (Obj.repr
-                            (FStar_Tactics_Effect.tac_bind
-                               (FStar_Sealed.seal
-                                  (Obj.magic
-                                     (FStar_Range.mk_range
-                                        "Pulse.Checker.AssertWithBinders.fst"
-                                        (Prims.of_int (150))
-                                        (Prims.of_int (35))
-                                        (Prims.of_int (150))
-                                        (Prims.of_int (58)))))
-                               (FStar_Sealed.seal
-                                  (Obj.magic
-                                     (FStar_Range.mk_range
-                                        "Pulse.Checker.AssertWithBinders.fst"
-                                        (Prims.of_int (150))
-                                        (Prims.of_int (24))
-                                        (Prims.of_int (150))
-                                        (Prims.of_int (58)))))
-                               (Obj.magic
-                                  (FStar_Tactics_Effect.tac_bind
-                                     (FStar_Sealed.seal
-                                        (Obj.magic
-                                           (FStar_Range.mk_range
-                                              "Pulse.Checker.AssertWithBinders.fst"
-                                              (Prims.of_int (150))
-                                              (Prims.of_int (43))
-                                              (Prims.of_int (150))
-                                              (Prims.of_int (50)))))
-                                     (FStar_Sealed.seal
-                                        (Obj.magic
-                                           (FStar_Range.mk_range
-                                              "Pulse.Checker.AssertWithBinders.fst"
-                                              (Prims.of_int (150))
-                                              (Prims.of_int (35))
-                                              (Prims.of_int (150))
-                                              (Prims.of_int (58)))))
-                                     (Obj.magic (aux l))
-                                     (fun uu___ ->
-                                        (fun uu___ ->
-                                           Obj.magic
-                                             (FStar_Tactics_Effect.tac_bind
-                                                (FStar_Sealed.seal
-                                                   (Obj.magic
-                                                      (FStar_Range.mk_range
-                                                         "Pulse.Checker.AssertWithBinders.fst"
-                                                         (Prims.of_int (150))
-                                                         (Prims.of_int (51))
-                                                         (Prims.of_int (150))
-                                                         (Prims.of_int (58)))))
-                                                (FStar_Sealed.seal
-                                                   (Obj.magic
-                                                      (FStar_Range.mk_range
-                                                         "Pulse.Checker.AssertWithBinders.fst"
-                                                         (Prims.of_int (150))
-                                                         (Prims.of_int (35))
-                                                         (Prims.of_int (150))
-                                                         (Prims.of_int (58)))))
-                                                (Obj.magic (aux r))
-                                                (fun uu___1 ->
-                                                   FStar_Tactics_Effect.lift_div_tac
-                                                     (fun uu___2 ->
-                                                        Pulse_Syntax_Base.Tm_Star
-                                                          (uu___, uu___1)))))
-                                          uu___)))
-                               (fun uu___ ->
-                                  FStar_Tactics_Effect.lift_div_tac
-                                    (fun uu___1 ->
-                                       {
-                                         Pulse_Syntax_Base.t = uu___;
-                                         Pulse_Syntax_Base.range1 =
-                                           (t1.Pulse_Syntax_Base.range1)
-                                       }))))
-                   | Pulse_Syntax_Base.Tm_ExistsSL (u, b, body) ->
-                       Obj.magic
-                         (Obj.repr
-                            (FStar_Tactics_Effect.tac_bind
-                               (FStar_Sealed.seal
-                                  (Obj.magic
-                                     (FStar_Range.mk_range
-                                        "Pulse.Checker.AssertWithBinders.fst"
-                                        (Prims.of_int (151))
-                                        (Prims.of_int (43))
-                                        (Prims.of_int (151))
-                                        (Prims.of_int (103)))))
-                               (FStar_Sealed.seal
-                                  (Obj.magic
-                                     (FStar_Range.mk_range
-                                        "Pulse.Checker.AssertWithBinders.fst"
-                                        (Prims.of_int (151))
-                                        (Prims.of_int (32))
-                                        (Prims.of_int (151))
-                                        (Prims.of_int (103)))))
-                               (Obj.magic
-                                  (FStar_Tactics_Effect.tac_bind
-                                     (FStar_Sealed.seal
-                                        (Obj.magic
-                                           (FStar_Range.mk_range
-                                              "Pulse.Checker.AssertWithBinders.fst"
-                                              (Prims.of_int (151))
-                                              (Prims.of_int (59))
-                                              (Prims.of_int (151))
-                                              (Prims.of_int (91)))))
-                                     (FStar_Sealed.seal
-                                        (Obj.magic
-                                           (FStar_Range.mk_range
-                                              "Pulse.Checker.AssertWithBinders.fst"
-                                              (Prims.of_int (151))
-                                              (Prims.of_int (43))
-                                              (Prims.of_int (151))
-                                              (Prims.of_int (103)))))
-                                     (Obj.magic
-                                        (FStar_Tactics_Effect.tac_bind
-                                           (FStar_Sealed.seal
-                                              (Obj.magic
-                                                 (FStar_Range.mk_range
-                                                    "Pulse.Checker.AssertWithBinders.fst"
-                                                    (Prims.of_int (151))
-                                                    (Prims.of_int (76))
-                                                    (Prims.of_int (151))
-                                                    (Prims.of_int (91)))))
-                                           (FStar_Sealed.seal
-                                              (Obj.magic
-                                                 (FStar_Range.mk_range
-                                                    "Pulse.Checker.AssertWithBinders.fst"
-                                                    (Prims.of_int (151))
-                                                    (Prims.of_int (59))
-                                                    (Prims.of_int (151))
-                                                    (Prims.of_int (91)))))
-                                           (Obj.magic
-                                              (aux
-                                                 b.Pulse_Syntax_Base.binder_ty))
-                                           (fun uu___ ->
-                                              FStar_Tactics_Effect.lift_div_tac
-                                                (fun uu___1 ->
+           (fun uu___ ->
+              match uu___ with
+              | (lhs, rhs) ->
+                  Obj.magic
+                    (FStar_Tactics_Effect.tac_bind
+                       (FStar_Sealed.seal
+                          (Obj.magic
+                             (FStar_Range.mk_range
+                                "Pulse.Checker.AssertWithBinders.fst"
+                                (Prims.of_int (138)) (Prims.of_int (4))
+                                (Prims.of_int (138)) (Prims.of_int (36)))))
+                       (FStar_Sealed.seal
+                          (Obj.magic
+                             (FStar_Range.mk_range
+                                "Pulse.Checker.AssertWithBinders.fst"
+                                (Prims.of_int (140)) (Prims.of_int (2))
+                                (Prims.of_int (163)) (Prims.of_int (9)))))
+                       (FStar_Tactics_Effect.lift_div_tac
+                          (fun uu___2 ->
+                             fun uu___1 ->
+                               (fun uu___1 ->
+                                  fun t1 ->
+                                    Obj.magic
+                                      (FStar_Tactics_Effect.lift_div_tac
+                                         (fun uu___2 ->
+                                            if
+                                              FStar_Reflection_V2_TermEq.term_eq
+                                                t1 lhs
+                                            then rhs
+                                            else t1))) uu___2 uu___1))
+                       (fun uu___1 ->
+                          (fun visitor ->
+                             match FStar_Reflection_V2_Builtins.inspect_ln
+                                     lhs
+                             with
+                             | FStar_Reflection_V2_Data.Tv_Var n ->
+                                 Obj.magic
+                                   (Obj.repr
+                                      (FStar_Tactics_Effect.lift_div_tac
+                                         (fun uu___1 ->
+                                            Pulse_Syntax_Naming.subst_term t
+                                              [Pulse_Syntax_Naming.NT
+                                                 (((FStar_Reflection_V2_Builtins.inspect_namedv
+                                                      n).FStar_Reflection_V2_Data.uniq),
                                                    {
-                                                     Pulse_Syntax_Base.binder_ty
-                                                       = uu___;
-                                                     Pulse_Syntax_Base.binder_ppname
+                                                     Pulse_Syntax_Base.t =
+                                                       (Pulse_Syntax_Base.Tm_FStar
+                                                          rhs);
+                                                     Pulse_Syntax_Base.range1
                                                        =
-                                                       (b.Pulse_Syntax_Base.binder_ppname)
-                                                   }))))
-                                     (fun uu___ ->
-                                        (fun uu___ ->
-                                           Obj.magic
-                                             (FStar_Tactics_Effect.tac_bind
-                                                (FStar_Sealed.seal
-                                                   (Obj.magic
-                                                      (FStar_Range.mk_range
-                                                         "Pulse.Checker.AssertWithBinders.fst"
-                                                         (Prims.of_int (151))
-                                                         (Prims.of_int (93))
-                                                         (Prims.of_int (151))
-                                                         (Prims.of_int (103)))))
-                                                (FStar_Sealed.seal
-                                                   (Obj.magic
-                                                      (FStar_Range.mk_range
-                                                         "Pulse.Checker.AssertWithBinders.fst"
-                                                         (Prims.of_int (151))
-                                                         (Prims.of_int (43))
-                                                         (Prims.of_int (151))
-                                                         (Prims.of_int (103)))))
-                                                (Obj.magic (aux body))
-                                                (fun uu___1 ->
-                                                   FStar_Tactics_Effect.lift_div_tac
-                                                     (fun uu___2 ->
-                                                        Pulse_Syntax_Base.Tm_ExistsSL
-                                                          (u, uu___, uu___1)))))
-                                          uu___)))
-                               (fun uu___ ->
-                                  FStar_Tactics_Effect.lift_div_tac
-                                    (fun uu___1 ->
-                                       {
-                                         Pulse_Syntax_Base.t = uu___;
-                                         Pulse_Syntax_Base.range1 =
-                                           (t1.Pulse_Syntax_Base.range1)
-                                       }))))
-                   | Pulse_Syntax_Base.Tm_ForallSL (u, b, body) ->
-                       Obj.magic
-                         (Obj.repr
-                            (FStar_Tactics_Effect.tac_bind
-                               (FStar_Sealed.seal
-                                  (Obj.magic
-                                     (FStar_Range.mk_range
-                                        "Pulse.Checker.AssertWithBinders.fst"
-                                        (Prims.of_int (152))
-                                        (Prims.of_int (43))
-                                        (Prims.of_int (152))
-                                        (Prims.of_int (103)))))
-                               (FStar_Sealed.seal
-                                  (Obj.magic
-                                     (FStar_Range.mk_range
-                                        "Pulse.Checker.AssertWithBinders.fst"
-                                        (Prims.of_int (152))
-                                        (Prims.of_int (32))
-                                        (Prims.of_int (152))
-                                        (Prims.of_int (103)))))
-                               (Obj.magic
-                                  (FStar_Tactics_Effect.tac_bind
-                                     (FStar_Sealed.seal
-                                        (Obj.magic
-                                           (FStar_Range.mk_range
-                                              "Pulse.Checker.AssertWithBinders.fst"
-                                              (Prims.of_int (152))
-                                              (Prims.of_int (59))
-                                              (Prims.of_int (152))
-                                              (Prims.of_int (91)))))
-                                     (FStar_Sealed.seal
-                                        (Obj.magic
-                                           (FStar_Range.mk_range
-                                              "Pulse.Checker.AssertWithBinders.fst"
-                                              (Prims.of_int (152))
-                                              (Prims.of_int (43))
-                                              (Prims.of_int (152))
-                                              (Prims.of_int (103)))))
-                                     (Obj.magic
-                                        (FStar_Tactics_Effect.tac_bind
-                                           (FStar_Sealed.seal
-                                              (Obj.magic
-                                                 (FStar_Range.mk_range
-                                                    "Pulse.Checker.AssertWithBinders.fst"
-                                                    (Prims.of_int (152))
-                                                    (Prims.of_int (76))
-                                                    (Prims.of_int (152))
-                                                    (Prims.of_int (91)))))
-                                           (FStar_Sealed.seal
-                                              (Obj.magic
-                                                 (FStar_Range.mk_range
-                                                    "Pulse.Checker.AssertWithBinders.fst"
-                                                    (Prims.of_int (152))
-                                                    (Prims.of_int (59))
-                                                    (Prims.of_int (152))
-                                                    (Prims.of_int (91)))))
-                                           (Obj.magic
-                                              (aux
-                                                 b.Pulse_Syntax_Base.binder_ty))
-                                           (fun uu___ ->
-                                              FStar_Tactics_Effect.lift_div_tac
-                                                (fun uu___1 ->
-                                                   {
-                                                     Pulse_Syntax_Base.binder_ty
-                                                       = uu___;
-                                                     Pulse_Syntax_Base.binder_ppname
-                                                       =
-                                                       (b.Pulse_Syntax_Base.binder_ppname)
-                                                   }))))
-                                     (fun uu___ ->
-                                        (fun uu___ ->
-                                           Obj.magic
-                                             (FStar_Tactics_Effect.tac_bind
-                                                (FStar_Sealed.seal
-                                                   (Obj.magic
-                                                      (FStar_Range.mk_range
-                                                         "Pulse.Checker.AssertWithBinders.fst"
-                                                         (Prims.of_int (152))
-                                                         (Prims.of_int (93))
-                                                         (Prims.of_int (152))
-                                                         (Prims.of_int (103)))))
-                                                (FStar_Sealed.seal
-                                                   (Obj.magic
-                                                      (FStar_Range.mk_range
-                                                         "Pulse.Checker.AssertWithBinders.fst"
-                                                         (Prims.of_int (152))
-                                                         (Prims.of_int (43))
-                                                         (Prims.of_int (152))
-                                                         (Prims.of_int (103)))))
-                                                (Obj.magic (aux body))
-                                                (fun uu___1 ->
-                                                   FStar_Tactics_Effect.lift_div_tac
-                                                     (fun uu___2 ->
-                                                        Pulse_Syntax_Base.Tm_ForallSL
-                                                          (u, uu___, uu___1)))))
-                                          uu___)))
-                               (fun uu___ ->
-                                  FStar_Tactics_Effect.lift_div_tac
-                                    (fun uu___1 ->
-                                       {
-                                         Pulse_Syntax_Base.t = uu___;
-                                         Pulse_Syntax_Base.range1 =
-                                           (t1.Pulse_Syntax_Base.range1)
-                                       }))))
-                   | Pulse_Syntax_Base.Tm_FStar h ->
-                       Obj.magic
-                         (Obj.repr
-                            (FStar_Tactics_Effect.tac_bind
-                               (FStar_Sealed.seal
-                                  (Obj.magic
-                                     (FStar_Range.mk_range
-                                        "Pulse.Checker.AssertWithBinders.fst"
-                                        (Prims.of_int (154))
-                                        (Prims.of_int (14))
-                                        (Prims.of_int (154))
-                                        (Prims.of_int (52)))))
-                               (FStar_Sealed.seal
-                                  (Obj.magic
-                                     (FStar_Range.mk_range
-                                        "Pulse.Checker.AssertWithBinders.fst"
-                                        (Prims.of_int (156))
-                                        (Prims.of_int (8))
-                                        (Prims.of_int (156))
-                                        (Prims.of_int (27)))))
-                               (Obj.magic
-                                  (FStar_Tactics_Visit.visit_tm visitor h))
-                               (fun h1 ->
-                                  FStar_Tactics_Effect.lift_div_tac
-                                    (fun uu___ ->
-                                       {
-                                         Pulse_Syntax_Base.t =
-                                           (Pulse_Syntax_Base.Tm_FStar h1);
-                                         Pulse_Syntax_Base.range1 =
-                                           (t1.Pulse_Syntax_Base.range1)
-                                       }))))) uu___ in
-              Obj.magic (aux t)) uu___)
+                                                       (t.Pulse_Syntax_Base.range1)
+                                                   })])))
+                             | uu___1 ->
+                                 Obj.magic
+                                   (Obj.repr
+                                      (let rec aux uu___2 =
+                                         (fun t1 ->
+                                            match t1.Pulse_Syntax_Base.t with
+                                            | Pulse_Syntax_Base.Tm_Emp ->
+                                                Obj.magic
+                                                  (Obj.repr
+                                                     (FStar_Tactics_Effect.lift_div_tac
+                                                        (fun uu___2 -> t1)))
+                                            | Pulse_Syntax_Base.Tm_VProp ->
+                                                Obj.magic
+                                                  (Obj.repr
+                                                     (FStar_Tactics_Effect.lift_div_tac
+                                                        (fun uu___2 -> t1)))
+                                            | Pulse_Syntax_Base.Tm_Inames ->
+                                                Obj.magic
+                                                  (Obj.repr
+                                                     (FStar_Tactics_Effect.lift_div_tac
+                                                        (fun uu___2 -> t1)))
+                                            | Pulse_Syntax_Base.Tm_EmpInames
+                                                ->
+                                                Obj.magic
+                                                  (Obj.repr
+                                                     (FStar_Tactics_Effect.lift_div_tac
+                                                        (fun uu___2 -> t1)))
+                                            | Pulse_Syntax_Base.Tm_Unknown ->
+                                                Obj.magic
+                                                  (Obj.repr
+                                                     (FStar_Tactics_Effect.lift_div_tac
+                                                        (fun uu___2 -> t1)))
+                                            | Pulse_Syntax_Base.Tm_Pure p1 ->
+                                                Obj.magic
+                                                  (Obj.repr
+                                                     (FStar_Tactics_Effect.tac_bind
+                                                        (FStar_Sealed.seal
+                                                           (Obj.magic
+                                                              (FStar_Range.mk_range
+                                                                 "Pulse.Checker.AssertWithBinders.fst"
+                                                                 (Prims.of_int (154))
+                                                                 (Prims.of_int (34))
+                                                                 (Prims.of_int (154))
+                                                                 (Prims.of_int (49)))))
+                                                        (FStar_Sealed.seal
+                                                           (Obj.magic
+                                                              (FStar_Range.mk_range
+                                                                 "Pulse.Checker.AssertWithBinders.fst"
+                                                                 (Prims.of_int (154))
+                                                                 (Prims.of_int (23))
+                                                                 (Prims.of_int (154))
+                                                                 (Prims.of_int (49)))))
+                                                        (Obj.magic
+                                                           (FStar_Tactics_Effect.tac_bind
+                                                              (FStar_Sealed.seal
+                                                                 (Obj.magic
+                                                                    (
+                                                                    FStar_Range.mk_range
+                                                                    "Pulse.Checker.AssertWithBinders.fst"
+                                                                    (Prims.of_int (154))
+                                                                    (Prims.of_int (42))
+                                                                    (Prims.of_int (154))
+                                                                    (Prims.of_int (49)))))
+                                                              (FStar_Sealed.seal
+                                                                 (Obj.magic
+                                                                    (
+                                                                    FStar_Range.mk_range
+                                                                    "Pulse.Checker.AssertWithBinders.fst"
+                                                                    (Prims.of_int (154))
+                                                                    (Prims.of_int (34))
+                                                                    (Prims.of_int (154))
+                                                                    (Prims.of_int (49)))))
+                                                              (Obj.magic
+                                                                 (aux p1))
+                                                              (fun uu___2 ->
+                                                                 FStar_Tactics_Effect.lift_div_tac
+                                                                   (fun
+                                                                    uu___3 ->
+                                                                    Pulse_Syntax_Base.Tm_Pure
+                                                                    uu___2))))
+                                                        (fun uu___2 ->
+                                                           FStar_Tactics_Effect.lift_div_tac
+                                                             (fun uu___3 ->
+                                                                {
+                                                                  Pulse_Syntax_Base.t
+                                                                    = uu___2;
+                                                                  Pulse_Syntax_Base.range1
+                                                                    =
+                                                                    (
+                                                                    t1.Pulse_Syntax_Base.range1)
+                                                                }))))
+                                            | Pulse_Syntax_Base.Tm_Star
+                                                (l, r) ->
+                                                Obj.magic
+                                                  (Obj.repr
+                                                     (FStar_Tactics_Effect.tac_bind
+                                                        (FStar_Sealed.seal
+                                                           (Obj.magic
+                                                              (FStar_Range.mk_range
+                                                                 "Pulse.Checker.AssertWithBinders.fst"
+                                                                 (Prims.of_int (155))
+                                                                 (Prims.of_int (37))
+                                                                 (Prims.of_int (155))
+                                                                 (Prims.of_int (60)))))
+                                                        (FStar_Sealed.seal
+                                                           (Obj.magic
+                                                              (FStar_Range.mk_range
+                                                                 "Pulse.Checker.AssertWithBinders.fst"
+                                                                 (Prims.of_int (155))
+                                                                 (Prims.of_int (26))
+                                                                 (Prims.of_int (155))
+                                                                 (Prims.of_int (60)))))
+                                                        (Obj.magic
+                                                           (FStar_Tactics_Effect.tac_bind
+                                                              (FStar_Sealed.seal
+                                                                 (Obj.magic
+                                                                    (
+                                                                    FStar_Range.mk_range
+                                                                    "Pulse.Checker.AssertWithBinders.fst"
+                                                                    (Prims.of_int (155))
+                                                                    (Prims.of_int (45))
+                                                                    (Prims.of_int (155))
+                                                                    (Prims.of_int (52)))))
+                                                              (FStar_Sealed.seal
+                                                                 (Obj.magic
+                                                                    (
+                                                                    FStar_Range.mk_range
+                                                                    "Pulse.Checker.AssertWithBinders.fst"
+                                                                    (Prims.of_int (155))
+                                                                    (Prims.of_int (37))
+                                                                    (Prims.of_int (155))
+                                                                    (Prims.of_int (60)))))
+                                                              (Obj.magic
+                                                                 (aux l))
+                                                              (fun uu___2 ->
+                                                                 (fun uu___2
+                                                                    ->
+                                                                    Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.AssertWithBinders.fst"
+                                                                    (Prims.of_int (155))
+                                                                    (Prims.of_int (53))
+                                                                    (Prims.of_int (155))
+                                                                    (Prims.of_int (60)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.AssertWithBinders.fst"
+                                                                    (Prims.of_int (155))
+                                                                    (Prims.of_int (37))
+                                                                    (Prims.of_int (155))
+                                                                    (Prims.of_int (60)))))
+                                                                    (Obj.magic
+                                                                    (aux r))
+                                                                    (fun
+                                                                    uu___3 ->
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___4 ->
+                                                                    Pulse_Syntax_Base.Tm_Star
+                                                                    (uu___2,
+                                                                    uu___3)))))
+                                                                   uu___2)))
+                                                        (fun uu___2 ->
+                                                           FStar_Tactics_Effect.lift_div_tac
+                                                             (fun uu___3 ->
+                                                                {
+                                                                  Pulse_Syntax_Base.t
+                                                                    = uu___2;
+                                                                  Pulse_Syntax_Base.range1
+                                                                    =
+                                                                    (
+                                                                    t1.Pulse_Syntax_Base.range1)
+                                                                }))))
+                                            | Pulse_Syntax_Base.Tm_ExistsSL
+                                                (u, b, body) ->
+                                                Obj.magic
+                                                  (Obj.repr
+                                                     (FStar_Tactics_Effect.tac_bind
+                                                        (FStar_Sealed.seal
+                                                           (Obj.magic
+                                                              (FStar_Range.mk_range
+                                                                 "Pulse.Checker.AssertWithBinders.fst"
+                                                                 (Prims.of_int (156))
+                                                                 (Prims.of_int (45))
+                                                                 (Prims.of_int (156))
+                                                                 (Prims.of_int (105)))))
+                                                        (FStar_Sealed.seal
+                                                           (Obj.magic
+                                                              (FStar_Range.mk_range
+                                                                 "Pulse.Checker.AssertWithBinders.fst"
+                                                                 (Prims.of_int (156))
+                                                                 (Prims.of_int (34))
+                                                                 (Prims.of_int (156))
+                                                                 (Prims.of_int (105)))))
+                                                        (Obj.magic
+                                                           (FStar_Tactics_Effect.tac_bind
+                                                              (FStar_Sealed.seal
+                                                                 (Obj.magic
+                                                                    (
+                                                                    FStar_Range.mk_range
+                                                                    "Pulse.Checker.AssertWithBinders.fst"
+                                                                    (Prims.of_int (156))
+                                                                    (Prims.of_int (61))
+                                                                    (Prims.of_int (156))
+                                                                    (Prims.of_int (93)))))
+                                                              (FStar_Sealed.seal
+                                                                 (Obj.magic
+                                                                    (
+                                                                    FStar_Range.mk_range
+                                                                    "Pulse.Checker.AssertWithBinders.fst"
+                                                                    (Prims.of_int (156))
+                                                                    (Prims.of_int (45))
+                                                                    (Prims.of_int (156))
+                                                                    (Prims.of_int (105)))))
+                                                              (Obj.magic
+                                                                 (FStar_Tactics_Effect.tac_bind
+                                                                    (
+                                                                    FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.AssertWithBinders.fst"
+                                                                    (Prims.of_int (156))
+                                                                    (Prims.of_int (78))
+                                                                    (Prims.of_int (156))
+                                                                    (Prims.of_int (93)))))
+                                                                    (
+                                                                    FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.AssertWithBinders.fst"
+                                                                    (Prims.of_int (156))
+                                                                    (Prims.of_int (61))
+                                                                    (Prims.of_int (156))
+                                                                    (Prims.of_int (93)))))
+                                                                    (
+                                                                    Obj.magic
+                                                                    (aux
+                                                                    b.Pulse_Syntax_Base.binder_ty))
+                                                                    (
+                                                                    fun
+                                                                    uu___2 ->
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___3 ->
+                                                                    {
+                                                                    Pulse_Syntax_Base.binder_ty
+                                                                    = uu___2;
+                                                                    Pulse_Syntax_Base.binder_ppname
+                                                                    =
+                                                                    (b.Pulse_Syntax_Base.binder_ppname)
+                                                                    }))))
+                                                              (fun uu___2 ->
+                                                                 (fun uu___2
+                                                                    ->
+                                                                    Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.AssertWithBinders.fst"
+                                                                    (Prims.of_int (156))
+                                                                    (Prims.of_int (95))
+                                                                    (Prims.of_int (156))
+                                                                    (Prims.of_int (105)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.AssertWithBinders.fst"
+                                                                    (Prims.of_int (156))
+                                                                    (Prims.of_int (45))
+                                                                    (Prims.of_int (156))
+                                                                    (Prims.of_int (105)))))
+                                                                    (Obj.magic
+                                                                    (aux body))
+                                                                    (fun
+                                                                    uu___3 ->
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___4 ->
+                                                                    Pulse_Syntax_Base.Tm_ExistsSL
+                                                                    (u,
+                                                                    uu___2,
+                                                                    uu___3)))))
+                                                                   uu___2)))
+                                                        (fun uu___2 ->
+                                                           FStar_Tactics_Effect.lift_div_tac
+                                                             (fun uu___3 ->
+                                                                {
+                                                                  Pulse_Syntax_Base.t
+                                                                    = uu___2;
+                                                                  Pulse_Syntax_Base.range1
+                                                                    =
+                                                                    (
+                                                                    t1.Pulse_Syntax_Base.range1)
+                                                                }))))
+                                            | Pulse_Syntax_Base.Tm_ForallSL
+                                                (u, b, body) ->
+                                                Obj.magic
+                                                  (Obj.repr
+                                                     (FStar_Tactics_Effect.tac_bind
+                                                        (FStar_Sealed.seal
+                                                           (Obj.magic
+                                                              (FStar_Range.mk_range
+                                                                 "Pulse.Checker.AssertWithBinders.fst"
+                                                                 (Prims.of_int (157))
+                                                                 (Prims.of_int (45))
+                                                                 (Prims.of_int (157))
+                                                                 (Prims.of_int (105)))))
+                                                        (FStar_Sealed.seal
+                                                           (Obj.magic
+                                                              (FStar_Range.mk_range
+                                                                 "Pulse.Checker.AssertWithBinders.fst"
+                                                                 (Prims.of_int (157))
+                                                                 (Prims.of_int (34))
+                                                                 (Prims.of_int (157))
+                                                                 (Prims.of_int (105)))))
+                                                        (Obj.magic
+                                                           (FStar_Tactics_Effect.tac_bind
+                                                              (FStar_Sealed.seal
+                                                                 (Obj.magic
+                                                                    (
+                                                                    FStar_Range.mk_range
+                                                                    "Pulse.Checker.AssertWithBinders.fst"
+                                                                    (Prims.of_int (157))
+                                                                    (Prims.of_int (61))
+                                                                    (Prims.of_int (157))
+                                                                    (Prims.of_int (93)))))
+                                                              (FStar_Sealed.seal
+                                                                 (Obj.magic
+                                                                    (
+                                                                    FStar_Range.mk_range
+                                                                    "Pulse.Checker.AssertWithBinders.fst"
+                                                                    (Prims.of_int (157))
+                                                                    (Prims.of_int (45))
+                                                                    (Prims.of_int (157))
+                                                                    (Prims.of_int (105)))))
+                                                              (Obj.magic
+                                                                 (FStar_Tactics_Effect.tac_bind
+                                                                    (
+                                                                    FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.AssertWithBinders.fst"
+                                                                    (Prims.of_int (157))
+                                                                    (Prims.of_int (78))
+                                                                    (Prims.of_int (157))
+                                                                    (Prims.of_int (93)))))
+                                                                    (
+                                                                    FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.AssertWithBinders.fst"
+                                                                    (Prims.of_int (157))
+                                                                    (Prims.of_int (61))
+                                                                    (Prims.of_int (157))
+                                                                    (Prims.of_int (93)))))
+                                                                    (
+                                                                    Obj.magic
+                                                                    (aux
+                                                                    b.Pulse_Syntax_Base.binder_ty))
+                                                                    (
+                                                                    fun
+                                                                    uu___2 ->
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___3 ->
+                                                                    {
+                                                                    Pulse_Syntax_Base.binder_ty
+                                                                    = uu___2;
+                                                                    Pulse_Syntax_Base.binder_ppname
+                                                                    =
+                                                                    (b.Pulse_Syntax_Base.binder_ppname)
+                                                                    }))))
+                                                              (fun uu___2 ->
+                                                                 (fun uu___2
+                                                                    ->
+                                                                    Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.AssertWithBinders.fst"
+                                                                    (Prims.of_int (157))
+                                                                    (Prims.of_int (95))
+                                                                    (Prims.of_int (157))
+                                                                    (Prims.of_int (105)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.AssertWithBinders.fst"
+                                                                    (Prims.of_int (157))
+                                                                    (Prims.of_int (45))
+                                                                    (Prims.of_int (157))
+                                                                    (Prims.of_int (105)))))
+                                                                    (Obj.magic
+                                                                    (aux body))
+                                                                    (fun
+                                                                    uu___3 ->
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___4 ->
+                                                                    Pulse_Syntax_Base.Tm_ForallSL
+                                                                    (u,
+                                                                    uu___2,
+                                                                    uu___3)))))
+                                                                   uu___2)))
+                                                        (fun uu___2 ->
+                                                           FStar_Tactics_Effect.lift_div_tac
+                                                             (fun uu___3 ->
+                                                                {
+                                                                  Pulse_Syntax_Base.t
+                                                                    = uu___2;
+                                                                  Pulse_Syntax_Base.range1
+                                                                    =
+                                                                    (
+                                                                    t1.Pulse_Syntax_Base.range1)
+                                                                }))))
+                                            | Pulse_Syntax_Base.Tm_FStar h ->
+                                                Obj.magic
+                                                  (Obj.repr
+                                                     (FStar_Tactics_Effect.tac_bind
+                                                        (FStar_Sealed.seal
+                                                           (Obj.magic
+                                                              (FStar_Range.mk_range
+                                                                 "Pulse.Checker.AssertWithBinders.fst"
+                                                                 (Prims.of_int (159))
+                                                                 (Prims.of_int (16))
+                                                                 (Prims.of_int (159))
+                                                                 (Prims.of_int (54)))))
+                                                        (FStar_Sealed.seal
+                                                           (Obj.magic
+                                                              (FStar_Range.mk_range
+                                                                 "Pulse.Checker.AssertWithBinders.fst"
+                                                                 (Prims.of_int (161))
+                                                                 (Prims.of_int (10))
+                                                                 (Prims.of_int (161))
+                                                                 (Prims.of_int (29)))))
+                                                        (Obj.magic
+                                                           (FStar_Tactics_Visit.visit_tm
+                                                              visitor h))
+                                                        (fun h1 ->
+                                                           FStar_Tactics_Effect.lift_div_tac
+                                                             (fun uu___2 ->
+                                                                {
+                                                                  Pulse_Syntax_Base.t
+                                                                    =
+                                                                    (
+                                                                    Pulse_Syntax_Base.Tm_FStar
+                                                                    h1);
+                                                                  Pulse_Syntax_Base.range1
+                                                                    =
+                                                                    (
+                                                                    t1.Pulse_Syntax_Base.range1)
+                                                                }))))) uu___2 in
+                                       aux t))) uu___1))) uu___)
 let (visit_and_rewrite_conjuncts :
+  (FStar_Reflection_Types.term * FStar_Reflection_Types.term) ->
+    Pulse_Syntax_Base.term Prims.list ->
+      (Pulse_Syntax_Base.term Prims.list, unit) FStar_Tactics_Effect.tac_repr)
+  = fun p -> fun tms -> FStar_Tactics_Util.map (visit_and_rewrite p) tms
+let (visit_and_rewrite_conjuncts_all :
   (FStar_Reflection_Types.term * FStar_Reflection_Types.term) Prims.list ->
     Pulse_Syntax_Base.term ->
       ((Pulse_Syntax_Base.term * Pulse_Syntax_Base.term), unit)
         FStar_Tactics_Effect.tac_repr)
   =
   fun p ->
-    fun t ->
+    fun goal ->
       FStar_Tactics_Effect.tac_bind
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.AssertWithBinders.fst"
-                 (Prims.of_int (161)) (Prims.of_int (12))
-                 (Prims.of_int (161)) (Prims.of_int (52)))))
+                 (Prims.of_int (170)) (Prims.of_int (12))
+                 (Prims.of_int (170)) (Prims.of_int (55)))))
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.AssertWithBinders.fst"
-                 (Prims.of_int (161)) (Prims.of_int (55))
-                 (Prims.of_int (174)) (Prims.of_int (10)))))
+                 (Prims.of_int (170)) (Prims.of_int (58))
+                 (Prims.of_int (182)) (Prims.of_int (44)))))
         (FStar_Tactics_Effect.lift_div_tac
-           (fun uu___ -> Pulse_Typing_Combinators.vprop_as_list t))
+           (fun uu___ -> Pulse_Typing_Combinators.vprop_as_list goal))
         (fun uu___ ->
            (fun tms ->
               Obj.magic
@@ -2153,87 +2254,111 @@ let (visit_and_rewrite_conjuncts :
                       (Obj.magic
                          (FStar_Range.mk_range
                             "Pulse.Checker.AssertWithBinders.fst"
-                            (Prims.of_int (163)) (Prims.of_int (4))
-                            (Prims.of_int (169)) (Prims.of_int (5)))))
+                            (Prims.of_int (171)) (Prims.of_int (13))
+                            (Prims.of_int (171)) (Prims.of_int (79)))))
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range
                             "Pulse.Checker.AssertWithBinders.fst"
-                            (Prims.of_int (170)) (Prims.of_int (4))
-                            (Prims.of_int (174)) (Prims.of_int (10)))))
+                            (Prims.of_int (172)) (Prims.of_int (41))
+                            (Prims.of_int (182)) (Prims.of_int (44)))))
                    (Obj.magic
-                      (FStar_Tactics_Effect.tac_bind
-                         (FStar_Sealed.seal
-                            (Obj.magic
-                               (FStar_Range.mk_range
-                                  "Pulse.Checker.AssertWithBinders.fst"
-                                  (Prims.of_int (163)) (Prims.of_int (14))
-                                  (Prims.of_int (169)) (Prims.of_int (5)))))
-                         (FStar_Sealed.seal
-                            (Obj.magic
-                               (FStar_Range.mk_range
-                                  "Pulse.Checker.AssertWithBinders.fst"
-                                  (Prims.of_int (163)) (Prims.of_int (4))
-                                  (Prims.of_int (169)) (Prims.of_int (5)))))
-                         (Obj.magic
-                            (FStar_Tactics_Util.map
-                               (fun t1 ->
-                                  FStar_Tactics_Effect.tac_bind
-                                    (FStar_Sealed.seal
-                                       (Obj.magic
-                                          (FStar_Range.mk_range
-                                             "Pulse.Checker.AssertWithBinders.fst"
-                                             (Prims.of_int (166))
-                                             (Prims.of_int (18))
-                                             (Prims.of_int (166))
-                                             (Prims.of_int (39)))))
-                                    (FStar_Sealed.seal
-                                       (Obj.magic
-                                          (FStar_Range.mk_range
-                                             "Pulse.Checker.AssertWithBinders.fst"
-                                             (Prims.of_int (167))
-                                             (Prims.of_int (10))
-                                             (Prims.of_int (167))
-                                             (Prims.of_int (44)))))
-                                    (Obj.magic (visit_and_rewrite p t1))
-                                    (fun s ->
-                                       FStar_Tactics_Effect.lift_div_tac
-                                         (fun uu___ ->
-                                            if Pulse_Syntax_Base.eq_tm s t1
-                                            then []
-                                            else [(t1, s)]))) tms))
-                         (fun uu___ ->
-                            FStar_Tactics_Effect.lift_div_tac
-                              (fun uu___1 ->
-                                 FStar_List_Tot_Base.flatten uu___))))
-                   (fun tms1 ->
-                      FStar_Tactics_Effect.lift_div_tac
-                        (fun uu___ ->
-                           match FStar_List_Tot_Base.unzip tms1 with
-                           | (lhs, rhs) ->
-                               ((Pulse_Typing_Combinators.list_as_vprop lhs),
-                                 (Pulse_Typing_Combinators.list_as_vprop rhs))))))
-             uu___)
+                      (FStar_Tactics_Util.fold_left
+                         (fun tms1 ->
+                            fun p1 -> visit_and_rewrite_conjuncts p1 tms1)
+                         tms p))
+                   (fun uu___ ->
+                      (fun tms' ->
+                         Obj.magic
+                           (FStar_Tactics_Effect.tac_bind
+                              (FStar_Sealed.seal
+                                 (Obj.magic
+                                    (FStar_Range.mk_range
+                                       "Pulse.Checker.AssertWithBinders.fst"
+                                       (Prims.of_int (174))
+                                       (Prims.of_int (4))
+                                       (Prims.of_int (179))
+                                       (Prims.of_int (14)))))
+                              (FStar_Sealed.seal
+                                 (Obj.magic
+                                    (FStar_Range.mk_range
+                                       "Pulse.Checker.AssertWithBinders.fst"
+                                       (Prims.of_int (172))
+                                       (Prims.of_int (41))
+                                       (Prims.of_int (182))
+                                       (Prims.of_int (44)))))
+                              (Obj.magic
+                                 (FStar_Tactics_Util.fold_left2
+                                    (fun uu___2 ->
+                                       fun uu___1 ->
+                                         fun uu___ ->
+                                           (fun uu___ ->
+                                              fun t ->
+                                                fun t' ->
+                                                  Obj.magic
+                                                    (FStar_Tactics_Effect.lift_div_tac
+                                                       (fun uu___1 ->
+                                                          match uu___ with
+                                                          | (lhs, rhs) ->
+                                                              if
+                                                                Pulse_Syntax_Base.eq_tm
+                                                                  t t'
+                                                              then (lhs, rhs)
+                                                              else
+                                                                ((t :: lhs),
+                                                                  (t' ::
+                                                                  rhs)))))
+                                             uu___2 uu___1 uu___) ([], [])
+                                    tms tms'))
+                              (fun uu___ ->
+                                 FStar_Tactics_Effect.lift_div_tac
+                                   (fun uu___1 ->
+                                      match uu___ with
+                                      | (lhs, rhs) ->
+                                          ((Pulse_Typing_Combinators.list_as_vprop
+                                              lhs),
+                                            (Pulse_Typing_Combinators.list_as_vprop
+                                               rhs)))))) uu___))) uu___)
+let (disjoint :
+  Pulse_Syntax_Base.var Prims.list ->
+    Pulse_Syntax_Base.var FStar_Set.set -> Prims.bool)
+  =
+  fun dom ->
+    fun cod ->
+      FStar_List_Tot_Base.for_all
+        (fun d -> Prims.op_Negation (FStar_Set.mem d cod)) dom
 let rec (as_subst :
   (Pulse_Syntax_Base.term * Pulse_Syntax_Base.term) Prims.list ->
     Pulse_Syntax_Naming.subst_elt Prims.list ->
-      Pulse_Syntax_Naming.subst_elt Prims.list FStar_Pervasives_Native.option)
+      Pulse_Syntax_Base.var Prims.list ->
+        Pulse_Syntax_Base.var FStar_Set.set ->
+          Pulse_Syntax_Naming.subst_elt Prims.list
+            FStar_Pervasives_Native.option)
   =
   fun p ->
     fun out ->
-      match p with
-      | [] -> FStar_Pervasives_Native.Some out
-      | (e1, e2)::p1 ->
-          (match e1.Pulse_Syntax_Base.t with
-           | Pulse_Syntax_Base.Tm_FStar e11 ->
-               (match FStar_Reflection_V2_Builtins.inspect_ln e11 with
-                | FStar_Reflection_V2_Data.Tv_Var n ->
-                    let nv = FStar_Reflection_V2_Builtins.inspect_namedv n in
-                    as_subst p1
-                      ((Pulse_Syntax_Naming.NT
-                          ((nv.FStar_Reflection_V2_Data.uniq), e2)) :: out)
-                | uu___ -> FStar_Pervasives_Native.None)
-           | uu___ -> FStar_Pervasives_Native.None)
+      fun domain ->
+        fun codomain ->
+          match p with
+          | [] ->
+              if disjoint domain codomain
+              then FStar_Pervasives_Native.Some out
+              else FStar_Pervasives_Native.None
+          | (e1, e2)::p1 ->
+              (match e1.Pulse_Syntax_Base.t with
+               | Pulse_Syntax_Base.Tm_FStar e11 ->
+                   (match FStar_Reflection_V2_Builtins.inspect_ln e11 with
+                    | FStar_Reflection_V2_Data.Tv_Var n ->
+                        let nv =
+                          FStar_Reflection_V2_Builtins.inspect_namedv n in
+                        as_subst p1
+                          ((Pulse_Syntax_Naming.NT
+                              ((nv.FStar_Reflection_V2_Data.uniq), e2)) ::
+                          out) ((nv.FStar_Reflection_V2_Data.uniq) :: domain)
+                          (FStar_Set.union codomain
+                             (Pulse_Syntax_Naming.freevars e2))
+                    | uu___ -> FStar_Pervasives_Native.None)
+               | uu___ -> FStar_Pervasives_Native.None)
 let (rewrite_all :
   Pulse_Typing_Env.env ->
     (Pulse_Syntax_Base.term * Pulse_Syntax_Base.term) Prims.list ->
@@ -2247,7 +2372,7 @@ let (rewrite_all :
         (fun g ->
            fun p ->
              fun t ->
-               match as_subst p [] with
+               match as_subst p [] [] (FStar_Set.empty ()) with
                | FStar_Pervasives_Native.Some s ->
                    Obj.magic
                      (Obj.repr
@@ -2262,14 +2387,14 @@ let (rewrite_all :
                               (Obj.magic
                                  (FStar_Range.mk_range
                                     "Pulse.Checker.AssertWithBinders.fst"
-                                    (Prims.of_int (200)) (Prims.of_int (6))
-                                    (Prims.of_int (204)) (Prims.of_int (9)))))
+                                    (Prims.of_int (221)) (Prims.of_int (6))
+                                    (Prims.of_int (225)) (Prims.of_int (9)))))
                            (FStar_Sealed.seal
                               (Obj.magic
                                  (FStar_Range.mk_range
                                     "Pulse.Checker.AssertWithBinders.fst"
-                                    (Prims.of_int (205)) (Prims.of_int (6))
-                                    (Prims.of_int (208)) (Prims.of_int (12)))))
+                                    (Prims.of_int (226)) (Prims.of_int (6))
+                                    (Prims.of_int (229)) (Prims.of_int (12)))))
                            (Obj.magic
                               (FStar_Tactics_Util.map
                                  (fun uu___1 ->
@@ -2280,17 +2405,17 @@ let (rewrite_all :
                                              (Obj.magic
                                                 (FStar_Range.mk_range
                                                    "Pulse.Checker.AssertWithBinders.fst"
-                                                   (Prims.of_int (202))
+                                                   (Prims.of_int (223))
                                                    (Prims.of_int (10))
-                                                   (Prims.of_int (202))
+                                                   (Prims.of_int (223))
                                                    (Prims.of_int (78)))))
                                           (FStar_Sealed.seal
                                              (Obj.magic
                                                 (FStar_Range.mk_range
                                                    "Pulse.Checker.AssertWithBinders.fst"
-                                                   (Prims.of_int (202))
+                                                   (Prims.of_int (223))
                                                    (Prims.of_int (10))
-                                                   (Prims.of_int (203))
+                                                   (Prims.of_int (224))
                                                    (Prims.of_int (78)))))
                                           (Obj.magic
                                              (FStar_Tactics_Effect.tac_bind
@@ -2298,17 +2423,17 @@ let (rewrite_all :
                                                    (Obj.magic
                                                       (FStar_Range.mk_range
                                                          "Pulse.Checker.AssertWithBinders.fst"
-                                                         (Prims.of_int (202))
+                                                         (Prims.of_int (223))
                                                          (Prims.of_int (20))
-                                                         (Prims.of_int (202))
+                                                         (Prims.of_int (223))
                                                          (Prims.of_int (78)))))
                                                 (FStar_Sealed.seal
                                                    (Obj.magic
                                                       (FStar_Range.mk_range
                                                          "Pulse.Checker.AssertWithBinders.fst"
-                                                         (Prims.of_int (202))
+                                                         (Prims.of_int (223))
                                                          (Prims.of_int (10))
-                                                         (Prims.of_int (202))
+                                                         (Prims.of_int (223))
                                                          (Prims.of_int (78)))))
                                                 (Obj.magic
                                                    (FStar_Tactics_Effect.tac_bind
@@ -2316,17 +2441,17 @@ let (rewrite_all :
                                                          (Obj.magic
                                                             (FStar_Range.mk_range
                                                                "Pulse.Checker.AssertWithBinders.fst"
-                                                               (Prims.of_int (202))
+                                                               (Prims.of_int (223))
                                                                (Prims.of_int (25))
-                                                               (Prims.of_int (202))
+                                                               (Prims.of_int (223))
                                                                (Prims.of_int (77)))))
                                                       (FStar_Sealed.seal
                                                          (Obj.magic
                                                             (FStar_Range.mk_range
                                                                "Pulse.Checker.AssertWithBinders.fst"
-                                                               (Prims.of_int (202))
+                                                               (Prims.of_int (223))
                                                                (Prims.of_int (20))
-                                                               (Prims.of_int (202))
+                                                               (Prims.of_int (223))
                                                                (Prims.of_int (78)))))
                                                       (Obj.magic
                                                          (Pulse_Checker_Pure.instantiate_term_implicits
@@ -2349,17 +2474,17 @@ let (rewrite_all :
                                                         (Obj.magic
                                                            (FStar_Range.mk_range
                                                               "Pulse.Checker.AssertWithBinders.fst"
-                                                              (Prims.of_int (203))
+                                                              (Prims.of_int (224))
                                                               (Prims.of_int (10))
-                                                              (Prims.of_int (203))
+                                                              (Prims.of_int (224))
                                                               (Prims.of_int (78)))))
                                                      (FStar_Sealed.seal
                                                         (Obj.magic
                                                            (FStar_Range.mk_range
                                                               "Pulse.Checker.AssertWithBinders.fst"
-                                                              (Prims.of_int (202))
+                                                              (Prims.of_int (223))
                                                               (Prims.of_int (10))
-                                                              (Prims.of_int (203))
+                                                              (Prims.of_int (224))
                                                               (Prims.of_int (78)))))
                                                      (Obj.magic
                                                         (FStar_Tactics_Effect.tac_bind
@@ -2367,17 +2492,17 @@ let (rewrite_all :
                                                               (Obj.magic
                                                                  (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (203))
+                                                                    (Prims.of_int (224))
                                                                     (Prims.of_int (20))
-                                                                    (Prims.of_int (203))
+                                                                    (Prims.of_int (224))
                                                                     (Prims.of_int (78)))))
                                                            (FStar_Sealed.seal
                                                               (Obj.magic
                                                                  (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (203))
+                                                                    (Prims.of_int (224))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (203))
+                                                                    (Prims.of_int (224))
                                                                     (Prims.of_int (78)))))
                                                            (Obj.magic
                                                               (FStar_Tactics_Effect.tac_bind
@@ -2386,18 +2511,18 @@ let (rewrite_all :
                                                                     Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (203))
+                                                                    (Prims.of_int (224))
                                                                     (Prims.of_int (25))
-                                                                    (Prims.of_int (203))
+                                                                    (Prims.of_int (224))
                                                                     (Prims.of_int (77)))))
                                                                  (FStar_Sealed.seal
                                                                     (
                                                                     Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (203))
+                                                                    (Prims.of_int (224))
                                                                     (Prims.of_int (20))
-                                                                    (Prims.of_int (203))
+                                                                    (Prims.of_int (224))
                                                                     (Prims.of_int (78)))))
                                                                  (Obj.magic
                                                                     (
@@ -2429,20 +2554,21 @@ let (rewrite_all :
                                          (Obj.magic
                                             (FStar_Range.mk_range
                                                "Pulse.Checker.AssertWithBinders.fst"
-                                               (Prims.of_int (206))
+                                               (Prims.of_int (227))
                                                (Prims.of_int (19))
-                                               (Prims.of_int (206))
-                                               (Prims.of_int (50)))))
+                                               (Prims.of_int (227))
+                                               (Prims.of_int (54)))))
                                       (FStar_Sealed.seal
                                          (Obj.magic
                                             (FStar_Range.mk_range
                                                "Pulse.Checker.AssertWithBinders.fst"
-                                               (Prims.of_int (205))
+                                               (Prims.of_int (226))
                                                (Prims.of_int (6))
-                                               (Prims.of_int (208))
+                                               (Prims.of_int (229))
                                                (Prims.of_int (12)))))
                                       (Obj.magic
-                                         (visit_and_rewrite_conjuncts p1 t))
+                                         (visit_and_rewrite_conjuncts_all p1
+                                            t))
                                       (fun uu___1 ->
                                          (fun uu___1 ->
                                             match uu___1 with
@@ -2453,17 +2579,17 @@ let (rewrite_all :
                                                         (Obj.magic
                                                            (FStar_Range.mk_range
                                                               "Pulse.Checker.AssertWithBinders.fst"
-                                                              (Prims.of_int (207))
+                                                              (Prims.of_int (228))
                                                               (Prims.of_int (4))
-                                                              (Prims.of_int (207))
+                                                              (Prims.of_int (228))
                                                               (Prims.of_int (106)))))
                                                      (FStar_Sealed.seal
                                                         (Obj.magic
                                                            (FStar_Range.mk_range
                                                               "Pulse.Checker.AssertWithBinders.fst"
-                                                              (Prims.of_int (208))
+                                                              (Prims.of_int (229))
                                                               (Prims.of_int (4))
-                                                              (Prims.of_int (208))
+                                                              (Prims.of_int (229))
                                                               (Prims.of_int (12)))))
                                                      (Obj.magic
                                                         (debug_log g
@@ -2473,17 +2599,17 @@ let (rewrite_all :
                                                                    (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (207))
+                                                                    (Prims.of_int (228))
                                                                     (Prims.of_int (83))
-                                                                    (Prims.of_int (207))
+                                                                    (Prims.of_int (228))
                                                                     (Prims.of_int (105)))))
                                                                 (FStar_Sealed.seal
                                                                    (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (207))
+                                                                    (Prims.of_int (228))
                                                                     (Prims.of_int (26))
-                                                                    (Prims.of_int (207))
+                                                                    (Prims.of_int (228))
                                                                     (Prims.of_int (105)))))
                                                                 (Obj.magic
                                                                    (Pulse_Syntax_Printer.term_to_string
@@ -2498,17 +2624,17 @@ let (rewrite_all :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (207))
+                                                                    (Prims.of_int (228))
                                                                     (Prims.of_int (26))
-                                                                    (Prims.of_int (207))
+                                                                    (Prims.of_int (228))
                                                                     (Prims.of_int (105)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (207))
+                                                                    (Prims.of_int (228))
                                                                     (Prims.of_int (26))
-                                                                    (Prims.of_int (207))
+                                                                    (Prims.of_int (228))
                                                                     (Prims.of_int (105)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -2516,9 +2642,9 @@ let (rewrite_all :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (207))
+                                                                    (Prims.of_int (228))
                                                                     (Prims.of_int (60))
-                                                                    (Prims.of_int (207))
+                                                                    (Prims.of_int (228))
                                                                     (Prims.of_int (82)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -2572,12 +2698,12 @@ let rec (check_renaming :
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Checker.AssertWithBinders.fst"
-                   (Prims.of_int (219)) (Prims.of_int (35))
-                   (Prims.of_int (219)) (Prims.of_int (42)))))
+                   (Prims.of_int (240)) (Prims.of_int (35))
+                   (Prims.of_int (240)) (Prims.of_int (42)))))
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Checker.AssertWithBinders.fst"
-                   (Prims.of_int (219)) Prims.int_one (Prims.of_int (245))
+                   (Prims.of_int (240)) Prims.int_one (Prims.of_int (266))
                    (Prims.of_int (3)))))
           (FStar_Tactics_Effect.lift_div_tac
              (fun uu___ -> st.Pulse_Syntax_Base.term1))
@@ -2591,14 +2717,14 @@ let rec (check_renaming :
                             (Obj.magic
                                (FStar_Range.mk_range
                                   "Pulse.Checker.AssertWithBinders.fst"
-                                  (Prims.of_int (220)) (Prims.of_int (65))
-                                  (Prims.of_int (220)) (Prims.of_int (67)))))
+                                  (Prims.of_int (241)) (Prims.of_int (65))
+                                  (Prims.of_int (241)) (Prims.of_int (67)))))
                          (FStar_Sealed.seal
                             (Obj.magic
                                (FStar_Range.mk_range
                                   "Pulse.Checker.AssertWithBinders.fst"
-                                  (Prims.of_int (219)) (Prims.of_int (45))
-                                  (Prims.of_int (245)) (Prims.of_int (3)))))
+                                  (Prims.of_int (240)) (Prims.of_int (45))
+                                  (Prims.of_int (266)) (Prims.of_int (3)))))
                          (FStar_Tactics_Effect.lift_div_tac
                             (fun uu___1 -> ht))
                          (fun uu___1 ->
@@ -2673,17 +2799,17 @@ let rec (check_renaming :
                                                    (Obj.magic
                                                       (FStar_Range.mk_range
                                                          "Pulse.Checker.AssertWithBinders.fst"
-                                                         (Prims.of_int (236))
+                                                         (Prims.of_int (257))
                                                          (Prims.of_int (19))
-                                                         (Prims.of_int (236))
+                                                         (Prims.of_int (257))
                                                          (Prims.of_int (42)))))
                                                 (FStar_Sealed.seal
                                                    (Obj.magic
                                                       (FStar_Range.mk_range
                                                          "Pulse.Checker.AssertWithBinders.fst"
-                                                         (Prims.of_int (234))
+                                                         (Prims.of_int (255))
                                                          (Prims.of_int (15))
-                                                         (Prims.of_int (238))
+                                                         (Prims.of_int (259))
                                                          (Prims.of_int (77)))))
                                                 (Obj.magic
                                                    (rewrite_all g pairs pre))
@@ -2708,9 +2834,9 @@ let rec (check_renaming :
                                                                     =
                                                                     (Pulse_Syntax_Base.Tm_Rewrite
                                                                     {
-                                                                    Pulse_Syntax_Base.t1
+                                                                    Pulse_Syntax_Base.t11
                                                                     = lhs;
-                                                                    Pulse_Syntax_Base.t2
+                                                                    Pulse_Syntax_Base.t21
                                                                     = rhs
                                                                     });
                                                                     Pulse_Syntax_Base.range2
@@ -2733,17 +2859,17 @@ let rec (check_renaming :
                                                    (Obj.magic
                                                       (FStar_Range.mk_range
                                                          "Pulse.Checker.AssertWithBinders.fst"
-                                                         (Prims.of_int (241))
+                                                         (Prims.of_int (262))
                                                          (Prims.of_int (20))
-                                                         (Prims.of_int (241))
+                                                         (Prims.of_int (262))
                                                          (Prims.of_int (56)))))
                                                 (FStar_Sealed.seal
                                                    (Obj.magic
                                                       (FStar_Range.mk_range
                                                          "Pulse.Checker.AssertWithBinders.fst"
-                                                         (Prims.of_int (240))
+                                                         (Prims.of_int (261))
                                                          (Prims.of_int (21))
-                                                         (Prims.of_int (245))
+                                                         (Prims.of_int (266))
                                                          (Prims.of_int (3)))))
                                                 (Obj.magic
                                                    (Pulse_Checker_Pure.instantiate_term_implicits
@@ -2758,17 +2884,17 @@ let rec (check_renaming :
                                                                   (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (242))
+                                                                    (Prims.of_int (263))
                                                                     (Prims.of_int (21))
-                                                                    (Prims.of_int (242))
+                                                                    (Prims.of_int (263))
                                                                     (Prims.of_int (45)))))
                                                                (FStar_Sealed.seal
                                                                   (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (241))
+                                                                    (Prims.of_int (262))
                                                                     (Prims.of_int (59))
-                                                                    (Prims.of_int (244))
+                                                                    (Prims.of_int (265))
                                                                     (Prims.of_int (79)))))
                                                                (Obj.magic
                                                                   (rewrite_all
@@ -2800,9 +2926,9 @@ let rec (check_renaming :
                                                                     =
                                                                     (Pulse_Syntax_Base.Tm_Rewrite
                                                                     {
-                                                                    Pulse_Syntax_Base.t1
+                                                                    Pulse_Syntax_Base.t11
                                                                     = lhs;
-                                                                    Pulse_Syntax_Base.t2
+                                                                    Pulse_Syntax_Base.t21
                                                                     = rhs
                                                                     });
                                                                     Pulse_Syntax_Base.range2
@@ -2841,14 +2967,14 @@ let (check :
                      (Obj.magic
                         (FStar_Range.mk_range
                            "Pulse.Checker.AssertWithBinders.fst"
-                           (Prims.of_int (259)) (Prims.of_int (10))
-                           (Prims.of_int (259)) (Prims.of_int (48)))))
+                           (Prims.of_int (280)) (Prims.of_int (10))
+                           (Prims.of_int (280)) (Prims.of_int (48)))))
                   (FStar_Sealed.seal
                      (Obj.magic
                         (FStar_Range.mk_range
                            "Pulse.Checker.AssertWithBinders.fst"
-                           (Prims.of_int (259)) (Prims.of_int (51))
-                           (Prims.of_int (311)) (Prims.of_int (50)))))
+                           (Prims.of_int (280)) (Prims.of_int (51))
+                           (Prims.of_int (346)) (Prims.of_int (50)))))
                   (FStar_Tactics_Effect.lift_div_tac
                      (fun uu___ ->
                         Pulse_Typing_Env.push_context g "check_assert"
@@ -2861,17 +2987,17 @@ let (check :
                                 (Obj.magic
                                    (FStar_Range.mk_range
                                       "Pulse.Checker.AssertWithBinders.fst"
-                                      (Prims.of_int (261))
+                                      (Prims.of_int (282))
                                       (Prims.of_int (66))
-                                      (Prims.of_int (261))
+                                      (Prims.of_int (282))
                                       (Prims.of_int (73)))))
                              (FStar_Sealed.seal
                                 (Obj.magic
                                    (FStar_Range.mk_range
                                       "Pulse.Checker.AssertWithBinders.fst"
-                                      (Prims.of_int (259))
+                                      (Prims.of_int (280))
                                       (Prims.of_int (51))
-                                      (Prims.of_int (311))
+                                      (Prims.of_int (346))
                                       (Prims.of_int (50)))))
                              (FStar_Tactics_Effect.lift_div_tac
                                 (fun uu___ -> st.Pulse_Syntax_Base.term1))
@@ -2897,17 +3023,17 @@ let (check :
                                                     (Obj.magic
                                                        (FStar_Range.mk_range
                                                           "Pulse.Checker.AssertWithBinders.fst"
-                                                          (Prims.of_int (266))
+                                                          (Prims.of_int (286))
                                                           (Prims.of_int (13))
-                                                          (Prims.of_int (266))
+                                                          (Prims.of_int (286))
                                                           (Prims.of_int (36)))))
                                                  (FStar_Sealed.seal
                                                     (Obj.magic
                                                        (FStar_Range.mk_range
                                                           "Pulse.Checker.AssertWithBinders.fst"
-                                                          (Prims.of_int (267))
+                                                          (Prims.of_int (287))
                                                           (Prims.of_int (4))
-                                                          (Prims.of_int (267))
+                                                          (Prims.of_int (287))
                                                           (Prims.of_int (50)))))
                                                  (Obj.magic
                                                     (check_renaming g1 pre st))
@@ -2918,6 +3044,208 @@ let (check :
                                                             post_hint
                                                             res_ppname st1))
                                                       uu___1))
+                                        | Pulse_Syntax_Base.REWRITE
+                                            { Pulse_Syntax_Base.t1 = t1;
+                                              Pulse_Syntax_Base.t2 = t2;_}
+                                            ->
+                                            (match bs with
+                                             | [] ->
+                                                 Obj.magic
+                                                   (FStar_Tactics_Effect.tac_bind
+                                                      (FStar_Sealed.seal
+                                                         (Obj.magic
+                                                            (FStar_Range.mk_range
+                                                               "Pulse.Checker.AssertWithBinders.fst"
+                                                               (Prims.of_int (292))
+                                                               (Prims.of_int (16))
+                                                               (Prims.of_int (292))
+                                                               (Prims.of_int (52)))))
+                                                      (FStar_Sealed.seal
+                                                         (Obj.magic
+                                                            (FStar_Range.mk_range
+                                                               "Pulse.Checker.AssertWithBinders.fst"
+                                                               (Prims.of_int (293))
+                                                               (Prims.of_int (6))
+                                                               (Prims.of_int (294))
+                                                               (Prims.of_int (83)))))
+                                                      (FStar_Tactics_Effect.lift_div_tac
+                                                         (fun uu___1 ->
+                                                            {
+                                                              Pulse_Syntax_Base.term1
+                                                                =
+                                                                (Pulse_Syntax_Base.Tm_Rewrite
+                                                                   {
+                                                                    Pulse_Syntax_Base.t11
+                                                                    = t1;
+                                                                    Pulse_Syntax_Base.t21
+                                                                    = t2
+                                                                   });
+                                                              Pulse_Syntax_Base.range2
+                                                                =
+                                                                (st.Pulse_Syntax_Base.range2)
+                                                            }))
+                                                      (fun uu___1 ->
+                                                         (fun t ->
+                                                            Obj.magic
+                                                              (check1 g1 pre
+                                                                 () post_hint
+                                                                 res_ppname
+                                                                 {
+                                                                   Pulse_Syntax_Base.term1
+                                                                    =
+                                                                    (Pulse_Syntax_Base.Tm_Bind
+                                                                    {
+                                                                    Pulse_Syntax_Base.binder
+                                                                    =
+                                                                    (Pulse_Typing.as_binder
+                                                                    Pulse_Typing.tm_unit);
+                                                                    Pulse_Syntax_Base.head1
+                                                                    = t;
+                                                                    Pulse_Syntax_Base.body1
+                                                                    = body
+                                                                    });
+                                                                   Pulse_Syntax_Base.range2
+                                                                    =
+                                                                    (st.Pulse_Syntax_Base.range2)
+                                                                 })) uu___1))
+                                             | uu___1 ->
+                                                 Obj.magic
+                                                   (FStar_Tactics_Effect.tac_bind
+                                                      (FStar_Sealed.seal
+                                                         (Obj.magic
+                                                            (FStar_Range.mk_range
+                                                               "Pulse.Checker.AssertWithBinders.fst"
+                                                               (Prims.of_int (296))
+                                                               (Prims.of_int (16))
+                                                               (Prims.of_int (296))
+                                                               (Prims.of_int (52)))))
+                                                      (FStar_Sealed.seal
+                                                         (Obj.magic
+                                                            (FStar_Range.mk_range
+                                                               "Pulse.Checker.AssertWithBinders.fst"
+                                                               (Prims.of_int (296))
+                                                               (Prims.of_int (57))
+                                                               (Prims.of_int (299))
+                                                               (Prims.of_int (52)))))
+                                                      (FStar_Tactics_Effect.lift_div_tac
+                                                         (fun uu___2 ->
+                                                            {
+                                                              Pulse_Syntax_Base.term1
+                                                                =
+                                                                (Pulse_Syntax_Base.Tm_Rewrite
+                                                                   {
+                                                                    Pulse_Syntax_Base.t11
+                                                                    = t1;
+                                                                    Pulse_Syntax_Base.t21
+                                                                    = t2
+                                                                   });
+                                                              Pulse_Syntax_Base.range2
+                                                                =
+                                                                (st.Pulse_Syntax_Base.range2)
+                                                            }))
+                                                      (fun uu___2 ->
+                                                         (fun t ->
+                                                            Obj.magic
+                                                              (FStar_Tactics_Effect.tac_bind
+                                                                 (FStar_Sealed.seal
+                                                                    (
+                                                                    Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.AssertWithBinders.fst"
+                                                                    (Prims.of_int (297))
+                                                                    (Prims.of_int (19))
+                                                                    (Prims.of_int (297))
+                                                                    (Prims.of_int (88)))))
+                                                                 (FStar_Sealed.seal
+                                                                    (
+                                                                    Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.AssertWithBinders.fst"
+                                                                    (Prims.of_int (297))
+                                                                    (Prims.of_int (93))
+                                                                    (Prims.of_int (299))
+                                                                    (Prims.of_int (52)))))
+                                                                 (FStar_Tactics_Effect.lift_div_tac
+                                                                    (
+                                                                    fun
+                                                                    uu___2 ->
+                                                                    {
+                                                                    Pulse_Syntax_Base.term1
+                                                                    =
+                                                                    (Pulse_Syntax_Base.Tm_Bind
+                                                                    {
+                                                                    Pulse_Syntax_Base.binder
+                                                                    =
+                                                                    (Pulse_Typing.as_binder
+                                                                    Pulse_Typing.tm_unit);
+                                                                    Pulse_Syntax_Base.head1
+                                                                    = t;
+                                                                    Pulse_Syntax_Base.body1
+                                                                    = body
+                                                                    });
+                                                                    Pulse_Syntax_Base.range2
+                                                                    =
+                                                                    (st.Pulse_Syntax_Base.range2)
+                                                                    }))
+                                                                 (fun uu___2
+                                                                    ->
+                                                                    (fun
+                                                                    body1 ->
+                                                                    Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.AssertWithBinders.fst"
+                                                                    (Prims.of_int (298))
+                                                                    (Prims.of_int (17))
+                                                                    (Prims.of_int (298))
+                                                                    (Prims.of_int (113)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.AssertWithBinders.fst"
+                                                                    (Prims.of_int (299))
+                                                                    (Prims.of_int (6))
+                                                                    (Prims.of_int (299))
+                                                                    (Prims.of_int (52)))))
+                                                                    (FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___2 ->
+                                                                    {
+                                                                    Pulse_Syntax_Base.term1
+                                                                    =
+                                                                    (Pulse_Syntax_Base.Tm_ProofHintWithBinders
+                                                                    {
+                                                                    Pulse_Syntax_Base.hint_type
+                                                                    =
+                                                                    (Pulse_Syntax_Base.ASSERT
+                                                                    {
+                                                                    Pulse_Syntax_Base.p
+                                                                    = t1
+                                                                    });
+                                                                    Pulse_Syntax_Base.binders
+                                                                    = bs;
+                                                                    Pulse_Syntax_Base.t3
+                                                                    = body1
+                                                                    });
+                                                                    Pulse_Syntax_Base.range2
+                                                                    =
+                                                                    (st.Pulse_Syntax_Base.range2)
+                                                                    }))
+                                                                    (fun
+                                                                    uu___2 ->
+                                                                    (fun st1
+                                                                    ->
+                                                                    Obj.magic
+                                                                    (check1
+                                                                    g1 pre ()
+                                                                    post_hint
+                                                                    res_ppname
+                                                                    st1))
+                                                                    uu___2)))
+                                                                    uu___2)))
+                                                           uu___2)))
                                         | Pulse_Syntax_Base.ASSERT
                                             { Pulse_Syntax_Base.p = v;_} ->
                                             Obj.magic
@@ -2926,17 +3254,17 @@ let (check :
                                                     (Obj.magic
                                                        (FStar_Range.mk_range
                                                           "Pulse.Checker.AssertWithBinders.fst"
-                                                          (Prims.of_int (270))
+                                                          (Prims.of_int (303))
                                                           (Prims.of_int (13))
-                                                          (Prims.of_int (270))
+                                                          (Prims.of_int (303))
                                                           (Prims.of_int (38)))))
                                                  (FStar_Sealed.seal
                                                     (Obj.magic
                                                        (FStar_Range.mk_range
                                                           "Pulse.Checker.AssertWithBinders.fst"
-                                                          (Prims.of_int (270))
+                                                          (Prims.of_int (303))
                                                           (Prims.of_int (41))
-                                                          (Prims.of_int (277))
+                                                          (Prims.of_int (312))
                                                           (Prims.of_int (52)))))
                                                  (Obj.magic
                                                     (infer_binder_types g1 bs
@@ -2949,17 +3277,17 @@ let (check :
                                                                (Obj.magic
                                                                   (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (271))
+                                                                    (Prims.of_int (304))
                                                                     (Prims.of_int (43))
-                                                                    (Prims.of_int (271))
+                                                                    (Prims.of_int (304))
                                                                     (Prims.of_int (90)))))
                                                             (FStar_Sealed.seal
                                                                (Obj.magic
                                                                   (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (270))
+                                                                    (Prims.of_int (303))
                                                                     (Prims.of_int (41))
-                                                                    (Prims.of_int (277))
+                                                                    (Prims.of_int (312))
                                                                     (Prims.of_int (52)))))
                                                             (Obj.magic
                                                                (open_binders
@@ -2983,17 +3311,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (272))
+                                                                    (Prims.of_int (305))
                                                                     (Prims.of_int (18))
-                                                                    (Prims.of_int (272))
+                                                                    (Prims.of_int (305))
                                                                     (Prims.of_int (39)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (271))
+                                                                    (Prims.of_int (304))
                                                                     (Prims.of_int (93))
-                                                                    (Prims.of_int (277))
+                                                                    (Prims.of_int (312))
                                                                     (Prims.of_int (52)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -3015,17 +3343,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (273))
+                                                                    (Prims.of_int (306))
                                                                     (Prims.of_int (21))
-                                                                    (Prims.of_int (273))
+                                                                    (Prims.of_int (306))
                                                                     (Prims.of_int (54)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (272))
+                                                                    (Prims.of_int (305))
                                                                     (Prims.of_int (42))
-                                                                    (Prims.of_int (277))
+                                                                    (Prims.of_int (312))
                                                                     (Prims.of_int (52)))))
                                                                     (Obj.magic
                                                                     (Pulse_Checker_Pure.check_vprop
@@ -3048,17 +3376,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (274))
+                                                                    (Prims.of_int (307))
                                                                     (Prims.of_int (39))
-                                                                    (Prims.of_int (274))
+                                                                    (Prims.of_int (307))
                                                                     (Prims.of_int (68)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (273))
+                                                                    (Prims.of_int (306))
                                                                     (Prims.of_int (57))
-                                                                    (Prims.of_int (277))
+                                                                    (Prims.of_int (312))
                                                                     (Prims.of_int (52)))))
                                                                     (Obj.magic
                                                                     (Pulse_Checker_Prover.prove
@@ -3083,17 +3411,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (276))
+                                                                    (Prims.of_int (309))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (276))
-                                                                    (Prims.of_int (117)))))
+                                                                    (Prims.of_int (311))
+                                                                    (Prims.of_int (65)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (274))
+                                                                    (Prims.of_int (307))
                                                                     (Prims.of_int (71))
-                                                                    (Prims.of_int (277))
+                                                                    (Prims.of_int (312))
                                                                     (Prims.of_int (52)))))
                                                                     (Obj.magic
                                                                     (check1
@@ -3149,17 +3477,17 @@ let (check :
                                                     (Obj.magic
                                                        (FStar_Range.mk_range
                                                           "Pulse.Checker.AssertWithBinders.fst"
-                                                          (Prims.of_int (282))
+                                                          (Prims.of_int (317))
                                                           (Prims.of_int (13))
-                                                          (Prims.of_int (282))
+                                                          (Prims.of_int (317))
                                                           (Prims.of_int (38)))))
                                                  (FStar_Sealed.seal
                                                     (Obj.magic
                                                        (FStar_Range.mk_range
                                                           "Pulse.Checker.AssertWithBinders.fst"
-                                                          (Prims.of_int (282))
+                                                          (Prims.of_int (317))
                                                           (Prims.of_int (41))
-                                                          (Prims.of_int (311))
+                                                          (Prims.of_int (346))
                                                           (Prims.of_int (50)))))
                                                  (Obj.magic
                                                     (infer_binder_types g1 bs
@@ -3172,17 +3500,17 @@ let (check :
                                                                (Obj.magic
                                                                   (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (283))
+                                                                    (Prims.of_int (318))
                                                                     (Prims.of_int (43))
-                                                                    (Prims.of_int (283))
+                                                                    (Prims.of_int (318))
                                                                     (Prims.of_int (90)))))
                                                             (FStar_Sealed.seal
                                                                (Obj.magic
                                                                   (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (282))
+                                                                    (Prims.of_int (317))
                                                                     (Prims.of_int (41))
-                                                                    (Prims.of_int (311))
+                                                                    (Prims.of_int (346))
                                                                     (Prims.of_int (50)))))
                                                             (Obj.magic
                                                                (open_binders
@@ -3206,17 +3534,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (284))
+                                                                    (Prims.of_int (319))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (284))
+                                                                    (Prims.of_int (319))
                                                                     (Prims.of_int (24)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (284))
+                                                                    (Prims.of_int (319))
                                                                     (Prims.of_int (25))
-                                                                    (Prims.of_int (311))
+                                                                    (Prims.of_int (346))
                                                                     (Prims.of_int (50)))))
                                                                     (Obj.magic
                                                                     (check_unfoldable
@@ -3231,17 +3559,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (285))
+                                                                    (Prims.of_int (320))
                                                                     (Prims.of_int (22))
-                                                                    (Prims.of_int (285))
+                                                                    (Prims.of_int (320))
                                                                     (Prims.of_int (77)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (284))
+                                                                    (Prims.of_int (319))
                                                                     (Prims.of_int (25))
-                                                                    (Prims.of_int (311))
+                                                                    (Prims.of_int (346))
                                                                     (Prims.of_int (50)))))
                                                                     (Obj.magic
                                                                     (Pulse_Checker_Pure.instantiate_term_implicits
@@ -3264,17 +3592,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (287))
+                                                                    (Prims.of_int (322))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (293))
+                                                                    (Prims.of_int (328))
                                                                     (Prims.of_int (16)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (285))
+                                                                    (Prims.of_int (320))
                                                                     (Prims.of_int (80))
-                                                                    (Prims.of_int (311))
+                                                                    (Prims.of_int (346))
                                                                     (Prims.of_int (50)))))
                                                                     (match hint_type
                                                                     with
@@ -3287,17 +3615,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (290))
+                                                                    (Prims.of_int (325))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (290))
+                                                                    (Prims.of_int (325))
                                                                     (Prims.of_int (50)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (289))
+                                                                    (Prims.of_int (324))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (290))
+                                                                    (Prims.of_int (325))
                                                                     (Prims.of_int (50)))))
                                                                     (Obj.magic
                                                                     (unfold_defs
@@ -3326,17 +3654,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (292))
+                                                                    (Prims.of_int (327))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (292))
+                                                                    (Prims.of_int (327))
                                                                     (Prims.of_int (48)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (292))
+                                                                    (Prims.of_int (327))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (293))
+                                                                    (Prims.of_int (328))
                                                                     (Prims.of_int (16)))))
                                                                     (Obj.magic
                                                                     (unfold_defs
@@ -3366,17 +3694,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (294))
+                                                                    (Prims.of_int (329))
                                                                     (Prims.of_int (17))
-                                                                    (Prims.of_int (294))
+                                                                    (Prims.of_int (329))
                                                                     (Prims.of_int (37)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (294))
+                                                                    (Prims.of_int (329))
                                                                     (Prims.of_int (40))
-                                                                    (Prims.of_int (311))
+                                                                    (Prims.of_int (346))
                                                                     (Prims.of_int (50)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -3394,17 +3722,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (295))
+                                                                    (Prims.of_int (330))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (295))
+                                                                    (Prims.of_int (330))
                                                                     (Prims.of_int (69)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (294))
+                                                                    (Prims.of_int (329))
                                                                     (Prims.of_int (40))
-                                                                    (Prims.of_int (311))
+                                                                    (Prims.of_int (346))
                                                                     (Prims.of_int (50)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -3430,17 +3758,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (296))
+                                                                    (Prims.of_int (331))
                                                                     (Prims.of_int (15))
-                                                                    (Prims.of_int (298))
+                                                                    (Prims.of_int (333))
                                                                     (Prims.of_int (31)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (298))
+                                                                    (Prims.of_int (333))
                                                                     (Prims.of_int (36))
-                                                                    (Prims.of_int (311))
+                                                                    (Prims.of_int (346))
                                                                     (Prims.of_int (50)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -3450,9 +3778,9 @@ let (check :
                                                                     =
                                                                     (Pulse_Syntax_Base.Tm_Rewrite
                                                                     {
-                                                                    Pulse_Syntax_Base.t1
+                                                                    Pulse_Syntax_Base.t11
                                                                     = lhs1;
-                                                                    Pulse_Syntax_Base.t2
+                                                                    Pulse_Syntax_Base.t21
                                                                     = rhs1
                                                                     });
                                                                     Pulse_Syntax_Base.range2
@@ -3469,17 +3797,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (299))
+                                                                    (Prims.of_int (334))
                                                                     (Prims.of_int (15))
-                                                                    (Prims.of_int (301))
+                                                                    (Prims.of_int (336))
                                                                     (Prims.of_int (31)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (301))
+                                                                    (Prims.of_int (336))
                                                                     (Prims.of_int (36))
-                                                                    (Prims.of_int (311))
+                                                                    (Prims.of_int (346))
                                                                     (Prims.of_int (50)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -3518,17 +3846,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (304))
+                                                                    (Prims.of_int (339))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (310))
+                                                                    (Prims.of_int (345))
                                                                     (Prims.of_int (28)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (311))
+                                                                    (Prims.of_int (346))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (311))
+                                                                    (Prims.of_int (346))
                                                                     (Prims.of_int (50)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -3591,17 +3919,17 @@ let (check :
                                                     (Obj.magic
                                                        (FStar_Range.mk_range
                                                           "Pulse.Checker.AssertWithBinders.fst"
-                                                          (Prims.of_int (282))
+                                                          (Prims.of_int (317))
                                                           (Prims.of_int (13))
-                                                          (Prims.of_int (282))
+                                                          (Prims.of_int (317))
                                                           (Prims.of_int (38)))))
                                                  (FStar_Sealed.seal
                                                     (Obj.magic
                                                        (FStar_Range.mk_range
                                                           "Pulse.Checker.AssertWithBinders.fst"
-                                                          (Prims.of_int (282))
+                                                          (Prims.of_int (317))
                                                           (Prims.of_int (41))
-                                                          (Prims.of_int (311))
+                                                          (Prims.of_int (346))
                                                           (Prims.of_int (50)))))
                                                  (Obj.magic
                                                     (infer_binder_types g1 bs
@@ -3614,17 +3942,17 @@ let (check :
                                                                (Obj.magic
                                                                   (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (283))
+                                                                    (Prims.of_int (318))
                                                                     (Prims.of_int (43))
-                                                                    (Prims.of_int (283))
+                                                                    (Prims.of_int (318))
                                                                     (Prims.of_int (90)))))
                                                             (FStar_Sealed.seal
                                                                (Obj.magic
                                                                   (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (282))
+                                                                    (Prims.of_int (317))
                                                                     (Prims.of_int (41))
-                                                                    (Prims.of_int (311))
+                                                                    (Prims.of_int (346))
                                                                     (Prims.of_int (50)))))
                                                             (Obj.magic
                                                                (open_binders
@@ -3648,17 +3976,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (284))
+                                                                    (Prims.of_int (319))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (284))
+                                                                    (Prims.of_int (319))
                                                                     (Prims.of_int (24)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (284))
+                                                                    (Prims.of_int (319))
                                                                     (Prims.of_int (25))
-                                                                    (Prims.of_int (311))
+                                                                    (Prims.of_int (346))
                                                                     (Prims.of_int (50)))))
                                                                     (Obj.magic
                                                                     (check_unfoldable
@@ -3673,17 +4001,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (285))
+                                                                    (Prims.of_int (320))
                                                                     (Prims.of_int (22))
-                                                                    (Prims.of_int (285))
+                                                                    (Prims.of_int (320))
                                                                     (Prims.of_int (77)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (284))
+                                                                    (Prims.of_int (319))
                                                                     (Prims.of_int (25))
-                                                                    (Prims.of_int (311))
+                                                                    (Prims.of_int (346))
                                                                     (Prims.of_int (50)))))
                                                                     (Obj.magic
                                                                     (Pulse_Checker_Pure.instantiate_term_implicits
@@ -3706,17 +4034,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (287))
+                                                                    (Prims.of_int (322))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (293))
+                                                                    (Prims.of_int (328))
                                                                     (Prims.of_int (16)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (285))
+                                                                    (Prims.of_int (320))
                                                                     (Prims.of_int (80))
-                                                                    (Prims.of_int (311))
+                                                                    (Prims.of_int (346))
                                                                     (Prims.of_int (50)))))
                                                                     (match hint_type
                                                                     with
@@ -3729,17 +4057,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (290))
+                                                                    (Prims.of_int (325))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (290))
+                                                                    (Prims.of_int (325))
                                                                     (Prims.of_int (50)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (289))
+                                                                    (Prims.of_int (324))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (290))
+                                                                    (Prims.of_int (325))
                                                                     (Prims.of_int (50)))))
                                                                     (Obj.magic
                                                                     (unfold_defs
@@ -3768,17 +4096,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (292))
+                                                                    (Prims.of_int (327))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (292))
+                                                                    (Prims.of_int (327))
                                                                     (Prims.of_int (48)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (292))
+                                                                    (Prims.of_int (327))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (293))
+                                                                    (Prims.of_int (328))
                                                                     (Prims.of_int (16)))))
                                                                     (Obj.magic
                                                                     (unfold_defs
@@ -3808,17 +4136,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (294))
+                                                                    (Prims.of_int (329))
                                                                     (Prims.of_int (17))
-                                                                    (Prims.of_int (294))
+                                                                    (Prims.of_int (329))
                                                                     (Prims.of_int (37)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (294))
+                                                                    (Prims.of_int (329))
                                                                     (Prims.of_int (40))
-                                                                    (Prims.of_int (311))
+                                                                    (Prims.of_int (346))
                                                                     (Prims.of_int (50)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -3836,17 +4164,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (295))
+                                                                    (Prims.of_int (330))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (295))
+                                                                    (Prims.of_int (330))
                                                                     (Prims.of_int (69)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (294))
+                                                                    (Prims.of_int (329))
                                                                     (Prims.of_int (40))
-                                                                    (Prims.of_int (311))
+                                                                    (Prims.of_int (346))
                                                                     (Prims.of_int (50)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -3872,17 +4200,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (296))
+                                                                    (Prims.of_int (331))
                                                                     (Prims.of_int (15))
-                                                                    (Prims.of_int (298))
+                                                                    (Prims.of_int (333))
                                                                     (Prims.of_int (31)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (298))
+                                                                    (Prims.of_int (333))
                                                                     (Prims.of_int (36))
-                                                                    (Prims.of_int (311))
+                                                                    (Prims.of_int (346))
                                                                     (Prims.of_int (50)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -3892,9 +4220,9 @@ let (check :
                                                                     =
                                                                     (Pulse_Syntax_Base.Tm_Rewrite
                                                                     {
-                                                                    Pulse_Syntax_Base.t1
+                                                                    Pulse_Syntax_Base.t11
                                                                     = lhs1;
-                                                                    Pulse_Syntax_Base.t2
+                                                                    Pulse_Syntax_Base.t21
                                                                     = rhs1
                                                                     });
                                                                     Pulse_Syntax_Base.range2
@@ -3911,17 +4239,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (299))
+                                                                    (Prims.of_int (334))
                                                                     (Prims.of_int (15))
-                                                                    (Prims.of_int (301))
+                                                                    (Prims.of_int (336))
                                                                     (Prims.of_int (31)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (301))
+                                                                    (Prims.of_int (336))
                                                                     (Prims.of_int (36))
-                                                                    (Prims.of_int (311))
+                                                                    (Prims.of_int (346))
                                                                     (Prims.of_int (50)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -3960,17 +4288,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (304))
+                                                                    (Prims.of_int (339))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (310))
+                                                                    (Prims.of_int (345))
                                                                     (Prims.of_int (28)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (311))
+                                                                    (Prims.of_int (346))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (311))
+                                                                    (Prims.of_int (346))
                                                                     (Prims.of_int (50)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun

--- a/src/ocaml/plugin/generated/Pulse_Checker_Exists.ml
+++ b/src/ocaml/plugin/generated/Pulse_Checker_Exists.ml
@@ -74,7 +74,7 @@ let (check_elim_exists :
                               (fun uu___ ->
                                  match uu___ with
                                  | Pulse_Syntax_Base.Tm_ElimExists
-                                     { Pulse_Syntax_Base.p1 = t1;_} ->
+                                     { Pulse_Syntax_Base.p4 = t1;_} ->
                                      Obj.magic
                                        (FStar_Tactics_Effect.tac_bind
                                           (FStar_Sealed.seal
@@ -547,7 +547,7 @@ let (check_elim_exists :
                                                                     (Pulse_Typing.wr
                                                                     (Pulse_Syntax_Base.Tm_ElimExists
                                                                     {
-                                                                    Pulse_Syntax_Base.p1
+                                                                    Pulse_Syntax_Base.p4
                                                                     =
                                                                     (Pulse_Syntax_Base.tm_exists_sl
                                                                     u
@@ -598,7 +598,7 @@ let (intro_exists_witness_singleton :
   fun st ->
     match st.Pulse_Syntax_Base.term1 with
     | Pulse_Syntax_Base.Tm_IntroExists
-        { Pulse_Syntax_Base.p2 = uu___;
+        { Pulse_Syntax_Base.p5 = uu___;
           Pulse_Syntax_Base.witnesses = uu___1::[];_}
         -> true
     | uu___ -> false
@@ -607,7 +607,7 @@ let (intro_exists_vprop :
   fun st ->
     match st.Pulse_Syntax_Base.term1 with
     | Pulse_Syntax_Base.Tm_IntroExists
-        { Pulse_Syntax_Base.p2 = p; Pulse_Syntax_Base.witnesses = uu___;_} ->
+        { Pulse_Syntax_Base.p5 = p; Pulse_Syntax_Base.witnesses = uu___;_} ->
         p
 let (check_intro_exists :
   Pulse_Typing_Env.env ->
@@ -666,7 +666,7 @@ let (check_intro_exists :
                                 (fun uu___ ->
                                    match uu___ with
                                    | Pulse_Syntax_Base.Tm_IntroExists
-                                       { Pulse_Syntax_Base.p2 = t;
+                                       { Pulse_Syntax_Base.p5 = t;
                                          Pulse_Syntax_Base.witnesses =
                                            witness::[];_}
                                        ->
@@ -1020,7 +1020,7 @@ let (check_intro_exists :
                                                                     (Pulse_Typing.wr
                                                                     (Pulse_Syntax_Base.Tm_IntroExists
                                                                     {
-                                                                    Pulse_Syntax_Base.p2
+                                                                    Pulse_Syntax_Base.p5
                                                                     =
                                                                     (Pulse_Syntax_Base.tm_exists_sl
                                                                     u b p);

--- a/src/ocaml/plugin/generated/Pulse_Checker_IntroPure.ml
+++ b/src/ocaml/plugin/generated/Pulse_Checker_IntroPure.ml
@@ -224,7 +224,7 @@ let (check :
                               (fun uu___ ->
                                  match uu___ with
                                  | Pulse_Syntax_Base.Tm_IntroPure
-                                     { Pulse_Syntax_Base.p = p;_} ->
+                                     { Pulse_Syntax_Base.p3 = p;_} ->
                                      Obj.magic
                                        (FStar_Tactics_Effect.tac_bind
                                           (FStar_Sealed.seal
@@ -329,7 +329,7 @@ let (check :
                                                                     (Pulse_Typing.wr
                                                                     (Pulse_Syntax_Base.Tm_IntroPure
                                                                     {
-                                                                    Pulse_Syntax_Base.p
+                                                                    Pulse_Syntax_Base.p3
                                                                     = p1
                                                                     }))
                                                                     (Pulse_Typing.comp_intro_pure

--- a/src/ocaml/plugin/generated/Pulse_Checker_Prover_ElimExists.ml
+++ b/src/ocaml/plugin/generated/Pulse_Checker_Prover_ElimExists.ml
@@ -42,7 +42,7 @@ let (mk :
                                   (Pulse_Typing.wr
                                      (Pulse_Syntax_Base.Tm_ElimExists
                                         {
-                                          Pulse_Syntax_Base.p1 =
+                                          Pulse_Syntax_Base.p4 =
                                             (Pulse_Syntax_Base.tm_exists_sl
                                                (Pulse_Syntax_Base.comp_u
                                                   (Pulse_Typing.comp_elim_exists

--- a/src/ocaml/plugin/generated/Pulse_Checker_Prover_IntroExists.ml
+++ b/src/ocaml/plugin/generated/Pulse_Checker_Prover_IntroExists.ml
@@ -42,7 +42,7 @@ let (k_intro_exists :
                             Pulse_Typing.wr
                               (Pulse_Syntax_Base.Tm_IntroExists
                                  {
-                                   Pulse_Syntax_Base.p2 =
+                                   Pulse_Syntax_Base.p5 =
                                      (Pulse_Syntax_Base.tm_exists_sl u b p);
                                    Pulse_Syntax_Base.witnesses = [e]
                                  })))
@@ -173,7 +173,7 @@ let (k_intro_exists :
                                                                     (Pulse_Typing.wr
                                                                     (Pulse_Syntax_Base.Tm_IntroExists
                                                                     {
-                                                                    Pulse_Syntax_Base.p2
+                                                                    Pulse_Syntax_Base.p5
                                                                     =
                                                                     (Pulse_Syntax_Base.tm_exists_sl
                                                                     u b p);

--- a/src/ocaml/plugin/generated/Pulse_Checker_Prover_IntroPure.ml
+++ b/src/ocaml/plugin/generated/Pulse_Checker_Prover_IntroPure.ml
@@ -33,7 +33,7 @@ let (k_intro_pure :
                  (fun uu___ ->
                     Pulse_Typing.wr
                       (Pulse_Syntax_Base.Tm_IntroPure
-                         { Pulse_Syntax_Base.p = p })))
+                         { Pulse_Syntax_Base.p3 = p })))
               (fun uu___ ->
                  (fun t ->
                     Obj.magic

--- a/src/ocaml/plugin/generated/Pulse_Checker_Rewrite.ml
+++ b/src/ocaml/plugin/generated/Pulse_Checker_Rewrite.ml
@@ -52,8 +52,8 @@ let (check :
                               (fun uu___ ->
                                  match uu___ with
                                  | Pulse_Syntax_Base.Tm_Rewrite
-                                     { Pulse_Syntax_Base.t1 = p;
-                                       Pulse_Syntax_Base.t2 = q;_}
+                                     { Pulse_Syntax_Base.t11 = p;
+                                       Pulse_Syntax_Base.t21 = q;_}
                                      ->
                                      Obj.magic
                                        (FStar_Tactics_Effect.tac_bind
@@ -558,9 +558,9 @@ let (check :
                                                                     (Pulse_Typing.wr
                                                                     (Pulse_Syntax_Base.Tm_Rewrite
                                                                     {
-                                                                    Pulse_Syntax_Base.t1
+                                                                    Pulse_Syntax_Base.t11
                                                                     = p1;
-                                                                    Pulse_Syntax_Base.t2
+                                                                    Pulse_Syntax_Base.t21
                                                                     = q1
                                                                     }))
                                                                     (Pulse_Typing.comp_rewrite

--- a/src/ocaml/plugin/generated/Pulse_Syntax_Base.ml
+++ b/src/ocaml/plugin/generated/Pulse_Syntax_Base.ml
@@ -211,22 +211,70 @@ let (ctag_of_comp_st : comp_st -> ctag) =
     | C_ST uu___ -> STT
     | C_STAtomic (uu___, uu___1) -> STT_Atomic
     | C_STGhost (uu___, uu___1) -> STT_Ghost
-type proof_hint_type =
-  | ASSERT 
-  | FOLD of Prims.string Prims.list FStar_Pervasives_Native.option 
-  | UNFOLD of Prims.string Prims.list FStar_Pervasives_Native.option 
+type proof_hint_type__ASSERT__payload = {
+  p: vprop }
+and proof_hint_type__FOLD__payload =
+  {
+  names: Prims.string Prims.list FStar_Pervasives_Native.option ;
+  p1: vprop }
+and proof_hint_type__UNFOLD__payload =
+  {
+  names1: Prims.string Prims.list FStar_Pervasives_Native.option ;
+  p2: vprop }
+and proof_hint_type__RENAME__payload =
+  {
+  pairs: (term * term) Prims.list ;
+  goal: term FStar_Pervasives_Native.option }
+and proof_hint_type =
+  | ASSERT of proof_hint_type__ASSERT__payload 
+  | FOLD of proof_hint_type__FOLD__payload 
+  | UNFOLD of proof_hint_type__UNFOLD__payload 
+  | RENAME of proof_hint_type__RENAME__payload 
+let (__proj__Mkproof_hint_type__ASSERT__payload__item__p :
+  proof_hint_type__ASSERT__payload -> vprop) =
+  fun projectee -> match projectee with | { p;_} -> p
+let (__proj__Mkproof_hint_type__FOLD__payload__item__names :
+  proof_hint_type__FOLD__payload ->
+    Prims.string Prims.list FStar_Pervasives_Native.option)
+  = fun projectee -> match projectee with | { names; p1 = p;_} -> names
+let (__proj__Mkproof_hint_type__FOLD__payload__item__p :
+  proof_hint_type__FOLD__payload -> vprop) =
+  fun projectee -> match projectee with | { names; p1 = p;_} -> p
+let (__proj__Mkproof_hint_type__UNFOLD__payload__item__names :
+  proof_hint_type__UNFOLD__payload ->
+    Prims.string Prims.list FStar_Pervasives_Native.option)
+  =
+  fun projectee ->
+    match projectee with | { names1 = names; p2 = p;_} -> names
+let (__proj__Mkproof_hint_type__UNFOLD__payload__item__p :
+  proof_hint_type__UNFOLD__payload -> vprop) =
+  fun projectee -> match projectee with | { names1 = names; p2 = p;_} -> p
+let (__proj__Mkproof_hint_type__RENAME__payload__item__pairs :
+  proof_hint_type__RENAME__payload -> (term * term) Prims.list) =
+  fun projectee -> match projectee with | { pairs; goal;_} -> pairs
+let (__proj__Mkproof_hint_type__RENAME__payload__item__goal :
+  proof_hint_type__RENAME__payload -> term FStar_Pervasives_Native.option) =
+  fun projectee -> match projectee with | { pairs; goal;_} -> goal
 let (uu___is_ASSERT : proof_hint_type -> Prims.bool) =
-  fun projectee -> match projectee with | ASSERT -> true | uu___ -> false
+  fun projectee -> match projectee with | ASSERT _0 -> true | uu___ -> false
+let (__proj__ASSERT__item___0 :
+  proof_hint_type -> proof_hint_type__ASSERT__payload) =
+  fun projectee -> match projectee with | ASSERT _0 -> _0
 let (uu___is_FOLD : proof_hint_type -> Prims.bool) =
   fun projectee -> match projectee with | FOLD _0 -> true | uu___ -> false
 let (__proj__FOLD__item___0 :
-  proof_hint_type -> Prims.string Prims.list FStar_Pervasives_Native.option)
-  = fun projectee -> match projectee with | FOLD _0 -> _0
+  proof_hint_type -> proof_hint_type__FOLD__payload) =
+  fun projectee -> match projectee with | FOLD _0 -> _0
 let (uu___is_UNFOLD : proof_hint_type -> Prims.bool) =
   fun projectee -> match projectee with | UNFOLD _0 -> true | uu___ -> false
 let (__proj__UNFOLD__item___0 :
-  proof_hint_type -> Prims.string Prims.list FStar_Pervasives_Native.option)
-  = fun projectee -> match projectee with | UNFOLD _0 -> _0
+  proof_hint_type -> proof_hint_type__UNFOLD__payload) =
+  fun projectee -> match projectee with | UNFOLD _0 -> _0
+let (uu___is_RENAME : proof_hint_type -> Prims.bool) =
+  fun projectee -> match projectee with | RENAME _0 -> true | uu___ -> false
+let (__proj__RENAME__item___0 :
+  proof_hint_type -> proof_hint_type__RENAME__payload) =
+  fun projectee -> match projectee with | RENAME _0 -> _0
 type st_term'__Tm_Return__payload =
   {
   ctag: ctag ;
@@ -265,12 +313,12 @@ and st_term'__Tm_Match__payload =
   returns_: vprop FStar_Pervasives_Native.option ;
   brs: (pattern * st_term) Prims.list }
 and st_term'__Tm_IntroPure__payload = {
-  p: term }
+  p3: term }
 and st_term'__Tm_ElimExists__payload = {
-  p1: vprop }
+  p4: vprop }
 and st_term'__Tm_IntroExists__payload =
   {
-  p2: vprop ;
+  p5: vprop ;
   witnesses: term Prims.list }
 and st_term'__Tm_While__payload =
   {
@@ -304,7 +352,6 @@ and st_term'__Tm_ProofHintWithBinders__payload =
   {
   hint_type: proof_hint_type ;
   binders: binder Prims.list ;
-  v: vprop ;
   t3: st_term }
 and st_term' =
   | Tm_Return of st_term'__Tm_Return__payload 
@@ -484,6 +531,27 @@ and (eq_sub_pat :
       | (p1, b1) ->
           let uu___1 = pb2 in
           (match uu___1 with | (p2, b2) -> (eq_pattern p1 p2) && (b1 = b2))
+let (eq_hint_type : proof_hint_type -> proof_hint_type -> Prims.bool) =
+  fun ht1 ->
+    fun ht2 ->
+      match (ht1, ht2) with
+      | (ASSERT { p = p1;_}, ASSERT { p = p2;_}) -> eq_tm p1 p2
+      | (FOLD { names = ns1; p1;_}, FOLD { names = ns2; p1 = p2;_}) ->
+          (eq_opt (eq_list (fun n1 -> fun n2 -> n1 = n2)) ns1 ns2) &&
+            (eq_tm p1 p2)
+      | (UNFOLD { names1 = ns1; p2 = p1;_}, UNFOLD { names1 = ns2; p2;_}) ->
+          (eq_opt (eq_list (fun n1 -> fun n2 -> n1 = n2)) ns1 ns2) &&
+            (eq_tm p1 p2)
+      | (RENAME { pairs = ps1; goal = p1;_}, RENAME
+         { pairs = ps2; goal = p2;_}) ->
+          (eq_list
+             (fun uu___ ->
+                fun uu___1 ->
+                  match (uu___, uu___1) with
+                  | ((x1, y1), (x2, y2)) -> (eq_tm x1 x2) && (eq_tm y1 y2))
+             ps1 ps2)
+            && (eq_opt eq_tm p1 p2)
+      | uu___ -> false
 let rec (eq_st_term : st_term -> st_term -> Prims.bool) =
   fun t1 ->
     fun t2 ->
@@ -507,10 +575,11 @@ let rec (eq_st_term : st_term -> st_term -> Prims.bool) =
          { binder1 = b2; head2 = t21; body2 = k2;_}) ->
           ((eq_tm b1.binder_ty b2.binder_ty) && (eq_tm t11 t21)) &&
             (eq_st_term k1 k2)
-      | (Tm_IntroPure { p = p1;_}, Tm_IntroPure { p = p2;_}) -> eq_tm p1 p2
-      | (Tm_IntroExists { p2 = p1; witnesses = l1;_}, Tm_IntroExists
-         { p2; witnesses = l2;_}) -> (eq_tm p1 p2) && (eq_tm_list l1 l2)
-      | (Tm_ElimExists { p1;_}, Tm_ElimExists { p1 = p2;_}) -> eq_tm p1 p2
+      | (Tm_IntroPure { p3 = p1;_}, Tm_IntroPure { p3 = p2;_}) -> eq_tm p1 p2
+      | (Tm_IntroExists { p5 = p1; witnesses = l1;_}, Tm_IntroExists
+         { p5 = p2; witnesses = l2;_}) -> (eq_tm p1 p2) && (eq_tm_list l1 l2)
+      | (Tm_ElimExists { p4 = p1;_}, Tm_ElimExists { p4 = p2;_}) ->
+          eq_tm p1 p2
       | (Tm_If { b1 = g1; then_ = ethen1; else_ = eelse1; post1 = p1;_},
          Tm_If { b1 = g2; then_ = ethen2; else_ = eelse2; post1 = p2;_}) ->
           (((eq_tm g1 g2) && (eq_st_term ethen1 ethen2)) &&
@@ -552,10 +621,10 @@ let rec (eq_st_term : st_term -> st_term -> Prims.bool) =
           (((c1 = c2) && (eq_univ u1 u2)) && (eq_tm t11 t21)) &&
             (eq_tm_opt post1 post2)
       | (Tm_ProofHintWithBinders
-         { hint_type = ht1; binders = bs1; v = v1; t3 = t11;_},
+         { hint_type = ht1; binders = bs1; t3 = t11;_},
          Tm_ProofHintWithBinders
-         { hint_type = ht2; binders = bs2; v = v2; t3 = t21;_}) ->
-          (((ht1 = ht2) && (eq_list eq_binder bs1 bs2)) && (eq_tm v1 v2)) &&
+         { hint_type = ht2; binders = bs2; t3 = t21;_}) ->
+          ((eq_hint_type ht1 ht2) && (eq_list eq_binder bs1 bs2)) &&
             (eq_st_term t11 t21)
       | uu___ -> false
 and (eq_branch : (pattern * st_term) -> (pattern * st_term) -> Prims.bool) =

--- a/src/ocaml/plugin/generated/Pulse_Syntax_Base.ml
+++ b/src/ocaml/plugin/generated/Pulse_Syntax_Base.ml
@@ -225,11 +225,15 @@ and proof_hint_type__RENAME__payload =
   {
   pairs: (term * term) Prims.list ;
   goal: term FStar_Pervasives_Native.option }
+and proof_hint_type__REWRITE__payload = {
+  t1: vprop ;
+  t2: vprop }
 and proof_hint_type =
   | ASSERT of proof_hint_type__ASSERT__payload 
   | FOLD of proof_hint_type__FOLD__payload 
   | UNFOLD of proof_hint_type__UNFOLD__payload 
   | RENAME of proof_hint_type__RENAME__payload 
+  | REWRITE of proof_hint_type__REWRITE__payload 
 let (__proj__Mkproof_hint_type__ASSERT__payload__item__p :
   proof_hint_type__ASSERT__payload -> vprop) =
   fun projectee -> match projectee with | { p;_} -> p
@@ -255,6 +259,12 @@ let (__proj__Mkproof_hint_type__RENAME__payload__item__pairs :
 let (__proj__Mkproof_hint_type__RENAME__payload__item__goal :
   proof_hint_type__RENAME__payload -> term FStar_Pervasives_Native.option) =
   fun projectee -> match projectee with | { pairs; goal;_} -> goal
+let (__proj__Mkproof_hint_type__REWRITE__payload__item__t1 :
+  proof_hint_type__REWRITE__payload -> vprop) =
+  fun projectee -> match projectee with | { t1; t2;_} -> t1
+let (__proj__Mkproof_hint_type__REWRITE__payload__item__t2 :
+  proof_hint_type__REWRITE__payload -> vprop) =
+  fun projectee -> match projectee with | { t1; t2;_} -> t2
 let (uu___is_ASSERT : proof_hint_type -> Prims.bool) =
   fun projectee -> match projectee with | ASSERT _0 -> true | uu___ -> false
 let (__proj__ASSERT__item___0 :
@@ -275,6 +285,11 @@ let (uu___is_RENAME : proof_hint_type -> Prims.bool) =
 let (__proj__RENAME__item___0 :
   proof_hint_type -> proof_hint_type__RENAME__payload) =
   fun projectee -> match projectee with | RENAME _0 -> _0
+let (uu___is_REWRITE : proof_hint_type -> Prims.bool) =
+  fun projectee -> match projectee with | REWRITE _0 -> true | uu___ -> false
+let (__proj__REWRITE__item___0 :
+  proof_hint_type -> proof_hint_type__REWRITE__payload) =
+  fun projectee -> match projectee with | REWRITE _0 -> _0
 type st_term'__Tm_Return__payload =
   {
   ctag: ctag ;
@@ -340,8 +355,8 @@ and st_term'__Tm_WithLocal__payload =
   initializer1: term ;
   body4: st_term }
 and st_term'__Tm_Rewrite__payload = {
-  t1: term ;
-  t2: term }
+  t11: term ;
+  t21: term }
 and st_term'__Tm_Admit__payload =
   {
   ctag1: ctag ;
@@ -551,6 +566,8 @@ let (eq_hint_type : proof_hint_type -> proof_hint_type -> Prims.bool) =
                   | ((x1, y1), (x2, y2)) -> (eq_tm x1 x2) && (eq_tm y1 y2))
              ps1 ps2)
             && (eq_opt eq_tm p1 p2)
+      | (REWRITE { t1; t2;_}, REWRITE { t1 = s1; t2 = s2;_}) ->
+          (eq_tm t1 s1) && (eq_tm t2 s2)
       | uu___ -> false
 let rec (eq_st_term : st_term -> st_term -> Prims.bool) =
   fun t1 ->
@@ -614,8 +631,8 @@ let rec (eq_st_term : st_term -> st_term -> Prims.bool) =
          Tm_WithLocal { binder2 = x2; initializer1 = e2; body4 = b2;_}) ->
           ((eq_tm x1.binder_ty x2.binder_ty) && (eq_tm e1 e2)) &&
             (eq_st_term b1 b2)
-      | (Tm_Rewrite { t1 = l1; t2 = r1;_}, Tm_Rewrite { t1 = l2; t2 = r2;_})
-          -> (eq_tm l1 l2) && (eq_tm r1 r2)
+      | (Tm_Rewrite { t11 = l1; t21 = r1;_}, Tm_Rewrite
+         { t11 = l2; t21 = r2;_}) -> (eq_tm l1 l2) && (eq_tm r1 r2)
       | (Tm_Admit { ctag1 = c1; u1; typ = t11; post3 = post1;_}, Tm_Admit
          { ctag1 = c2; u1 = u2; typ = t21; post3 = post2;_}) ->
           (((c1 = c2) && (eq_univ u1 u2)) && (eq_tm t11 t21)) &&

--- a/src/ocaml/plugin/generated/Pulse_Syntax_Builder.ml
+++ b/src/ocaml/plugin/generated/Pulse_Syntax_Builder.ml
@@ -185,7 +185,7 @@ let (tm_rewrite :
   fun t1 ->
     fun t2 ->
       Pulse_Syntax_Base.Tm_Rewrite
-        { Pulse_Syntax_Base.t1 = t1; Pulse_Syntax_Base.t2 = t2 }
+        { Pulse_Syntax_Base.t11 = t1; Pulse_Syntax_Base.t21 = t2 }
 let (tm_rename :
   (Pulse_Syntax_Base.term * Pulse_Syntax_Base.term) Prims.list ->
     Pulse_Syntax_Base.st_term -> Pulse_Syntax_Base.st_term')
@@ -270,3 +270,11 @@ let (mk_rename_hint_type :
     fun goal ->
       Pulse_Syntax_Base.RENAME
         { Pulse_Syntax_Base.pairs = pairs; Pulse_Syntax_Base.goal = goal }
+let (mk_rewrite_hint_type :
+  Pulse_Syntax_Base.vprop ->
+    Pulse_Syntax_Base.vprop -> Pulse_Syntax_Base.proof_hint_type)
+  =
+  fun t1 ->
+    fun t2 ->
+      Pulse_Syntax_Base.REWRITE
+        { Pulse_Syntax_Base.t1 = t1; Pulse_Syntax_Base.t2 = t2 }

--- a/src/ocaml/plugin/generated/Pulse_Syntax_Builder.ml
+++ b/src/ocaml/plugin/generated/Pulse_Syntax_Builder.ml
@@ -115,7 +115,7 @@ let (tm_match :
             Pulse_Syntax_Base.brs = brs
           }
 let (tm_elim_exists : Pulse_Syntax_Base.vprop -> Pulse_Syntax_Base.st_term')
-  = fun p -> Pulse_Syntax_Base.Tm_ElimExists { Pulse_Syntax_Base.p1 = p }
+  = fun p -> Pulse_Syntax_Base.Tm_ElimExists { Pulse_Syntax_Base.p4 = p }
 let (tm_intro_exists :
   Pulse_Syntax_Base.vprop ->
     Pulse_Syntax_Base.term Prims.list -> Pulse_Syntax_Base.st_term')
@@ -123,7 +123,7 @@ let (tm_intro_exists :
   fun p ->
     fun witnesses ->
       Pulse_Syntax_Base.Tm_IntroExists
-        { Pulse_Syntax_Base.p2 = p; Pulse_Syntax_Base.witnesses = witnesses }
+        { Pulse_Syntax_Base.p5 = p; Pulse_Syntax_Base.witnesses = witnesses }
 let (tm_while :
   Pulse_Syntax_Base.term ->
     Pulse_Syntax_Base.st_term ->
@@ -186,6 +186,23 @@ let (tm_rewrite :
     fun t2 ->
       Pulse_Syntax_Base.Tm_Rewrite
         { Pulse_Syntax_Base.t1 = t1; Pulse_Syntax_Base.t2 = t2 }
+let (tm_rename :
+  (Pulse_Syntax_Base.term * Pulse_Syntax_Base.term) Prims.list ->
+    Pulse_Syntax_Base.st_term -> Pulse_Syntax_Base.st_term')
+  =
+  fun pairs ->
+    fun t ->
+      Pulse_Syntax_Base.Tm_ProofHintWithBinders
+        {
+          Pulse_Syntax_Base.hint_type =
+            (Pulse_Syntax_Base.RENAME
+               {
+                 Pulse_Syntax_Base.pairs = pairs;
+                 Pulse_Syntax_Base.goal = FStar_Pervasives_Native.None
+               });
+          Pulse_Syntax_Base.binders = [];
+          Pulse_Syntax_Base.t3 = t
+        }
 let (tm_admit :
   Pulse_Syntax_Base.ctag ->
     Pulse_Syntax_Base.universe ->
@@ -216,12 +233,40 @@ let (tm_assert_with_binders :
       Pulse_Syntax_Base.st_term -> Pulse_Syntax_Base.st_term')
   =
   fun bs ->
-    fun v ->
+    fun p ->
       fun t ->
         Pulse_Syntax_Base.Tm_ProofHintWithBinders
           {
-            Pulse_Syntax_Base.hint_type = Pulse_Syntax_Base.ASSERT;
+            Pulse_Syntax_Base.hint_type =
+              (Pulse_Syntax_Base.ASSERT { Pulse_Syntax_Base.p = p });
             Pulse_Syntax_Base.binders = bs;
-            Pulse_Syntax_Base.v = v;
             Pulse_Syntax_Base.t3 = t
           }
+let (mk_assert_hint_type :
+  Pulse_Syntax_Base.vprop -> Pulse_Syntax_Base.proof_hint_type) =
+  fun p -> Pulse_Syntax_Base.ASSERT { Pulse_Syntax_Base.p = p }
+let (mk_unfold_hint_type :
+  Prims.string Prims.list FStar_Pervasives_Native.option ->
+    Pulse_Syntax_Base.vprop -> Pulse_Syntax_Base.proof_hint_type)
+  =
+  fun names ->
+    fun p ->
+      Pulse_Syntax_Base.UNFOLD
+        { Pulse_Syntax_Base.names1 = names; Pulse_Syntax_Base.p2 = p }
+let (mk_fold_hint_type :
+  Prims.string Prims.list FStar_Pervasives_Native.option ->
+    Pulse_Syntax_Base.vprop -> Pulse_Syntax_Base.proof_hint_type)
+  =
+  fun names ->
+    fun p ->
+      Pulse_Syntax_Base.FOLD
+        { Pulse_Syntax_Base.names = names; Pulse_Syntax_Base.p1 = p }
+let (mk_rename_hint_type :
+  (Pulse_Syntax_Base.term * Pulse_Syntax_Base.term) Prims.list ->
+    Pulse_Syntax_Base.term FStar_Pervasives_Native.option ->
+      Pulse_Syntax_Base.proof_hint_type)
+  =
+  fun pairs ->
+    fun goal ->
+      Pulse_Syntax_Base.RENAME
+        { Pulse_Syntax_Base.pairs = pairs; Pulse_Syntax_Base.goal = goal }

--- a/src/ocaml/plugin/generated/Pulse_Syntax_Naming.ml
+++ b/src/ocaml/plugin/generated/Pulse_Syntax_Naming.ml
@@ -80,6 +80,9 @@ let (freevars_proof_hint :
     | Pulse_Syntax_Base.RENAME
         { Pulse_Syntax_Base.pairs = pairs; Pulse_Syntax_Base.goal = goal;_}
         -> FStar_Set.union (freevars_pairs pairs) (freevars_term_opt goal)
+    | Pulse_Syntax_Base.REWRITE
+        { Pulse_Syntax_Base.t1 = t1; Pulse_Syntax_Base.t2 = t2;_} ->
+        FStar_Set.union (freevars t1) (freevars t2)
 let rec (freevars_st :
   Pulse_Syntax_Base.st_term -> Pulse_Syntax_Base.var FStar_Set.set) =
   fun t ->
@@ -162,7 +165,7 @@ let rec (freevars_st :
         FStar_Set.union (freevars binder.Pulse_Syntax_Base.binder_ty)
           (FStar_Set.union (freevars initializer1) (freevars_st body))
     | Pulse_Syntax_Base.Tm_Rewrite
-        { Pulse_Syntax_Base.t1 = t1; Pulse_Syntax_Base.t2 = t2;_} ->
+        { Pulse_Syntax_Base.t11 = t1; Pulse_Syntax_Base.t21 = t2;_} ->
         FStar_Set.union (freevars t1) (freevars t2)
     | Pulse_Syntax_Base.Tm_Admit
         { Pulse_Syntax_Base.ctag1 = uu___; Pulse_Syntax_Base.u1 = uu___1;
@@ -252,6 +255,9 @@ let (ln_proof_hint' :
       | Pulse_Syntax_Base.RENAME
           { Pulse_Syntax_Base.pairs = pairs; Pulse_Syntax_Base.goal = goal;_}
           -> (ln_terms' pairs i) && (ln_opt' goal i)
+      | Pulse_Syntax_Base.REWRITE
+          { Pulse_Syntax_Base.t1 = t1; Pulse_Syntax_Base.t2 = t2;_} ->
+          (ln' t1 i) && (ln' t2 i)
 let rec (ln_st' : Pulse_Syntax_Base.st_term -> Prims.int -> Prims.bool) =
   fun t ->
     fun i ->
@@ -332,7 +338,7 @@ let rec (ln_st' : Pulse_Syntax_Base.st_term -> Prims.int -> Prims.bool) =
           ((ln' binder.Pulse_Syntax_Base.binder_ty i) && (ln' initializer1 i))
             && (ln_st' body (i + Prims.int_one))
       | Pulse_Syntax_Base.Tm_Rewrite
-          { Pulse_Syntax_Base.t1 = t1; Pulse_Syntax_Base.t2 = t2;_} ->
+          { Pulse_Syntax_Base.t11 = t1; Pulse_Syntax_Base.t21 = t2;_} ->
           (ln' t1 i) && (ln' t2 i)
       | Pulse_Syntax_Base.Tm_Admit
           { Pulse_Syntax_Base.ctag1 = uu___; Pulse_Syntax_Base.u1 = uu___1;
@@ -600,6 +606,13 @@ let (subst_proof_hint :
               Pulse_Syntax_Base.pairs = (subst_term_pairs pairs ss);
               Pulse_Syntax_Base.goal = (subst_term_opt goal ss)
             }
+      | Pulse_Syntax_Base.REWRITE
+          { Pulse_Syntax_Base.t1 = t1; Pulse_Syntax_Base.t2 = t2;_} ->
+          Pulse_Syntax_Base.REWRITE
+            {
+              Pulse_Syntax_Base.t1 = (subst_term t1 ss);
+              Pulse_Syntax_Base.t2 = (subst_term t2 ss)
+            }
 let (open_term_pairs' :
   (Pulse_Syntax_Base.term * Pulse_Syntax_Base.term) Prims.list ->
     Pulse_Syntax_Base.term ->
@@ -772,11 +785,11 @@ let rec (subst_st_term :
                   (subst_st_term body (shift_subst ss))
               }
         | Pulse_Syntax_Base.Tm_Rewrite
-            { Pulse_Syntax_Base.t1 = t1; Pulse_Syntax_Base.t2 = t2;_} ->
+            { Pulse_Syntax_Base.t11 = t1; Pulse_Syntax_Base.t21 = t2;_} ->
             Pulse_Syntax_Base.Tm_Rewrite
               {
-                Pulse_Syntax_Base.t1 = (subst_term t1 ss);
-                Pulse_Syntax_Base.t2 = (subst_term t2 ss)
+                Pulse_Syntax_Base.t11 = (subst_term t1 ss);
+                Pulse_Syntax_Base.t21 = (subst_term t2 ss)
               }
         | Pulse_Syntax_Base.Tm_Admit
             { Pulse_Syntax_Base.ctag1 = ctag; Pulse_Syntax_Base.u1 = u;

--- a/src/ocaml/plugin/generated/Pulse_Syntax_Naming.ml
+++ b/src/ocaml/plugin/generated/Pulse_Syntax_Naming.ml
@@ -56,6 +56,30 @@ let rec (freevars_list :
     match t with
     | [] -> FStar_Set.empty ()
     | hd::tl -> FStar_Set.union (freevars hd) (freevars_list tl)
+let rec (freevars_pairs :
+  (Pulse_Syntax_Base.term * Pulse_Syntax_Base.term) Prims.list ->
+    Pulse_Syntax_Base.var FStar_Set.set)
+  =
+  fun pairs ->
+    match pairs with
+    | [] -> FStar_Set.empty ()
+    | (t1, t2)::tl ->
+        FStar_Set.union (FStar_Set.union (freevars t1) (freevars t2))
+          (freevars_pairs tl)
+let (freevars_proof_hint :
+  Pulse_Syntax_Base.proof_hint_type -> Pulse_Syntax_Base.var FStar_Set.set) =
+  fun ht ->
+    match ht with
+    | Pulse_Syntax_Base.ASSERT { Pulse_Syntax_Base.p = p;_} -> freevars p
+    | Pulse_Syntax_Base.FOLD
+        { Pulse_Syntax_Base.names = uu___; Pulse_Syntax_Base.p1 = p;_} ->
+        freevars p
+    | Pulse_Syntax_Base.UNFOLD
+        { Pulse_Syntax_Base.names1 = uu___; Pulse_Syntax_Base.p2 = p;_} ->
+        freevars p
+    | Pulse_Syntax_Base.RENAME
+        { Pulse_Syntax_Base.pairs = pairs; Pulse_Syntax_Base.goal = goal;_}
+        -> FStar_Set.union (freevars_pairs pairs) (freevars_term_opt goal)
 let rec (freevars_st :
   Pulse_Syntax_Base.st_term -> Pulse_Syntax_Base.var FStar_Set.set) =
   fun t ->
@@ -103,12 +127,12 @@ let rec (freevars_st :
         let op_At_At = FStar_Set.union in
         op_At_At (freevars sc)
           (op_At_At (freevars_term_opt returns_) (freevars_branches brs))
-    | Pulse_Syntax_Base.Tm_IntroPure { Pulse_Syntax_Base.p = p;_} ->
+    | Pulse_Syntax_Base.Tm_IntroPure { Pulse_Syntax_Base.p3 = p;_} ->
         freevars p
-    | Pulse_Syntax_Base.Tm_ElimExists { Pulse_Syntax_Base.p1 = p;_} ->
+    | Pulse_Syntax_Base.Tm_ElimExists { Pulse_Syntax_Base.p4 = p;_} ->
         freevars p
     | Pulse_Syntax_Base.Tm_IntroExists
-        { Pulse_Syntax_Base.p2 = p;
+        { Pulse_Syntax_Base.p5 = p;
           Pulse_Syntax_Base.witnesses = witnesses;_}
         -> FStar_Set.union (freevars p) (freevars_list witnesses)
     | Pulse_Syntax_Base.Tm_While
@@ -145,10 +169,9 @@ let rec (freevars_st :
           Pulse_Syntax_Base.typ = typ; Pulse_Syntax_Base.post3 = post;_}
         -> FStar_Set.union (freevars typ) (freevars_term_opt post)
     | Pulse_Syntax_Base.Tm_ProofHintWithBinders
-        { Pulse_Syntax_Base.hint_type = uu___;
-          Pulse_Syntax_Base.binders = binders; Pulse_Syntax_Base.v = v;
-          Pulse_Syntax_Base.t3 = t1;_}
-        -> FStar_Set.union (freevars v) (freevars_st t1)
+        { Pulse_Syntax_Base.hint_type = hint_type;
+          Pulse_Syntax_Base.binders = binders; Pulse_Syntax_Base.t3 = t1;_}
+        -> FStar_Set.union (freevars_proof_hint hint_type) (freevars_st t1)
 and (freevars_branches :
   (Pulse_Syntax_Base.pattern * Pulse_Syntax_Base.st_term) Prims.list ->
     Pulse_Syntax_Base.var FStar_Set.set)
@@ -205,6 +228,30 @@ let rec (ln_list' :
   fun t ->
     fun i ->
       match t with | [] -> true | hd::tl -> (ln' hd i) && (ln_list' tl i)
+let rec (ln_terms' :
+  (Pulse_Syntax_Base.term * Pulse_Syntax_Base.term) Prims.list ->
+    Prims.int -> Prims.bool)
+  =
+  fun t ->
+    fun i ->
+      match t with
+      | [] -> true
+      | (t1, t2)::tl -> ((ln' t1 i) && (ln' t2 i)) && (ln_terms' tl i)
+let (ln_proof_hint' :
+  Pulse_Syntax_Base.proof_hint_type -> Prims.int -> Prims.bool) =
+  fun ht ->
+    fun i ->
+      match ht with
+      | Pulse_Syntax_Base.ASSERT { Pulse_Syntax_Base.p = p;_} -> ln' p i
+      | Pulse_Syntax_Base.UNFOLD
+          { Pulse_Syntax_Base.names1 = uu___; Pulse_Syntax_Base.p2 = p;_} ->
+          ln' p i
+      | Pulse_Syntax_Base.FOLD
+          { Pulse_Syntax_Base.names = uu___; Pulse_Syntax_Base.p1 = p;_} ->
+          ln' p i
+      | Pulse_Syntax_Base.RENAME
+          { Pulse_Syntax_Base.pairs = pairs; Pulse_Syntax_Base.goal = goal;_}
+          -> (ln_terms' pairs i) && (ln_opt' goal i)
 let rec (ln_st' : Pulse_Syntax_Base.st_term -> Prims.int -> Prims.bool) =
   fun t ->
     fun i ->
@@ -250,12 +297,12 @@ let rec (ln_st' : Pulse_Syntax_Base.st_term -> Prims.int -> Prims.bool) =
           { Pulse_Syntax_Base.sc = sc; Pulse_Syntax_Base.returns_ = returns_;
             Pulse_Syntax_Base.brs = brs;_}
           -> ((ln' sc i) && (ln_opt' returns_ i)) && (ln_branches' t brs i)
-      | Pulse_Syntax_Base.Tm_IntroPure { Pulse_Syntax_Base.p = p;_} ->
+      | Pulse_Syntax_Base.Tm_IntroPure { Pulse_Syntax_Base.p3 = p;_} ->
           ln' p i
-      | Pulse_Syntax_Base.Tm_ElimExists { Pulse_Syntax_Base.p1 = p;_} ->
+      | Pulse_Syntax_Base.Tm_ElimExists { Pulse_Syntax_Base.p4 = p;_} ->
           ln' p i
       | Pulse_Syntax_Base.Tm_IntroExists
-          { Pulse_Syntax_Base.p2 = p;
+          { Pulse_Syntax_Base.p5 = p;
             Pulse_Syntax_Base.witnesses = witnesses;_}
           -> (ln' p i) && (ln_list' witnesses i)
       | Pulse_Syntax_Base.Tm_While
@@ -292,12 +339,11 @@ let rec (ln_st' : Pulse_Syntax_Base.st_term -> Prims.int -> Prims.bool) =
             Pulse_Syntax_Base.typ = typ; Pulse_Syntax_Base.post3 = post;_}
           -> (ln' typ i) && (ln_opt' post (i + Prims.int_one))
       | Pulse_Syntax_Base.Tm_ProofHintWithBinders
-          { Pulse_Syntax_Base.hint_type = uu___;
-            Pulse_Syntax_Base.binders = binders; Pulse_Syntax_Base.v = v;
-            Pulse_Syntax_Base.t3 = t1;_}
+          { Pulse_Syntax_Base.hint_type = hint_type;
+            Pulse_Syntax_Base.binders = binders; Pulse_Syntax_Base.t3 = t1;_}
           ->
           let n = FStar_List_Tot_Base.length binders in
-          (ln' v (i + n)) && (ln_st' t1 (i + n))
+          (ln_proof_hint' hint_type (i + n)) && (ln_st' t1 (i + n))
 and (ln_branch' :
   (Pulse_Syntax_Base.pattern * Pulse_Syntax_Base.st_term) ->
     Prims.int -> Prims.bool)
@@ -512,6 +558,70 @@ let (open_binder :
           Pulse_Syntax_Base.binder_ppname =
             (b.Pulse_Syntax_Base.binder_ppname)
         }
+let rec (subst_term_pairs :
+  (Pulse_Syntax_Base.term * Pulse_Syntax_Base.term) Prims.list ->
+    subst -> (Pulse_Syntax_Base.term * Pulse_Syntax_Base.term) Prims.list)
+  =
+  fun t ->
+    fun ss ->
+      match t with
+      | [] -> []
+      | (t1, t2)::tl -> ((subst_term t1 ss), (subst_term t2 ss)) ::
+          (subst_term_pairs tl ss)
+let (subst_proof_hint :
+  Pulse_Syntax_Base.proof_hint_type ->
+    subst -> Pulse_Syntax_Base.proof_hint_type)
+  =
+  fun ht ->
+    fun ss ->
+      match ht with
+      | Pulse_Syntax_Base.ASSERT { Pulse_Syntax_Base.p = p;_} ->
+          Pulse_Syntax_Base.ASSERT
+            { Pulse_Syntax_Base.p = (subst_term p ss) }
+      | Pulse_Syntax_Base.UNFOLD
+          { Pulse_Syntax_Base.names1 = names; Pulse_Syntax_Base.p2 = p;_} ->
+          Pulse_Syntax_Base.UNFOLD
+            {
+              Pulse_Syntax_Base.names1 = names;
+              Pulse_Syntax_Base.p2 = (subst_term p ss)
+            }
+      | Pulse_Syntax_Base.FOLD
+          { Pulse_Syntax_Base.names = names; Pulse_Syntax_Base.p1 = p;_} ->
+          Pulse_Syntax_Base.FOLD
+            {
+              Pulse_Syntax_Base.names = names;
+              Pulse_Syntax_Base.p1 = (subst_term p ss)
+            }
+      | Pulse_Syntax_Base.RENAME
+          { Pulse_Syntax_Base.pairs = pairs; Pulse_Syntax_Base.goal = goal;_}
+          ->
+          Pulse_Syntax_Base.RENAME
+            {
+              Pulse_Syntax_Base.pairs = (subst_term_pairs pairs ss);
+              Pulse_Syntax_Base.goal = (subst_term_opt goal ss)
+            }
+let (open_term_pairs' :
+  (Pulse_Syntax_Base.term * Pulse_Syntax_Base.term) Prims.list ->
+    Pulse_Syntax_Base.term ->
+      Pulse_Syntax_Base.index ->
+        (Pulse_Syntax_Base.term * Pulse_Syntax_Base.term) Prims.list)
+  = fun t -> fun v -> fun i -> subst_term_pairs t [DT (i, v)]
+let (close_term_pairs' :
+  (Pulse_Syntax_Base.term * Pulse_Syntax_Base.term) Prims.list ->
+    Pulse_Syntax_Base.var ->
+      Pulse_Syntax_Base.index ->
+        (Pulse_Syntax_Base.term * Pulse_Syntax_Base.term) Prims.list)
+  = fun t -> fun x -> fun i -> subst_term_pairs t [ND (x, i)]
+let (open_proof_hint' :
+  Pulse_Syntax_Base.proof_hint_type ->
+    Pulse_Syntax_Base.term ->
+      Pulse_Syntax_Base.index -> Pulse_Syntax_Base.proof_hint_type)
+  = fun ht -> fun v -> fun i -> subst_proof_hint ht [DT (i, v)]
+let (close_proof_hint' :
+  Pulse_Syntax_Base.proof_hint_type ->
+    Pulse_Syntax_Base.var ->
+      Pulse_Syntax_Base.index -> Pulse_Syntax_Base.proof_hint_type)
+  = fun ht -> fun x -> fun i -> subst_proof_hint ht [ND (x, i)]
 let rec (subst_st_term :
   Pulse_Syntax_Base.st_term -> subst -> Pulse_Syntax_Base.st_term) =
   fun t ->
@@ -602,19 +712,19 @@ let rec (subst_st_term :
                 Pulse_Syntax_Base.returns_ = (subst_term_opt returns_ ss);
                 Pulse_Syntax_Base.brs = (subst_branches t ss brs)
               }
-        | Pulse_Syntax_Base.Tm_IntroPure { Pulse_Syntax_Base.p = p;_} ->
+        | Pulse_Syntax_Base.Tm_IntroPure { Pulse_Syntax_Base.p3 = p;_} ->
             Pulse_Syntax_Base.Tm_IntroPure
-              { Pulse_Syntax_Base.p = (subst_term p ss) }
-        | Pulse_Syntax_Base.Tm_ElimExists { Pulse_Syntax_Base.p1 = p;_} ->
+              { Pulse_Syntax_Base.p3 = (subst_term p ss) }
+        | Pulse_Syntax_Base.Tm_ElimExists { Pulse_Syntax_Base.p4 = p;_} ->
             Pulse_Syntax_Base.Tm_ElimExists
-              { Pulse_Syntax_Base.p1 = (subst_term p ss) }
+              { Pulse_Syntax_Base.p4 = (subst_term p ss) }
         | Pulse_Syntax_Base.Tm_IntroExists
-            { Pulse_Syntax_Base.p2 = p;
+            { Pulse_Syntax_Base.p5 = p;
               Pulse_Syntax_Base.witnesses = witnesses;_}
             ->
             Pulse_Syntax_Base.Tm_IntroExists
               {
-                Pulse_Syntax_Base.p2 = (subst_term p ss);
+                Pulse_Syntax_Base.p5 = (subst_term p ss);
                 Pulse_Syntax_Base.witnesses = (subst_term_list witnesses ss)
               }
         | Pulse_Syntax_Base.Tm_While
@@ -682,16 +792,16 @@ let rec (subst_st_term :
               }
         | Pulse_Syntax_Base.Tm_ProofHintWithBinders
             { Pulse_Syntax_Base.hint_type = hint_type;
-              Pulse_Syntax_Base.binders = binders; Pulse_Syntax_Base.v = v;
+              Pulse_Syntax_Base.binders = binders;
               Pulse_Syntax_Base.t3 = t1;_}
             ->
             let n = FStar_List_Tot_Base.length binders in
             let ss1 = shift_subst_n n ss in
             Pulse_Syntax_Base.Tm_ProofHintWithBinders
               {
-                Pulse_Syntax_Base.hint_type = hint_type;
+                Pulse_Syntax_Base.hint_type =
+                  (subst_proof_hint hint_type ss1);
                 Pulse_Syntax_Base.binders = binders;
-                Pulse_Syntax_Base.v = (subst_term v ss1);
                 Pulse_Syntax_Base.t3 = (subst_st_term t1 ss1)
               } in
       {

--- a/src/ocaml/plugin/generated/Pulse_Syntax_Printer.ml
+++ b/src/ocaml/plugin/generated/Pulse_Syntax_Printer.ml
@@ -2587,7 +2587,7 @@ let rec (st_term_to_string' :
                           FStar_Tactics_Effect.lift_div_tac
                             (fun uu___2 -> uu___1 uu___)))) uu___)
       | Pulse_Syntax_Base.Tm_Rewrite
-          { Pulse_Syntax_Base.t1 = t1; Pulse_Syntax_Base.t2 = t2;_} ->
+          { Pulse_Syntax_Base.t11 = t1; Pulse_Syntax_Base.t21 = t2;_} ->
           FStar_Tactics_Effect.tac_bind
             (FStar_Sealed.seal
                (Obj.magic
@@ -2892,7 +2892,7 @@ let rec (st_term_to_string' :
                (Obj.magic
                   (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
                      (Prims.of_int (262)) (Prims.of_int (8))
-                     (Prims.of_int (283)) (Prims.of_int (36)))))
+                     (Prims.of_int (285)) (Prims.of_int (36)))))
             (match binders with
              | [] ->
                  Obj.magic
@@ -2956,7 +2956,7 @@ let rec (st_term_to_string' :
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
                                 (Prims.of_int (266)) (Prims.of_int (8))
-                                (Prims.of_int (283)) (Prims.of_int (36)))))
+                                (Prims.of_int (285)) (Prims.of_int (36)))))
                        (FStar_Tactics_Effect.lift_div_tac
                           (fun uu___ ->
                              fun uu___1 ->
@@ -2976,15 +2976,15 @@ let rec (st_term_to_string' :
                                            "Pulse.Syntax.Printer.fst"
                                            (Prims.of_int (268))
                                            (Prims.of_int (8))
-                                           (Prims.of_int (280))
-                                           (Prims.of_int (60)))))
+                                           (Prims.of_int (282))
+                                           (Prims.of_int (80)))))
                                   (FStar_Sealed.seal
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "Pulse.Syntax.Printer.fst"
                                            (Prims.of_int (266))
                                            (Prims.of_int (8))
-                                           (Prims.of_int (283))
+                                           (Prims.of_int (285))
                                            (Prims.of_int (36)))))
                                   (match hint_type with
                                    | Pulse_Syntax_Base.ASSERT
@@ -3233,7 +3233,7 @@ let rec (st_term_to_string' :
                                                      FStar_Tactics_Effect.lift_div_tac
                                                        (fun uu___1 ->
                                                           Prims.strcat
-                                                            "rename "
+                                                            "rewrite each "
                                                             (Prims.strcat
                                                                uu___ "")))))
                                             (fun uu___ ->
@@ -3308,7 +3308,114 @@ let rec (st_term_to_string' :
                                                             (fun uu___2 ->
                                                                (uu___,
                                                                  uu___1)))))
-                                                 uu___)))
+                                                 uu___))
+                                   | Pulse_Syntax_Base.REWRITE
+                                       { Pulse_Syntax_Base.t1 = t11;
+                                         Pulse_Syntax_Base.t2 = t2;_}
+                                       ->
+                                       Obj.magic
+                                         (FStar_Tactics_Effect.tac_bind
+                                            (FStar_Sealed.seal
+                                               (Obj.magic
+                                                  (FStar_Range.mk_range
+                                                     "Pulse.Syntax.Printer.fst"
+                                                     (Prims.of_int (282))
+                                                     (Prims.of_int (10))
+                                                     (Prims.of_int (282))
+                                                     (Prims.of_int (76)))))
+                                            (FStar_Sealed.seal
+                                               (Obj.magic
+                                                  (FStar_Range.mk_range
+                                                     "Pulse.Syntax.Printer.fst"
+                                                     (Prims.of_int (282))
+                                                     (Prims.of_int (10))
+                                                     (Prims.of_int (282))
+                                                     (Prims.of_int (80)))))
+                                            (Obj.magic
+                                               (FStar_Tactics_Effect.tac_bind
+                                                  (FStar_Sealed.seal
+                                                     (Obj.magic
+                                                        (FStar_Range.mk_range
+                                                           "Pulse.Syntax.Printer.fst"
+                                                           (Prims.of_int (282))
+                                                           (Prims.of_int (57))
+                                                           (Prims.of_int (282))
+                                                           (Prims.of_int (76)))))
+                                                  (FStar_Sealed.seal
+                                                     (Obj.magic
+                                                        (FStar_Range.mk_range
+                                                           "Pulse.Syntax.Printer.fst"
+                                                           (Prims.of_int (282))
+                                                           (Prims.of_int (10))
+                                                           (Prims.of_int (282))
+                                                           (Prims.of_int (76)))))
+                                                  (Obj.magic
+                                                     (term_to_string t2))
+                                                  (fun uu___ ->
+                                                     (fun uu___ ->
+                                                        Obj.magic
+                                                          (FStar_Tactics_Effect.tac_bind
+                                                             (FStar_Sealed.seal
+                                                                (Obj.magic
+                                                                   (FStar_Range.mk_range
+                                                                    "Pulse.Syntax.Printer.fst"
+                                                                    (Prims.of_int (282))
+                                                                    (Prims.of_int (10))
+                                                                    (Prims.of_int (282))
+                                                                    (Prims.of_int (76)))))
+                                                             (FStar_Sealed.seal
+                                                                (Obj.magic
+                                                                   (FStar_Range.mk_range
+                                                                    "Pulse.Syntax.Printer.fst"
+                                                                    (Prims.of_int (282))
+                                                                    (Prims.of_int (10))
+                                                                    (Prims.of_int (282))
+                                                                    (Prims.of_int (76)))))
+                                                             (Obj.magic
+                                                                (FStar_Tactics_Effect.tac_bind
+                                                                   (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Syntax.Printer.fst"
+                                                                    (Prims.of_int (282))
+                                                                    (Prims.of_int (37))
+                                                                    (Prims.of_int (282))
+                                                                    (Prims.of_int (56)))))
+                                                                   (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "FStar.Printf.fst"
+                                                                    (Prims.of_int (121))
+                                                                    (Prims.of_int (8))
+                                                                    (Prims.of_int (123))
+                                                                    (Prims.of_int (44)))))
+                                                                   (Obj.magic
+                                                                    (term_to_string
+                                                                    t11))
+                                                                   (fun
+                                                                    uu___1 ->
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___2 ->
+                                                                    fun x ->
+                                                                    Prims.strcat
+                                                                    (Prims.strcat
+                                                                    "rewrite "
+                                                                    (Prims.strcat
+                                                                    uu___1
+                                                                    " as "))
+                                                                    (Prims.strcat
+                                                                    x "")))))
+                                                             (fun uu___1 ->
+                                                                FStar_Tactics_Effect.lift_div_tac
+                                                                  (fun uu___2
+                                                                    ->
+                                                                    uu___1
+                                                                    uu___))))
+                                                       uu___)))
+                                            (fun uu___ ->
+                                               FStar_Tactics_Effect.lift_div_tac
+                                                 (fun uu___1 -> (uu___, "")))))
                                   (fun uu___ ->
                                      (fun uu___ ->
                                         match uu___ with
@@ -3319,9 +3426,9 @@ let rec (st_term_to_string' :
                                                     (Obj.magic
                                                        (FStar_Range.mk_range
                                                           "Pulse.Syntax.Printer.fst"
-                                                          (Prims.of_int (283))
+                                                          (Prims.of_int (285))
                                                           (Prims.of_int (8))
-                                                          (Prims.of_int (283))
+                                                          (Prims.of_int (285))
                                                           (Prims.of_int (36)))))
                                                  (FStar_Sealed.seal
                                                     (Obj.magic
@@ -3370,13 +3477,13 @@ and (branches_to_string :
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                            (Prims.of_int (288)) (Prims.of_int (13))
-                            (Prims.of_int (288)) (Prims.of_int (31)))))
+                            (Prims.of_int (290)) (Prims.of_int (13))
+                            (Prims.of_int (290)) (Prims.of_int (31)))))
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                            (Prims.of_int (288)) (Prims.of_int (13))
-                            (Prims.of_int (288)) (Prims.of_int (55)))))
+                            (Prims.of_int (290)) (Prims.of_int (13))
+                            (Prims.of_int (290)) (Prims.of_int (55)))))
                    (Obj.magic (branch_to_string b))
                    (fun uu___ ->
                       (fun uu___ ->
@@ -3386,9 +3493,9 @@ and (branches_to_string :
                                  (Obj.magic
                                     (FStar_Range.mk_range
                                        "Pulse.Syntax.Printer.fst"
-                                       (Prims.of_int (288))
+                                       (Prims.of_int (290))
                                        (Prims.of_int (34))
-                                       (Prims.of_int (288))
+                                       (Prims.of_int (290))
                                        (Prims.of_int (55)))))
                               (FStar_Sealed.seal
                                  (Obj.magic
@@ -3411,12 +3518,12 @@ and (branch_to_string :
       (FStar_Sealed.seal
          (Obj.magic
             (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-               (Prims.of_int (291)) (Prims.of_int (17)) (Prims.of_int (291))
+               (Prims.of_int (293)) (Prims.of_int (17)) (Prims.of_int (293))
                (Prims.of_int (19)))))
       (FStar_Sealed.seal
          (Obj.magic
             (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-               (Prims.of_int (290)) (Prims.of_int (35)) (Prims.of_int (292))
+               (Prims.of_int (292)) (Prims.of_int (35)) (Prims.of_int (294))
                (Prims.of_int (25)))))
       (FStar_Tactics_Effect.lift_div_tac (fun uu___ -> br))
       (fun uu___ ->
@@ -3482,8 +3589,8 @@ let (tag_of_comp :
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                            (Prims.of_int (333)) (Prims.of_int (31))
-                            (Prims.of_int (333)) (Prims.of_int (49)))))
+                            (Prims.of_int (335)) (Prims.of_int (31))
+                            (Prims.of_int (335)) (Prims.of_int (49)))))
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "prims.fst"
@@ -3501,8 +3608,8 @@ let (tag_of_comp :
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                            (Prims.of_int (335)) (Prims.of_int (30))
-                            (Prims.of_int (335)) (Prims.of_int (48)))))
+                            (Prims.of_int (337)) (Prims.of_int (30))
+                            (Prims.of_int (337)) (Prims.of_int (48)))))
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "prims.fst"

--- a/src/ocaml/plugin/generated/Pulse_Syntax_Printer.ml
+++ b/src/ocaml/plugin/generated/Pulse_Syntax_Printer.ml
@@ -1963,7 +1963,7 @@ let rec (st_term_to_string' :
                        (fun uu___2 ->
                           FStar_Tactics_Effect.lift_div_tac
                             (fun uu___3 -> uu___2 uu___1)))) uu___1)
-      | Pulse_Syntax_Base.Tm_IntroPure { Pulse_Syntax_Base.p = p;_} ->
+      | Pulse_Syntax_Base.Tm_IntroPure { Pulse_Syntax_Base.p3 = p;_} ->
           FStar_Tactics_Effect.tac_bind
             (FStar_Sealed.seal
                (Obj.magic
@@ -1983,7 +1983,7 @@ let rec (st_term_to_string' :
                       (Prims.strcat "introduce pure (\n"
                          (Prims.strcat (indent level) ""))
                       (Prims.strcat uu___ ")")))
-      | Pulse_Syntax_Base.Tm_ElimExists { Pulse_Syntax_Base.p1 = p;_} ->
+      | Pulse_Syntax_Base.Tm_ElimExists { Pulse_Syntax_Base.p4 = p;_} ->
           FStar_Tactics_Effect.tac_bind
             (FStar_Sealed.seal
                (Obj.magic
@@ -2000,7 +2000,7 @@ let rec (st_term_to_string' :
                  (fun uu___1 ->
                     Prims.strcat "elim_exists " (Prims.strcat uu___ "")))
       | Pulse_Syntax_Base.Tm_IntroExists
-          { Pulse_Syntax_Base.p2 = p;
+          { Pulse_Syntax_Base.p5 = p;
             Pulse_Syntax_Base.witnesses = witnesses;_}
           ->
           FStar_Tactics_Effect.tac_bind
@@ -2592,13 +2592,13 @@ let rec (st_term_to_string' :
             (FStar_Sealed.seal
                (Obj.magic
                   (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                     (Prims.of_int (236)) (Prims.of_int (15))
-                     (Prims.of_int (236)) (Prims.of_int (34)))))
+                     (Prims.of_int (236)) (Prims.of_int (8))
+                     (Prims.of_int (236)) (Prims.of_int (27)))))
             (FStar_Sealed.seal
                (Obj.magic
                   (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
                      (Prims.of_int (234)) (Prims.of_int (7))
-                     (Prims.of_int (236)) (Prims.of_int (34)))))
+                     (Prims.of_int (236)) (Prims.of_int (27)))))
             (Obj.magic (term_to_string t2))
             (fun uu___ ->
                (fun uu___ ->
@@ -2608,12 +2608,12 @@ let rec (st_term_to_string' :
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
                                 (Prims.of_int (234)) (Prims.of_int (7))
-                                (Prims.of_int (236)) (Prims.of_int (34)))))
+                                (Prims.of_int (236)) (Prims.of_int (27)))))
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
                                 (Prims.of_int (234)) (Prims.of_int (7))
-                                (Prims.of_int (236)) (Prims.of_int (34)))))
+                                (Prims.of_int (236)) (Prims.of_int (27)))))
                        (Obj.magic
                           (FStar_Tactics_Effect.tac_bind
                              (FStar_Sealed.seal
@@ -2879,83 +2879,480 @@ let rec (st_term_to_string' :
                           FStar_Tactics_Effect.lift_div_tac
                             (fun uu___2 -> uu___1 uu___)))) uu___)
       | Pulse_Syntax_Base.Tm_ProofHintWithBinders
-          { Pulse_Syntax_Base.hint_type = uu___;
-            Pulse_Syntax_Base.binders = binders; Pulse_Syntax_Base.v = v;
-            Pulse_Syntax_Base.t3 = t1;_}
+          { Pulse_Syntax_Base.hint_type = hint_type;
+            Pulse_Syntax_Base.binders = binders; Pulse_Syntax_Base.t3 = t1;_}
           ->
           FStar_Tactics_Effect.tac_bind
             (FStar_Sealed.seal
                (Obj.magic
                   (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                     (Prims.of_int (263)) (Prims.of_int (8))
-                     (Prims.of_int (263)) (Prims.of_int (36)))))
+                     (Prims.of_int (259)) (Prims.of_int (8))
+                     (Prims.of_int (261)) (Prims.of_int (86)))))
             (FStar_Sealed.seal
                (Obj.magic
                   (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                     (Prims.of_int (258)) (Prims.of_int (6))
-                     (Prims.of_int (263)) (Prims.of_int (36)))))
-            (Obj.magic (st_term_to_string' level t1))
-            (fun uu___1 ->
-               (fun uu___1 ->
+                     (Prims.of_int (262)) (Prims.of_int (8))
+                     (Prims.of_int (283)) (Prims.of_int (36)))))
+            (match binders with
+             | [] ->
+                 Obj.magic
+                   (Obj.repr
+                      (FStar_Tactics_Effect.lift_div_tac (fun uu___ -> "")))
+             | uu___ ->
+                 Obj.magic
+                   (Obj.repr
+                      (FStar_Tactics_Effect.tac_bind
+                         (FStar_Sealed.seal
+                            (Obj.magic
+                               (FStar_Range.mk_range
+                                  "Pulse.Syntax.Printer.fst"
+                                  (Prims.of_int (261)) (Prims.of_int (34))
+                                  (Prims.of_int (261)) (Prims.of_int (86)))))
+                         (FStar_Sealed.seal
+                            (Obj.magic
+                               (FStar_Range.mk_range "prims.fst"
+                                  (Prims.of_int (590)) (Prims.of_int (19))
+                                  (Prims.of_int (590)) (Prims.of_int (31)))))
+                         (Obj.magic
+                            (FStar_Tactics_Effect.tac_bind
+                               (FStar_Sealed.seal
+                                  (Obj.magic
+                                     (FStar_Range.mk_range
+                                        "Pulse.Syntax.Printer.fst"
+                                        (Prims.of_int (261))
+                                        (Prims.of_int (53))
+                                        (Prims.of_int (261))
+                                        (Prims.of_int (85)))))
+                               (FStar_Sealed.seal
+                                  (Obj.magic
+                                     (FStar_Range.mk_range
+                                        "Pulse.Syntax.Printer.fst"
+                                        (Prims.of_int (261))
+                                        (Prims.of_int (34))
+                                        (Prims.of_int (261))
+                                        (Prims.of_int (86)))))
+                               (Obj.magic
+                                  (FStar_Tactics_Util.map binder_to_string
+                                     binders))
+                               (fun uu___1 ->
+                                  FStar_Tactics_Effect.lift_div_tac
+                                    (fun uu___2 ->
+                                       FStar_String.concat " " uu___1))))
+                         (fun uu___1 ->
+                            FStar_Tactics_Effect.lift_div_tac
+                              (fun uu___2 ->
+                                 Prims.strcat "with "
+                                   (Prims.strcat uu___1 "."))))))
+            (fun uu___ ->
+               (fun with_prefix ->
                   Obj.magic
                     (FStar_Tactics_Effect.tac_bind
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (258)) (Prims.of_int (6))
-                                (Prims.of_int (263)) (Prims.of_int (36)))))
+                                (Prims.of_int (263)) (Prims.of_int (28))
+                                (Prims.of_int (265)) (Prims.of_int (58)))))
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (258)) (Prims.of_int (6))
-                                (Prims.of_int (263)) (Prims.of_int (36)))))
-                       (Obj.magic
-                          (FStar_Tactics_Effect.tac_bind
-                             (FStar_Sealed.seal
-                                (Obj.magic
-                                   (FStar_Range.mk_range
-                                      "Pulse.Syntax.Printer.fst"
-                                      (Prims.of_int (262)) (Prims.of_int (8))
-                                      (Prims.of_int (262))
-                                      (Prims.of_int (26)))))
-                             (FStar_Sealed.seal
-                                (Obj.magic
-                                   (FStar_Range.mk_range "FStar.Printf.fst"
-                                      (Prims.of_int (121)) (Prims.of_int (8))
-                                      (Prims.of_int (123))
-                                      (Prims.of_int (44)))))
-                             (Obj.magic (term_to_string v))
-                             (fun uu___2 ->
-                                FStar_Tactics_Effect.lift_div_tac
-                                  (fun uu___3 ->
-                                     fun x ->
-                                       Prims.strcat
-                                         (Prims.strcat
-                                            (Prims.strcat "assert "
-                                               (Prims.strcat
-                                                  (if
-                                                     (FStar_List_Tot_Base.length
-                                                        binders)
-                                                       = Prims.int_zero
-                                                   then ""
-                                                   else
-                                                     Prims.strcat ""
-                                                       (Prims.strcat
-                                                          (FStar_List_Tot_Base.fold_left
-                                                             (fun s ->
-                                                                fun _b ->
-                                                                  Prims.strcat
+                                (Prims.of_int (266)) (Prims.of_int (8))
+                                (Prims.of_int (283)) (Prims.of_int (36)))))
+                       (FStar_Tactics_Effect.lift_div_tac
+                          (fun uu___ ->
+                             fun uu___1 ->
+                               match uu___1 with
+                               | FStar_Pervasives_Native.None -> ""
+                               | FStar_Pervasives_Native.Some l ->
+                                   Prims.strcat " ["
+                                     (Prims.strcat
+                                        (FStar_String.concat "; " l) "]")))
+                       (fun uu___ ->
+                          (fun names_to_string ->
+                             Obj.magic
+                               (FStar_Tactics_Effect.tac_bind
+                                  (FStar_Sealed.seal
+                                     (Obj.magic
+                                        (FStar_Range.mk_range
+                                           "Pulse.Syntax.Printer.fst"
+                                           (Prims.of_int (268))
+                                           (Prims.of_int (8))
+                                           (Prims.of_int (280))
+                                           (Prims.of_int (60)))))
+                                  (FStar_Sealed.seal
+                                     (Obj.magic
+                                        (FStar_Range.mk_range
+                                           "Pulse.Syntax.Printer.fst"
+                                           (Prims.of_int (266))
+                                           (Prims.of_int (8))
+                                           (Prims.of_int (283))
+                                           (Prims.of_int (36)))))
+                                  (match hint_type with
+                                   | Pulse_Syntax_Base.ASSERT
+                                       { Pulse_Syntax_Base.p = p;_} ->
+                                       Obj.magic
+                                         (FStar_Tactics_Effect.tac_bind
+                                            (FStar_Sealed.seal
+                                               (Obj.magic
+                                                  (FStar_Range.mk_range
+                                                     "Pulse.Syntax.Printer.fst"
+                                                     (Prims.of_int (269))
+                                                     (Prims.of_int (36))
+                                                     (Prims.of_int (269))
+                                                     (Prims.of_int (52)))))
+                                            (FStar_Sealed.seal
+                                               (Obj.magic
+                                                  (FStar_Range.mk_range
+                                                     "Pulse.Syntax.Printer.fst"
+                                                     (Prims.of_int (269))
+                                                     (Prims.of_int (26))
+                                                     (Prims.of_int (269))
+                                                     (Prims.of_int (52)))))
+                                            (Obj.magic (term_to_string p))
+                                            (fun uu___ ->
+                                               FStar_Tactics_Effect.lift_div_tac
+                                                 (fun uu___1 ->
+                                                    ("assert", uu___))))
+                                   | Pulse_Syntax_Base.UNFOLD
+                                       { Pulse_Syntax_Base.names1 = names;
+                                         Pulse_Syntax_Base.p2 = p;_}
+                                       ->
+                                       Obj.magic
+                                         (FStar_Tactics_Effect.tac_bind
+                                            (FStar_Sealed.seal
+                                               (Obj.magic
+                                                  (FStar_Range.mk_range
+                                                     "Pulse.Syntax.Printer.fst"
+                                                     (Prims.of_int (270))
+                                                     (Prims.of_int (77))
+                                                     (Prims.of_int (270))
+                                                     (Prims.of_int (93)))))
+                                            (FStar_Sealed.seal
+                                               (Obj.magic
+                                                  (FStar_Range.mk_range
+                                                     "Pulse.Syntax.Printer.fst"
+                                                     (Prims.of_int (270))
+                                                     (Prims.of_int (33))
+                                                     (Prims.of_int (270))
+                                                     (Prims.of_int (93)))))
+                                            (Obj.magic (term_to_string p))
+                                            (fun uu___ ->
+                                               FStar_Tactics_Effect.lift_div_tac
+                                                 (fun uu___1 ->
+                                                    ((Prims.strcat "unfold"
+                                                        (Prims.strcat
+                                                           (names_to_string
+                                                              names) "")),
+                                                      uu___))))
+                                   | Pulse_Syntax_Base.FOLD
+                                       { Pulse_Syntax_Base.names = names;
+                                         Pulse_Syntax_Base.p1 = p;_}
+                                       ->
+                                       Obj.magic
+                                         (FStar_Tactics_Effect.tac_bind
+                                            (FStar_Sealed.seal
+                                               (Obj.magic
+                                                  (FStar_Range.mk_range
+                                                     "Pulse.Syntax.Printer.fst"
+                                                     (Prims.of_int (271))
+                                                     (Prims.of_int (73))
+                                                     (Prims.of_int (271))
+                                                     (Prims.of_int (89)))))
+                                            (FStar_Sealed.seal
+                                               (Obj.magic
+                                                  (FStar_Range.mk_range
+                                                     "Pulse.Syntax.Printer.fst"
+                                                     (Prims.of_int (271))
+                                                     (Prims.of_int (31))
+                                                     (Prims.of_int (271))
+                                                     (Prims.of_int (89)))))
+                                            (Obj.magic (term_to_string p))
+                                            (fun uu___ ->
+                                               FStar_Tactics_Effect.lift_div_tac
+                                                 (fun uu___1 ->
+                                                    ((Prims.strcat "fold"
+                                                        (Prims.strcat
+                                                           (names_to_string
+                                                              names) "")),
+                                                      uu___))))
+                                   | Pulse_Syntax_Base.RENAME
+                                       { Pulse_Syntax_Base.pairs = pairs;
+                                         Pulse_Syntax_Base.goal = goal;_}
+                                       ->
+                                       Obj.magic
+                                         (FStar_Tactics_Effect.tac_bind
+                                            (FStar_Sealed.seal
+                                               (Obj.magic
+                                                  (FStar_Range.mk_range
+                                                     "Pulse.Syntax.Printer.fst"
+                                                     (Prims.of_int (273))
+                                                     (Prims.of_int (10))
+                                                     (Prims.of_int (277))
+                                                     (Prims.of_int (21)))))
+                                            (FStar_Sealed.seal
+                                               (Obj.magic
+                                                  (FStar_Range.mk_range
+                                                     "Pulse.Syntax.Printer.fst"
+                                                     (Prims.of_int (273))
+                                                     (Prims.of_int (10))
+                                                     (Prims.of_int (280))
+                                                     (Prims.of_int (60)))))
+                                            (Obj.magic
+                                               (FStar_Tactics_Effect.tac_bind
+                                                  (FStar_Sealed.seal
+                                                     (Obj.magic
+                                                        (FStar_Range.mk_range
+                                                           "Pulse.Syntax.Printer.fst"
+                                                           (Prims.of_int (274))
+                                                           (Prims.of_int (12))
+                                                           (Prims.of_int (277))
+                                                           (Prims.of_int (21)))))
+                                                  (FStar_Sealed.seal
+                                                     (Obj.magic
+                                                        (FStar_Range.mk_range
+                                                           "prims.fst"
+                                                           (Prims.of_int (590))
+                                                           (Prims.of_int (19))
+                                                           (Prims.of_int (590))
+                                                           (Prims.of_int (31)))))
+                                                  (Obj.magic
+                                                     (FStar_Tactics_Effect.tac_bind
+                                                        (FStar_Sealed.seal
+                                                           (Obj.magic
+                                                              (FStar_Range.mk_range
+                                                                 "Pulse.Syntax.Printer.fst"
+                                                                 (Prims.of_int (275))
+                                                                 (Prims.of_int (14))
+                                                                 (Prims.of_int (277))
+                                                                 (Prims.of_int (20)))))
+                                                        (FStar_Sealed.seal
+                                                           (Obj.magic
+                                                              (FStar_Range.mk_range
+                                                                 "Pulse.Syntax.Printer.fst"
+                                                                 (Prims.of_int (274))
+                                                                 (Prims.of_int (12))
+                                                                 (Prims.of_int (277))
+                                                                 (Prims.of_int (21)))))
+                                                        (Obj.magic
+                                                           (FStar_Tactics_Util.map
+                                                              (fun uu___ ->
+                                                                 match uu___
+                                                                 with
+                                                                 | (x, y) ->
+                                                                    FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Syntax.Printer.fst"
+                                                                    (Prims.of_int (276))
+                                                                    (Prims.of_int (69))
+                                                                    (Prims.of_int (276))
+                                                                    (Prims.of_int (87)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Syntax.Printer.fst"
+                                                                    (Prims.of_int (276))
+                                                                    (Prims.of_int (31))
+                                                                    (Prims.of_int (276))
+                                                                    (Prims.of_int (87)))))
+                                                                    (Obj.magic
+                                                                    (term_to_string
+                                                                    y))
+                                                                    (fun
+                                                                    uu___1 ->
+                                                                    (fun
+                                                                    uu___1 ->
+                                                                    Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Syntax.Printer.fst"
+                                                                    (Prims.of_int (276))
+                                                                    (Prims.of_int (31))
+                                                                    (Prims.of_int (276))
+                                                                    (Prims.of_int (87)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Syntax.Printer.fst"
+                                                                    (Prims.of_int (276))
+                                                                    (Prims.of_int (31))
+                                                                    (Prims.of_int (276))
+                                                                    (Prims.of_int (87)))))
+                                                                    (Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Syntax.Printer.fst"
+                                                                    (Prims.of_int (276))
+                                                                    (Prims.of_int (50))
+                                                                    (Prims.of_int (276))
+                                                                    (Prims.of_int (68)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "FStar.Printf.fst"
+                                                                    (Prims.of_int (121))
+                                                                    (Prims.of_int (8))
+                                                                    (Prims.of_int (123))
+                                                                    (Prims.of_int (44)))))
+                                                                    (Obj.magic
+                                                                    (term_to_string
+                                                                    x))
+                                                                    (fun
+                                                                    uu___2 ->
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___3 ->
+                                                                    fun x1 ->
+                                                                    Prims.strcat
+                                                                    (Prims.strcat
+                                                                    ""
+                                                                    (Prims.strcat
+                                                                    uu___2
+                                                                    " as "))
+                                                                    (Prims.strcat
+                                                                    x1 "")))))
+                                                                    (fun
+                                                                    uu___2 ->
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___3 ->
+                                                                    uu___2
+                                                                    uu___1))))
+                                                                    uu___1))
+                                                              pairs))
+                                                        (fun uu___ ->
+                                                           FStar_Tactics_Effect.lift_div_tac
+                                                             (fun uu___1 ->
+                                                                FStar_String.concat
+                                                                  ", " uu___))))
+                                                  (fun uu___ ->
+                                                     FStar_Tactics_Effect.lift_div_tac
+                                                       (fun uu___1 ->
+                                                          Prims.strcat
+                                                            "rename "
+                                                            (Prims.strcat
+                                                               uu___ "")))))
+                                            (fun uu___ ->
+                                               (fun uu___ ->
+                                                  Obj.magic
+                                                    (FStar_Tactics_Effect.tac_bind
+                                                       (FStar_Sealed.seal
+                                                          (Obj.magic
+                                                             (FStar_Range.mk_range
+                                                                "Pulse.Syntax.Printer.fst"
+                                                                (Prims.of_int (278))
+                                                                (Prims.of_int (12))
+                                                                (Prims.of_int (280))
+                                                                (Prims.of_int (60)))))
+                                                       (FStar_Sealed.seal
+                                                          (Obj.magic
+                                                             (FStar_Range.mk_range
+                                                                "Pulse.Syntax.Printer.fst"
+                                                                (Prims.of_int (273))
+                                                                (Prims.of_int (10))
+                                                                (Prims.of_int (280))
+                                                                (Prims.of_int (60)))))
+                                                       (match goal with
+                                                        | FStar_Pervasives_Native.None
+                                                            ->
+                                                            Obj.magic
+                                                              (Obj.repr
+                                                                 (FStar_Tactics_Effect.lift_div_tac
+                                                                    (
+                                                                    fun
+                                                                    uu___1 ->
+                                                                    "")))
+                                                        | FStar_Pervasives_Native.Some
+                                                            t2 ->
+                                                            Obj.magic
+                                                              (Obj.repr
+                                                                 (FStar_Tactics_Effect.tac_bind
+                                                                    (
+                                                                    FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Syntax.Printer.fst"
+                                                                    (Prims.of_int (280))
+                                                                    (Prims.of_int (41))
+                                                                    (Prims.of_int (280))
+                                                                    (Prims.of_int (59)))))
+                                                                    (
+                                                                    FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "prims.fst"
+                                                                    (Prims.of_int (590))
+                                                                    (Prims.of_int (19))
+                                                                    (Prims.of_int (590))
+                                                                    (Prims.of_int (31)))))
+                                                                    (
+                                                                    Obj.magic
+                                                                    (term_to_string
+                                                                    t2))
+                                                                    (
+                                                                    fun
+                                                                    uu___1 ->
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___2 ->
+                                                                    Prims.strcat
+                                                                    " in "
+                                                                    (Prims.strcat
+                                                                    uu___1 ""))))))
+                                                       (fun uu___1 ->
+                                                          FStar_Tactics_Effect.lift_div_tac
+                                                            (fun uu___2 ->
+                                                               (uu___,
+                                                                 uu___1)))))
+                                                 uu___)))
+                                  (fun uu___ ->
+                                     (fun uu___ ->
+                                        match uu___ with
+                                        | (ht, p) ->
+                                            Obj.magic
+                                              (FStar_Tactics_Effect.tac_bind
+                                                 (FStar_Sealed.seal
+                                                    (Obj.magic
+                                                       (FStar_Range.mk_range
+                                                          "Pulse.Syntax.Printer.fst"
+                                                          (Prims.of_int (283))
+                                                          (Prims.of_int (8))
+                                                          (Prims.of_int (283))
+                                                          (Prims.of_int (36)))))
+                                                 (FStar_Sealed.seal
+                                                    (Obj.magic
+                                                       (FStar_Range.mk_range
+                                                          "prims.fst"
+                                                          (Prims.of_int (590))
+                                                          (Prims.of_int (19))
+                                                          (Prims.of_int (590))
+                                                          (Prims.of_int (31)))))
+                                                 (Obj.magic
+                                                    (st_term_to_string' level
+                                                       t1))
+                                                 (fun uu___1 ->
+                                                    FStar_Tactics_Effect.lift_div_tac
+                                                      (fun uu___2 ->
+                                                         Prims.strcat
+                                                           (Prims.strcat
+                                                              (Prims.strcat
+                                                                 (Prims.strcat
                                                                     ""
                                                                     (
                                                                     Prims.strcat
-                                                                    s " _"))
-                                                             "" binders) "."))
-                                                  ""))
-                                            (Prims.strcat uu___2 " in\n"))
-                                         (Prims.strcat x "")))))
-                       (fun uu___2 ->
-                          FStar_Tactics_Effect.lift_div_tac
-                            (fun uu___3 -> uu___2 uu___1)))) uu___1)
+                                                                    with_prefix
+                                                                    " "))
+                                                                 (Prims.strcat
+                                                                    ht " "))
+                                                              (Prims.strcat p
+                                                                 "; "))
+                                                           (Prims.strcat
+                                                              uu___1 "")))))
+                                       uu___))) uu___))) uu___)
 and (branches_to_string :
   (Pulse_Syntax_Base.pattern * Pulse_Syntax_Base.st_term) Prims.list ->
     (Prims.string, unit) FStar_Tactics_Effect.tac_repr)
@@ -2973,13 +3370,13 @@ and (branches_to_string :
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                            (Prims.of_int (268)) (Prims.of_int (13))
-                            (Prims.of_int (268)) (Prims.of_int (31)))))
+                            (Prims.of_int (288)) (Prims.of_int (13))
+                            (Prims.of_int (288)) (Prims.of_int (31)))))
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                            (Prims.of_int (268)) (Prims.of_int (13))
-                            (Prims.of_int (268)) (Prims.of_int (55)))))
+                            (Prims.of_int (288)) (Prims.of_int (13))
+                            (Prims.of_int (288)) (Prims.of_int (55)))))
                    (Obj.magic (branch_to_string b))
                    (fun uu___ ->
                       (fun uu___ ->
@@ -2989,9 +3386,9 @@ and (branches_to_string :
                                  (Obj.magic
                                     (FStar_Range.mk_range
                                        "Pulse.Syntax.Printer.fst"
-                                       (Prims.of_int (268))
+                                       (Prims.of_int (288))
                                        (Prims.of_int (34))
-                                       (Prims.of_int (268))
+                                       (Prims.of_int (288))
                                        (Prims.of_int (55)))))
                               (FStar_Sealed.seal
                                  (Obj.magic
@@ -3014,12 +3411,12 @@ and (branch_to_string :
       (FStar_Sealed.seal
          (Obj.magic
             (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-               (Prims.of_int (271)) (Prims.of_int (17)) (Prims.of_int (271))
+               (Prims.of_int (291)) (Prims.of_int (17)) (Prims.of_int (291))
                (Prims.of_int (19)))))
       (FStar_Sealed.seal
          (Obj.magic
             (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-               (Prims.of_int (270)) (Prims.of_int (35)) (Prims.of_int (272))
+               (Prims.of_int (290)) (Prims.of_int (35)) (Prims.of_int (292))
                (Prims.of_int (25)))))
       (FStar_Tactics_Effect.lift_div_tac (fun uu___ -> br))
       (fun uu___ ->
@@ -3085,8 +3482,8 @@ let (tag_of_comp :
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                            (Prims.of_int (313)) (Prims.of_int (31))
-                            (Prims.of_int (313)) (Prims.of_int (49)))))
+                            (Prims.of_int (333)) (Prims.of_int (31))
+                            (Prims.of_int (333)) (Prims.of_int (49)))))
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "prims.fst"
@@ -3104,8 +3501,8 @@ let (tag_of_comp :
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                            (Prims.of_int (315)) (Prims.of_int (30))
-                            (Prims.of_int (315)) (Prims.of_int (48)))))
+                            (Prims.of_int (335)) (Prims.of_int (30))
+                            (Prims.of_int (335)) (Prims.of_int (48)))))
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "prims.fst"

--- a/src/ocaml/plugin/generated/Pulse_Typing_LN.ml
+++ b/src/ocaml/plugin/generated/Pulse_Typing_LN.ml
@@ -8,3 +8,25 @@ let (__brs_of :
         { Pulse_Syntax_Base.sc = uu___1; Pulse_Syntax_Base.returns_ = uu___2;
           Pulse_Syntax_Base.brs = brs;_}
         -> brs
+let (open_term_pairs' :
+  (Pulse_Syntax_Base.term * Pulse_Syntax_Base.term) Prims.list ->
+    Pulse_Syntax_Base.term ->
+      Pulse_Syntax_Base.index ->
+        (Pulse_Syntax_Base.term * Pulse_Syntax_Base.term) Prims.list)
+  =
+  fun t ->
+    fun v ->
+      fun i ->
+        Pulse_Syntax_Naming.subst_term_pairs t
+          [Pulse_Syntax_Naming.DT (i, v)]
+let (close_term_pairs' :
+  (Pulse_Syntax_Base.term * Pulse_Syntax_Base.term) Prims.list ->
+    Pulse_Syntax_Base.var ->
+      Pulse_Syntax_Base.index ->
+        (Pulse_Syntax_Base.term * Pulse_Syntax_Base.term) Prims.list)
+  =
+  fun t ->
+    fun v ->
+      fun i ->
+        Pulse_Syntax_Naming.subst_term_pairs t
+          [Pulse_Syntax_Naming.ND (v, i)]

--- a/src/ocaml/plugin/pulseparser.mly
+++ b/src/ocaml/plugin/pulseparser.mly
@@ -138,14 +138,14 @@ pulseStmtNoSeq:
     { PulseSugar.mk_par p1 p2 q1 q2 b1 b2 }
   | REWRITE p1=pulseVprop AS p2=pulseVprop
     { PulseSugar.mk_rewrite p1 p2 }
-  | RENAME bs=separated_nonempty_list (COMMA, x=appTerm AS y=appTerm { (x, y)})
-    { PulseSugar.mk_rename bs }
+  | bs=withBindersOpt RENAME pairs=separated_nonempty_list (COMMA, x=appTerm AS y=appTerm { (x, y)}) goal=option(IN t=pulseVprop { t })
+    { PulseSugar.mk_proof_hint_with_binders (RENAME(pairs, goal)) bs }
   | bs=withBindersOpt ASSERT p=pulseVprop
-    { PulseSugar.mk_proof_hint_with_binders ASSERT bs p }
+    { PulseSugar.mk_proof_hint_with_binders (ASSERT p) bs }
   | bs=withBindersOpt UNFOLD ns=option(names) p=pulseVprop
-    { PulseSugar.mk_proof_hint_with_binders (UNFOLD ns) bs p }
+    { PulseSugar.mk_proof_hint_with_binders (UNFOLD (ns,p)) bs }
   | bs=withBindersOpt FOLD ns=option(names) p=pulseVprop
-    { PulseSugar.mk_proof_hint_with_binders (FOLD ns) bs p }
+    { PulseSugar.mk_proof_hint_with_binders (FOLD (ns,p)) bs }
 
 
 names:

--- a/src/ocaml/plugin/pulseparser.mly
+++ b/src/ocaml/plugin/pulseparser.mly
@@ -57,7 +57,7 @@ let r p = rng (fst p) (snd p)
 %}
 
 /* pulse specific tokens; rest are inherited from F* */
-%token MUT FN INVARIANT WHILE REF PARALLEL REWRITE FOLD GHOST ATOMIC
+%token MUT FN INVARIANT WHILE REF PARALLEL REWRITE FOLD GHOST ATOMIC RENAME
 
 %start pulseDecl
 %start peekFnId
@@ -138,6 +138,8 @@ pulseStmtNoSeq:
     { PulseSugar.mk_par p1 p2 q1 q2 b1 b2 }
   | REWRITE p1=pulseVprop AS p2=pulseVprop
     { PulseSugar.mk_rewrite p1 p2 }
+  | RENAME bs=separated_nonempty_list (COMMA, x=appTerm AS y=appTerm { (x, y)})
+    { PulseSugar.mk_rename bs }
   | bs=withBindersOpt ASSERT p=pulseVprop
     { PulseSugar.mk_proof_hint_with_binders ASSERT bs p }
   | bs=withBindersOpt UNFOLD ns=option(names) p=pulseVprop

--- a/src/syntax_extension/PulseDesugar.fst
+++ b/src/syntax_extension/PulseDesugar.fst
@@ -453,6 +453,17 @@ let rec desugar_stmt (env:env_t) (s:Sugar.stmt)
       let? p2 = desugar_vprop env p2 in
       return (SW.tm_rewrite p1 p2 s.range)
 
+    | Rename { pairs } ->
+      let? pairs =
+        map_err
+          (fun (x, y) -> 
+            let? x = desugar_term env x in
+            let? y = desugar_term env y in
+            return (x, y))
+          pairs
+      in
+      return (SW.tm_rename pairs s.range)
+      
     | LetBinding _ -> 
       fail "Terminal let binding" s.range
 
@@ -899,6 +910,7 @@ let rec transform_stmt_with_reads (m:menv) (p:Sugar.stmt)
     
     | Introduce _ 
     | Rewrite _
+    | Rename _
     | ProofHintWithBinders _ ->
       //This is a proof step; no implicit dereference
       return (p, [], m)

--- a/src/syntax_extension/PulseDesugar.fst
+++ b/src/syntax_extension/PulseDesugar.fst
@@ -325,17 +325,34 @@ let resolve_names (env:env_t) (ns:option (list lident))
     | None -> return None
     | Some ns -> let? ns = map_err (resolve_lid env) ns in return (Some ns)
 
-let resolve_hint_type (env:env_t) (ht:Sugar.hint_type)
-  : err Sugar.hint_type
+let desugar_hint_type (env:env_t) (ht:Sugar.hint_type)
+  : err SW.hint_type
   = let open Sugar in
     match ht with
-    | ASSERT -> return ASSERT
-    | UNFOLD ns -> 
+    | ASSERT vp ->
+      let? vp = desugar_vprop env vp in
+      return (SW.mk_assert_hint_type vp)
+    | UNFOLD (ns, vp) -> 
+      let? vp = desugar_vprop env vp in
       let? ns = resolve_names env ns in
-      return (UNFOLD ns)
-    | FOLD ns -> 
+      let ns = BU.map_opt ns (L.map FStar.Ident.string_of_lid) in
+      return (SW.mk_unfold_hint_type ns vp)
+    | FOLD (ns, vp) -> 
+      let? vp = desugar_vprop env vp in
       let? ns = resolve_names env ns in
-      return (FOLD ns)
+      let ns = BU.map_opt ns (L.map FStar.Ident.string_of_lid) in
+      return (SW.mk_fold_hint_type ns vp)
+    | RENAME (pairs, goal) ->
+      let? pairs =
+        map_err 
+          (fun (t1, t2) ->
+            let? t1 = desugar_term env t1 in
+            let? t2 = desugar_term env t2 in
+            return (t1, t2))
+          pairs
+      in
+      let? goal = map_err_opt (desugar_vprop env) goal in
+      return (SW.mk_rename_hint_type pairs goal)
 
 // FIXME
 // should just mimic let resolve_lid
@@ -382,10 +399,10 @@ let rec desugar_stmt (env:env_t) (s:Sugar.stmt)
       desugar_bind env lb s2 s.range
 
     | ProofHintWithBinders _ ->
-      desugar_assert_with_binders env s None s.range
+      desugar_proof_hint_with_binders env s None s.range
 
     | Sequence { s1; s2 } when ProofHintWithBinders? s1.s ->
-      desugar_assert_with_binders env s1 (Some s2) s.range
+      desugar_proof_hint_with_binders env s1 (Some s2) s.range
 
     | Sequence { s1; s2 } -> 
       desugar_sequence env s1 s2 s.range
@@ -452,17 +469,6 @@ let rec desugar_stmt (env:env_t) (s:Sugar.stmt)
       let? p1 = desugar_vprop env p1 in
       let? p2 = desugar_vprop env p2 in
       return (SW.tm_rewrite p1 p2 s.range)
-
-    | Rename { pairs } ->
-      let? pairs =
-        map_err
-          (fun (x, y) -> 
-            let? x = desugar_term env x in
-            let? y = desugar_term env y in
-            return (x, y))
-          pairs
-      in
-      return (SW.tm_rename pairs s.range)
       
     | LetBinding _ -> 
       fail "Terminal let binding" s.range
@@ -547,13 +553,13 @@ and desugar_sequence (env:env_t) (s1 s2:Sugar.stmt) r
     let annot = SW.mk_binder (Ident.id_of_text "_") (SW.tm_unknown r) in
     return (mk_bind annot s1 s2 r)
 
-and desugar_assert_with_binders (env:env_t) (s1:Sugar.stmt) (k:option Sugar.stmt) r
+and desugar_proof_hint_with_binders (env:env_t) (s1:Sugar.stmt) (k:option Sugar.stmt) r
   : err SW.st_term
   = match s1.s with
-    | Sugar.ProofHintWithBinders { hint_type; binders=bs; vprop=v } ->
+    | Sugar.ProofHintWithBinders { hint_type; binders=bs } -> //; vprop=v } ->
       let? env, binders, bvs = desugar_binders env bs in
       let vars = L.map (fun bv -> bv.S.index) bvs in
-      let? v = desugar_vprop env v in
+      let? ht = desugar_hint_type env hint_type in
       let? s2 = 
         match k with
         | None -> return (SW.tm_ghost_return (SW.tm_expr S.unit_const r) r)
@@ -561,9 +567,8 @@ and desugar_assert_with_binders (env:env_t) (s1:Sugar.stmt) (k:option Sugar.stmt
       let binders = L.map snd binders in
       let sub = SW.bvs_as_subst vars in
       let s2 = SW.subst_st_term sub s2 in
-      let v = SW.subst_term sub v in
-      let? ht = resolve_hint_type env hint_type in
-      return (SW.tm_proof_hint_with_binders ht (SW.close_binders binders vars) v s2 r)
+      let ht = SW.subst_proof_hint sub ht in
+      return (SW.tm_proof_hint_with_binders ht (SW.close_binders binders vars) s2 r)
     | _ -> fail "Expected ProofHintWithBinders" s1.range
 
 and desugar_binders (env:env_t) (bs:Sugar.binders)
@@ -910,7 +915,6 @@ let rec transform_stmt_with_reads (m:menv) (p:Sugar.stmt)
     
     | Introduce _ 
     | Rewrite _
-    | Rename _
     | ProofHintWithBinders _ ->
       //This is a proof step; no implicit dereference
       return (p, [], m)

--- a/src/syntax_extension/PulseDesugar.fst
+++ b/src/syntax_extension/PulseDesugar.fst
@@ -353,6 +353,10 @@ let desugar_hint_type (env:env_t) (ht:Sugar.hint_type)
       in
       let? goal = map_err_opt (desugar_vprop env) goal in
       return (SW.mk_rename_hint_type pairs goal)
+    | REWRITE (t1, t2) ->
+      let? t1 = desugar_vprop env t1 in
+      let? t2 = desugar_vprop env t2 in
+      return (SW.mk_rewrite_hint_type t1 t2)
 
 // FIXME
 // should just mimic let resolve_lid

--- a/src/syntax_extension/PulseSugar.fst
+++ b/src/syntax_extension/PulseSugar.fst
@@ -122,6 +122,10 @@ type stmt' =
       p1:vprop;
       p2:vprop;
     }
+    
+  | Rename {
+      pairs: list (A.term & A.term)
+    }
 
   | ProofHintWithBinders {
       hint_type:hint_type;
@@ -170,4 +174,5 @@ let mk_decl id binders ascription body range = { id; binders; ascription; body; 
 let mk_open lid = Open lid
 let mk_par p1 p2 q1 q2 b1 b2 = Parallel { p1; p2; q1; q2; b1; b2 }
 let mk_rewrite p1 p2 = Rewrite { p1; p2 }
+let mk_rename pairs = Rename { pairs }
 let mk_proof_hint_with_binders ht bs p =  ProofHintWithBinders { hint_type=ht; binders=bs; vprop=p }

--- a/src/syntax_extension/PulseSugar.fst
+++ b/src/syntax_extension/PulseSugar.fst
@@ -46,9 +46,10 @@ type pat =
     }
 
 type hint_type =
-  | ASSERT 
-  | UNFOLD of option (list lident)
-  | FOLD of option (list lident)
+  | ASSERT of vprop
+  | UNFOLD of option (list lident) & vprop
+  | FOLD of option (list lident) & vprop
+  | RENAME of list (A.term & A.term) & option vprop
 
 type stmt' =
   | Open of lident
@@ -123,14 +124,9 @@ type stmt' =
       p2:vprop;
     }
     
-  | Rename {
-      pairs: list (A.term & A.term)
-    }
-
   | ProofHintWithBinders {
       hint_type:hint_type;
       binders:binders;
-      vprop:vprop;
     }
 
 and stmt = {
@@ -174,5 +170,4 @@ let mk_decl id binders ascription body range = { id; binders; ascription; body; 
 let mk_open lid = Open lid
 let mk_par p1 p2 q1 q2 b1 b2 = Parallel { p1; p2; q1; q2; b1; b2 }
 let mk_rewrite p1 p2 = Rewrite { p1; p2 }
-let mk_rename pairs = Rename { pairs }
-let mk_proof_hint_with_binders ht bs p =  ProofHintWithBinders { hint_type=ht; binders=bs; vprop=p }
+let mk_proof_hint_with_binders ht bs =  ProofHintWithBinders { hint_type=ht; binders=bs }

--- a/src/syntax_extension/PulseSugar.fst
+++ b/src/syntax_extension/PulseSugar.fst
@@ -50,6 +50,7 @@ type hint_type =
   | UNFOLD of option (list lident) & vprop
   | FOLD of option (list lident) & vprop
   | RENAME of list (A.term & A.term) & option vprop
+  | REWRITE of vprop & vprop
 
 type stmt' =
   | Open of lident

--- a/src/syntax_extension/PulseSyntaxWrapper.fsti
+++ b/src/syntax_extension/PulseSyntaxWrapper.fsti
@@ -70,6 +70,7 @@ val is_tm_intro_exists (x:st_term) : bool
 val tm_protect (s:st_term) : st_term
 val tm_par (p1:term) (p2:term) (q1:term) (q2:term) (b1:st_term) (b2:st_term) (_:range) : st_term
 val tm_rewrite (p1:term) (p2:term) (_:range) : st_term
+val tm_rename (pairs:list (term & term)) (_:range) : st_term
 val tm_admit (_:range) : st_term
 val tm_proof_hint_with_binders (_:PulseSugar.hint_type) (_:list binder) (t:term) (body:st_term) (_:range) : st_term
 val close_binders (bs:list binder) (xs:list var) : list binder

--- a/src/syntax_extension/PulseSyntaxWrapper.fsti
+++ b/src/syntax_extension/PulseSyntaxWrapper.fsti
@@ -45,6 +45,12 @@ val mk_comp (pre:term) (ret:binder) (post:term) : comp
 val ghost_comp (inames:term) (pre:term) (ret:binder) (post:term) : comp
 val atomic_comp (inames:term) (pre:term) (ret:binder) (post:term) : comp
 
+val hint_type : Type0
+val mk_assert_hint_type (vp:vprop) : hint_type
+val mk_unfold_hint_type (l:option (list string)) (vp:vprop) : hint_type
+val mk_fold_hint_type (l:option (list string)) (vp:vprop) : hint_type
+val mk_rename_hint_type (l:list (term & term)) (goal:option vprop) : hint_type
+
 new val constant : Type0
 val inspect_const : FStar.Const.sconst -> constant
 
@@ -72,7 +78,7 @@ val tm_par (p1:term) (p2:term) (q1:term) (q2:term) (b1:st_term) (b2:st_term) (_:
 val tm_rewrite (p1:term) (p2:term) (_:range) : st_term
 val tm_rename (pairs:list (term & term)) (_:range) : st_term
 val tm_admit (_:range) : st_term
-val tm_proof_hint_with_binders (_:PulseSugar.hint_type) (_:list binder) (t:term) (body:st_term) (_:range) : st_term
+val tm_proof_hint_with_binders (_:hint_type) (_:list binder) (body:st_term) (_:range) : st_term
 val close_binders (bs:list binder) (xs:list var) : list binder
 val close_term (t:term) (v:var) : term
 val close_st_term (t:st_term) (v:var) : st_term
@@ -92,3 +98,4 @@ val subst : Type0
 val bvs_as_subst (l:list var) : subst
 val subst_term (s:subst) (t:term) : term
 val subst_st_term (s:subst) (t:st_term) : st_term
+val subst_proof_hint (s:subst) (h:hint_type) : hint_type

--- a/src/syntax_extension/PulseSyntaxWrapper.fsti
+++ b/src/syntax_extension/PulseSyntaxWrapper.fsti
@@ -50,6 +50,7 @@ val mk_assert_hint_type (vp:vprop) : hint_type
 val mk_unfold_hint_type (l:option (list string)) (vp:vprop) : hint_type
 val mk_fold_hint_type (l:option (list string)) (vp:vprop) : hint_type
 val mk_rename_hint_type (l:list (term & term)) (goal:option vprop) : hint_type
+val mk_rewrite_hint_type (p1:term) (p2:term) : hint_type
 
 new val constant : Type0
 val inspect_const : FStar.Const.sconst -> constant


### PR DESCRIPTION
1. We have rewrite p as q: This rewrites the vprop p to q, when p is provable in the current context. I plan to generalize this, so you can write with bs. rewrite p as q where the binders bs are free in p and are solved for against the current context.

2. I am adding rewrite each e1 as e1', e2 as e2', .., en as en' This does the following: It takes the current context p and generates  rewrite p as p[e1/e1']...[en/en']. Note, I write [e/e'] to mean replace every occurrence of e with e'. Note, these rewritings are composed. So, you can, if you want, write rewrite each x as y, y as z instead of rewrite x as z. Note, if you write rewrite x as e, y as e' and fvs(e, e') disjoint from {x, y}, then internally this is handled using a parallel substitution for efficiency reasons, but that's an implementation detail.

I also provide a variant with binders and a goal: i.e., you can write with bs. rewrite each e1 as e1', ..., en as en' in p  which solves for bs by trying to prove p (with bs free) in the current context, and then generates sol(rewrite p as p[e1/e1']..[en/en']) where sol is the solution to the bs.

Note, Thibault asks:

Q:
>I'm not sure I understand the sol(...) notation though
>Does it mean that e1, e1', etc. can refer to bs as well?

A: sol is the solution to the binders bs. Yes, e1, e1' etc can refer to those

There are test cases in Records.fst and ZetaHashAccumulator. I also used them quite a lot in DPE.fst to reduce many implicit argument annotations.