### PR TITLE
Fresh invariant

### DIFF
--- a/lib/steel/Steel.Effect.Atomic.fst
+++ b/lib/steel/Steel.Effect.Atomic.fst
@@ -630,11 +630,13 @@ let exists_cong p q =
       reveal_equiv (h_exists p) (h_exists q);
       exists_equiv p q)
 
-let new_invariant #uses p =
+let fresh_invariant #uses p ctxt =
   rewrite_slprop p (to_vprop (hp_of p)) (fun _ -> ());
-  let i = as_atomic_unobservable_action (new_invariant uses (hp_of p)) in
+  let i = as_atomic_unobservable_action (fresh_invariant uses (hp_of p) ctxt) in
   rewrite_slprop (to_vprop Mem.emp) emp (fun _ -> reveal_emp ());
   return i
+
+let new_invariant #uses p = let i = fresh_invariant #uses p [] in return i
 
 (*
  * AR: SteelAtomic and SteelGhost are not marked reifiable since we intend to run Steel programs natively

--- a/lib/steel/Steel.Effect.Atomic.fsti
+++ b/lib/steel/Steel.Effect.Atomic.fsti
@@ -711,6 +711,18 @@ val exists_cong (#a:_) (#u:_) (p:a -> vprop) (q:a -> vprop {forall x. equiv (p x
                 (fun _ -> h_exists q)
 
 (* Lifting invariants to vprops *)
+let fresh_inv (e:inames) (ctxt:list pre_inv) #p (i:inv p) =
+  not (mem_inv e i) /\
+  (forall qi. List.Tot.memP qi ctxt ==> name_of_pre_inv qi =!= name_of_inv i)
+
+/// Creation of a new invariant associated to vprop [p].
+/// After execution of this function, [p] is consumed and not available in the context anymore
+/// The newly allocated invariant is distinct from the opened invariants and any other
+/// invariants in ctxt provided by the caller
+val fresh_invariant (#opened_invariants:inames) (p:vprop) (ctxt:list pre_inv)
+  : SteelAtomicUT (i:inv p {fresh_inv opened_invariants ctxt i})
+                 opened_invariants p (fun _ -> emp)
+
 /// Creation of a new invariant associated to vprop [p].
 /// After execution of this function, [p] is consumed and not available in the context anymore
 val new_invariant (#opened_invariants:inames) (p:vprop)

--- a/lib/steel/Steel.Memory.fst
+++ b/lib/steel/Steel.Memory.fst
@@ -1583,3 +1583,214 @@ let star_is_witinv_right (#a:Type)
   : Lemma (requires (is_witness_invariant g))
           (ensures  (is_witness_invariant (fun x -> f x `star` g x)))
   = ()
+
+
+/////////////////////////////////////
+// This is a "flipped" version of lock_store_invariant
+// Only the invariant in `e` are valid
+let rec owns_invariants_in_store (e:inames) (l:lock_store u#a) : slprop u#a =
+  let current_addr = L.length l - 1 in
+  match l with
+  | [] -> emp
+  | Invariant p :: tl ->
+    if current_addr `S.mem` e then
+      p `star` owns_invariants_in_store e tl
+    else
+      owns_invariants_in_store e tl
+
+let rec owns_invariant_remove_unused (e:inames) (x:iname) (l:lock_store u#a)
+  : Lemma
+    (requires x >= L.length l)
+    (ensures owns_invariants_in_store e l ==
+            owns_invariants_in_store (Set.remove x e) l)
+  = match l with
+    | [] -> ()
+    | Invariant p :: tl ->
+      owns_invariant_remove_unused e x tl
+
+let rec owns_invariant_add_unused (e:inames) (x:iname) (l:lock_store u#a)
+  : Lemma (requires x >= L.length l)
+          (ensures owns_invariants_in_store e l == owns_invariants_in_store (Set.add x e) l)
+  = match l with
+    | [] -> ()
+    | Invariant p :: tl ->
+      owns_invariant_add_unused e x tl
+
+let extend_lock_store_flip (e:inames) (l:lock_store{ e `inames_in` l}) (p:slprop)
+  : i:iname &
+    l':lock_store {
+      owns_invariants_in_store e l' == owns_invariants_in_store e l /\
+      iname_for_p i p l' /\
+      owns_invariants_in_store (Set.add i e) l' == p `star` owns_invariants_in_store (Set.add i e) l
+    }
+  = (| L.length l, Invariant p :: l |)
+
+let rec move_invariant_flip (e:inames) (l:lock_store) (p:slprop)
+                            (i:iname{iname_for_p i p l /\ i `Set.mem` e})
+   : Lemma (H.equiv (owns_invariants_in_store e l)
+                    (p `star` owns_invariants_in_store (Set.remove i e) l))
+   = let current_addr = L.length l - 1 in
+     match l with
+     | [] -> ()
+     | Invariant q::tl ->
+        if i = current_addr
+        then owns_invariant_remove_unused e i tl
+        else begin
+          move_invariant_flip e tl p i;
+          assert (owns_invariants_in_store e tl `equiv`
+                 (p `star` owns_invariants_in_store (Set.remove i e) tl));
+          if Set.mem current_addr e
+          then begin
+            H.star_congruence q (owns_invariants_in_store e tl) q (p `star` owns_invariants_in_store (Set.remove i e) tl);
+            assert (owns_invariants_in_store e l `equiv`
+                    (q `star` (p `star` owns_invariants_in_store (Set.remove i e) tl)));
+            H.star_associative q p (owns_invariants_in_store (Set.remove i e) tl);
+            H.star_commutative q p;
+            H.star_congruence (q `star` p) (owns_invariants_in_store (Set.remove i e) tl) (p `star` q) (owns_invariants_in_store (Set.remove i e) tl);
+            H.star_associative p q (owns_invariants_in_store (Set.remove i e) tl);
+            assert (owns_invariants_in_store e l `equiv`
+                    (p `star` (q `star` owns_invariants_in_store (Set.remove i e) tl)))
+          end
+        end
+
+let invariant_store_has (e:inames) (m:mem u#a) : slprop u#a =
+   owns_invariants_in_store e m.locks
+   `star`
+   ctr_validity m.ctr (heap_of_mem m)
+
+let owns_invariants_in e m = invariant_store_has e m
+
+let flush = ()
+
+(** Memory refined with invariants and a footprint *)
+let hmem_owns_invariants (e:inames) (fp:slprop u#a) =
+  m:full_mem{inames_ok e m /\ interp (fp `star` invariant_store_has e m) m}
+
+let frame_preserving_new (fp0 fp1:slprop u#a)
+                         (owns0 owns1:inames)
+                         (m0:hmem_owns_invariants owns0 fp0)
+                         (m1:hmem_owns_invariants owns1 fp1) =
+    forall (frame:slprop u#a).
+      interp ((fp0 `star` frame) `star` invariant_store_has owns0 m0) m0 ==>
+      interp ((fp1 `star` frame) `star` invariant_store_has owns1 m1) m1
+
+let emp_inames = Set.empty
+
+let rec owns_invariants_in_store_emp (l:lock_store) : Lemma (owns_invariants_in_store emp_inames l == emp)
+  = match l with
+    | [] -> ()
+    | Invariant p :: tl ->
+      owns_invariants_in_store_emp tl
+module T = FStar.Tactics
+let alloc_invariant_tot_action (p:slprop) (m0:hmem_owns_invariants emp_inames p)
+  : Pure (i:iname & hmem_owns_invariants emp_inames emp)
+         (requires True)
+         (ensures fun (|i, m1|) ->
+           iname_for_p_mem i p m1 /\
+           frame_preserving_new p emp emp_inames emp_inames m0 m1 /\
+           mem_evolves m0 m1)
+  = let (| i, l1 |) = extend_lock_store emp_inames m0.locks p in
+    let m1 : full_mem = { m0 with locks = l1 } in
+    assert (inames_ok emp_inames m1);
+    calc (equiv) {
+      emp `star` invariant_store_has emp_inames m1;
+        (==)    {  owns_invariants_in_store_emp m1.locks }
+      emp `star` (emp `star` ctr_validity m1.ctr (heap_of_mem m1));
+        (equiv) { H.star_associative emp emp (ctr_validity m1.ctr (heap_of_mem m1)) }
+      (emp `star` emp) `star` ctr_validity m1.ctr (heap_of_mem m1);
+        (equiv) { H.star_commutative (emp `star` emp) (ctr_validity m1.ctr (heap_of_mem m1)) }
+      ctr_validity m1.ctr (heap_of_mem m1) `star` (emp `star` emp);
+        (equiv) { H.star_associative (ctr_validity m1.ctr (heap_of_mem m1)) emp emp;
+                  H.emp_unit (ctr_validity m1.ctr (heap_of_mem m1) `star` emp) }
+      ctr_validity m1.ctr (heap_of_mem m1) `star` emp;
+        (equiv)  { H.emp_unit (ctr_validity m1.ctr (heap_of_mem m1)) }
+      ctr_validity m1.ctr (heap_of_mem m1);
+    };
+    assert (interp (emp `star` invariant_store_has emp_inames m1) m1);
+    assert (iname_for_p_mem i p m1);
+    assert (mem_evolves m0 m1);
+    assume (frame_preserving_new p emp emp_inames emp_inames m0 m1);
+    (| i, m1 |)
+
+
+//     let m1 = { m0 with locks = l1 } in
+//     assert (lock_store_invariant e m1.locks ==
+//             p `star` lock_store_invariant e m0.locks);
+//     calc (equiv) {
+//       linv e m1;
+//         (equiv) {}
+//       (lock_store_invariant e m1.locks
+//         `star`
+//        ctr_validity m1.ctr (heap_of_mem m1));
+//         (equiv) {}
+//       ((p `star` lock_store_invariant e m0.locks)
+//         `star`
+//        ctr_validity m1.ctr (heap_of_mem m1));
+//         (equiv) {
+//           H.star_associative p (lock_store_invariant e m0.locks) (ctr_validity m1.ctr (heap_of_mem m1))
+//          }
+//       (p `star` (lock_store_invariant e m0.locks
+//         `star`
+//        ctr_validity m1.ctr (heap_of_mem m1)));
+//         (equiv) { }
+//       (p `star` linv e m0);
+//     };
+//     assert (iname_for_p_mem i p m1);
+//     assert (lock_store_evolves m0.locks l1);
+//     assert (mem_evolves m0 m1);
+//     hmem_with_inv_equiv e m0 p;
+//     assert (interp (p `star` lock_store_invariant e m0.locks) m1);
+//     assert (interp (lock_store_invariant e m1.locks) m1);
+//     H.emp_unit (lock_store_invariant e m1.locks);
+//     H.star_commutative (lock_store_invariant e m1.locks) emp;
+//     assert (interp (emp `star` lock_store_invariant e m1.locks) m1);
+//     hmem_with_inv_equiv e m1 emp;
+//     let m1 : hmem_with_inv_except e emp = m1 in
+//     let aux (frame:slprop)
+//       : Lemma
+//         (requires interp ((p `star` frame) `star` linv e m0) m0)
+//         (ensures interp ((emp `star` frame) `star` linv e m1) m1 /\
+//                  mem_evolves m0 m1 /\
+//                  (forall (mp:mprop frame). mp (core_mem m0) <==> mp (core_mem m1)))
+//         [SMTPat (p `star` frame)]
+//       = assert (interp ((p `star` frame) `star` linv e m0) m1);
+//         calc (equiv) {
+//           ((p `star` frame) `star` linv e m0);
+//             (equiv) {
+//                       H.star_commutative p frame;
+//                       H.star_congruence (p `star` frame) (linv e m0) (frame `star` p) (linv e m0);
+//                       H.star_associative frame p (linv e m0)
+//                     }
+//           (frame `star` (p `star` linv e m0));
+//             (equiv) {
+//                       H.star_congruence frame (p `star` linv e m0) frame (linv e m1)
+//                     }
+//           (frame `star` linv e m1);
+//             (equiv) {
+//                        H.emp_unit (frame `star` linv e m1);
+//                        H.star_commutative (frame `star` linv e m1) emp;
+//                        H.star_associative emp frame (linv e m1)
+//                     }
+//           ((emp `star` frame) `star` linv e m1);
+//         };
+//         assert (interp ((emp `star` frame) `star` linv e m1) m1)
+//     in
+//     assert (frame_related_mems p emp e m0 m1);
+//     ( i, m1 )
+let alloc_invariant_simple (p:slprop) (frame:slprop)
+  : UsingInvariants (inv p) emp_inames p (fun _ -> emp) frame
+  = let m0 = NMSTTotal.get () in
+    ac_reasoning_for_m_frame_preserving p frame (invariant_store_has emp_inames m0) m0;
+    assert (interp (p `star` owns_invariants_in emp_inames m0) m0);
+    let r = alloc_invariant_tot_action p m0 in
+    let (| i, m1 |) = r in
+    assert (mem_evolves m0 m1);
+    NMSTTotal.put #full_mem #mem_evolves m1;
+    iname_for_p_stable i p;
+    let w  = NMSTTotal.witness full_mem mem_evolves (iname_for_p_mem i p) in
+    let r : inv p = (| hide i, w |) in
+    r
+
+let alloc_invariant_simple' (p:slprop)
+  : action_using (inv p) emp_inames p (fun _ -> emp)
+  = alloc_invariant_simple p

--- a/lib/steel/Steel.Memory.fsti
+++ b/lib/steel/Steel.Memory.fsti
@@ -511,6 +511,13 @@ let add_inv (#p:slprop) (e:inames) (i:inv p) : inames =
   Set.union (Set.singleton (name_of_inv i)) (reveal e)
 
 (** Creates a new invariant from a separation logic predicate [p] owned at the time of the call *)
+let fresh_wrt (ctx:list (q:_ & inv q))
+              (i:iname)
+  = forall qi'. List.Tot.memP qi' ctx ==> name_of_inv (dsnd qi') <> i
+
+val fresh_invariant (e:inames) (p:slprop) (ctx:list (q:_ & inv q))
+  : action_except (i:inv p { not (mem_inv e i) /\ fresh_wrt ctx (name_of_inv i) }) e p (fun _ -> emp)
+
 val new_invariant (e:inames) (p:slprop)
   : action_except (inv p) e p (fun _ -> emp)
 
@@ -611,42 +618,3 @@ val star_is_witinv_right (#a:Type)
   : Lemma (requires (is_witness_invariant g))
           (ensures  (is_witness_invariant (fun x -> f x `star` g x)))
           //[SMTPat   (is_witness_invariant (fun x -> f x `star` g x))]
-
-// An alternate version of invariant masks
-val owns_invariants_in (e:inames) (m:mem u#a) : slprop u#a
-
-effect UsingInvariants
-  (a:Type u#a)
-  (invariants:inames)
-  (expects:slprop u#1)
-  (provides: a -> slprop u#1)
-  (frame:slprop u#1)
-  = NMSTTotal.NMSTATETOT a (full_mem u#1) mem_evolves
-    (requires fun m0 ->
-        inames_ok invariants m0 /\
-        interp (expects `star` frame `star` owns_invariants_in invariants m0) m0)
-    (ensures fun m0 x m1 ->
-        inames_ok invariants m1 /\
-        interp (expects `star` frame `star` owns_invariants_in invariants m0) m0 /\  //TODO: fix the effect so as not to repeat this
-        interp (provides x `star` frame `star` owns_invariants_in invariants m1) m1)
-
-val flush : unit
-(** An action is just a thunked computation in [MstTot] that takes a frame as argument *)
-let action_using (a:Type u#a) (invariants:inames) (expects:slprop) (provides: a -> slprop) =
-  frame:slprop -> UsingInvariants a invariants expects provides frame
-
-val alloc_invariant (fresh:list (p:_ & inv p)) (e:inames) (p:slprop)
-  : action_using
-    (i:inv p {
-        forall j. j `List.Tot.memP` fresh ==>
-                  name_of_inv i =!= name_of_inv (dsnd j)
-    }) e p (fun _ -> emp)
-
-val use_invariant (#a:Type)
-                  (#fp:slprop)
-                  (#fp':a -> slprop)
-                  (#uses:inames)
-                  (#p:slprop)
-                  (i:inv p{not (mem_inv uses i)})
-                  (f:action_using a uses (p `star` fp) (fun x -> p `star` fp' x))
-  : action_except a (add_inv uses i) fp fp'

--- a/lib/steel/Steel.Memory.fsti
+++ b/lib/steel/Steel.Memory.fsti
@@ -501,9 +501,17 @@ val recall (#a:Type u#1) (#pcm:pcm a) (#fact:property a)
 (**** Invariants *)
 
 (**[i : inv p] is an invariant whose content is [p] *)
+val pre_inv : Type0
+
 val inv (p:slprop u#1) : Type0
 
-val name_of_inv (#p:slprop) (i:inv p) : GTot iname
+val pre_inv_of_inv (#p:slprop) (i:inv p) : pre_inv
+
+val name_of_pre_inv (i:pre_inv) : GTot iname
+
+let name_of_inv (#p:slprop) (i:inv p)
+  : GTot iname
+  = name_of_pre_inv (pre_inv_of_inv i)
 
 let mem_inv (#p:slprop) (e:inames) (i:inv p) : erased bool = elift2 (fun e i -> Set.mem i e) e (name_of_inv i)
 
@@ -511,11 +519,11 @@ let add_inv (#p:slprop) (e:inames) (i:inv p) : inames =
   Set.union (Set.singleton (name_of_inv i)) (reveal e)
 
 (** Creates a new invariant from a separation logic predicate [p] owned at the time of the call *)
-let fresh_wrt (ctx:list (q:_ & inv q))
+let fresh_wrt (ctx:list pre_inv)
               (i:iname)
-  = forall qi'. List.Tot.memP qi' ctx ==> name_of_inv (dsnd qi') <> i
+  = forall i'. List.Tot.memP i' ctx ==> name_of_pre_inv i' <> i
 
-val fresh_invariant (e:inames) (p:slprop) (ctx:list (q:_ & inv q))
+val fresh_invariant (e:inames) (p:slprop) (ctx:list pre_inv)
   : action_except (i:inv p { not (mem_inv e i) /\ fresh_wrt ctx (name_of_inv i) }) e p (fun _ -> emp)
 
 val new_invariant (e:inames) (p:slprop)

--- a/lib/steel/Steel.ST.Util.fst
+++ b/lib/steel/Steel.ST.Util.fst
@@ -132,8 +132,11 @@ let exists_equiv #a p1 p2
 let exists_cong #a #u p q
   = coerce_ghost (fun _ -> SEA.exists_cong #a #u p q)
 
+let fresh_invariant #u p ctxt
+  = coerce_atomic (fun _ -> SEA.fresh_invariant #u p ctxt)
+
 let new_invariant #u p
-  = coerce_atomic (fun _ -> SEA.new_invariant #u p)
+  = let i = fresh_invariant #u p [] in return i
 
 let with_invariant (#a:Type)
                    (#fp:vprop)

--- a/lib/steel/Steel.ST.Util.fsti
+++ b/lib/steel/Steel.ST.Util.fsti
@@ -202,6 +202,20 @@ val exists_cong (#a:_)
 
 /// Creation of a new invariant associated to vprop [p].
 /// After execution of this function, [p] is consumed and not available in the context anymore
+/// The newly allocated invariant is distinct from the opened invariants and any other
+/// invariants in ctxt provided by the caller
+
+(* Lifting invariants to vprops *)
+let fresh_inv (e:inames) (ctxt:list pre_inv) #p (i:inv p) =
+  not (mem_inv e i) /\
+  (forall qi. List.Tot.memP qi ctxt ==> name_of_pre_inv qi =!= name_of_inv i)
+
+val fresh_invariant (#opened_invariants:inames) (p:vprop) (ctxt:list pre_inv)
+  : STAtomicUT (i:inv p {fresh_inv opened_invariants ctxt i})
+                 opened_invariants p (fun _ -> emp)
+
+/// Creation of a new invariant associated to vprop [p].
+/// After execution of this function, [p] is consumed and not available in the context anymore
 val new_invariant (#opened_invariants:inames) (p:vprop)
   : STAtomicUT (inv p) opened_invariants p (fun _ -> emp)
 


### PR DESCRIPTION
When allocating an invariant, it is useful to know that the new invariant is distinct from all other allocated invariants.

While we don't yet have a way to refer to the universe of all allocated invariants, we can allow the caller to pass in the set of invariants and ensure that the newly allocated invariant is distinct from all of them.

I've added a `fresh_invariant` in Steel.Memory, and propagated it to Steel.Effect.Atomic and Steel.ST.Effect.Atomic

Here is its signature in Steel.ST.Effect.Atomic

```fstar
let fresh_inv (e:inames) (ctxt:list pre_inv) #p (i:inv p) =
  not (mem_inv e i) /\
  (forall qi. List.Tot.memP qi ctxt ==> name_of_pre_inv qi =!= name_of_inv i)

val fresh_invariant (#opened_invariants:inames) (p:vprop) (ctxt:list pre_inv)
  : STAtomicUT (i:inv p {fresh_inv opened_invariants ctxt i})
                 opened_invariants p (fun _ -> emp)
```

Notice it uses a notion of `pre_inv`, which is a non-indexed version of an invariant, which makes it easier to collect all invariants in a single list, rather than requiring a list of pairs (and avoiding universe problems, in case such a list is to be stored in memory). Steel.Memory provides a new function `pre_inv_of_inv #p (i:inv p) : pre_inv` to extract a pre_inv from an inv.