### PR TITLE
Making desugaring errors more localized

### DIFF
--- a/lib/steel/pulse/Pulse.ASTBuilder.fsti
+++ b/lib/steel/pulse/Pulse.ASTBuilder.fsti
@@ -6,4 +6,5 @@ val parse_pulse (env:R.env)
                 (content:string)
                 (file_name:string)
                 (line col:int)
-  : Dv (either Pulse.Syntax.st_term (string & R.range))
+  : Dv (either Pulse.Syntax.st_term (option (string & R.range)))
+  // Option can be empty if all errors were already logged.

--- a/lib/steel/pulse/Pulse.Main.fst
+++ b/lib/steel/pulse/Pulse.Main.fst
@@ -109,7 +109,11 @@ let check_pulse (namespaces:list string)
       match Pulse.ASTBuilder.parse_pulse env namespaces module_abbrevs content file_name line col with
       | Inl st_term ->
         main st_term tm_emp env
-      | Inr (msg, range) ->
+
+      | Inr None ->
+        T.fail "Pulse parser failed"
+
+      | Inr (Some (msg, range)) ->
         let i =
           Issue.mk_issue "Error"
                    (Printf.sprintf "%s: %s" (T.range_to_string range) msg)

--- a/src/ocaml/plugin/Pulse_Parser.ml
+++ b/src/ocaml/plugin/Pulse_Parser.ml
@@ -217,10 +217,10 @@ let parse_decl (s:string) (r:range) =
   | e ->
     let pos = FStar_Parser_Util.pos_of_lexpos (lexbuf.cur_p) in
     let r = FStar_Compiler_Range.mk_range fn pos pos in
-    Inr ("Syntax error", r)
+    Inr (Some ("Syntax error", r))
 
  
-let parse_peek_id (s:string) (r:range) =
+let parse_peek_id (s:string) (r:range) : (string, string * range) either =
   (* print_string ("About to parse <" ^ s ^ ">"); *)
   let fn = file_of_range r in
   let lexbuf, lexer = lexbuf_and_lexer s r in

--- a/src/ocaml/plugin/generated/Pulse_ASTBuilder.ml
+++ b/src/ocaml/plugin/generated/Pulse_ASTBuilder.ml
@@ -117,7 +117,8 @@ let (parse_pulse :
             Prims.int ->
               Prims.int ->
                 (PulseSyntaxWrapper.st_term,
-                  (Prims.string * FStar_Compiler_Range_Type.range))
+                  (Prims.string * FStar_Compiler_Range_Type.range)
+                    FStar_Pervasives_Native.option)
                   FStar_Pervasives.either)
   =
   fun env ->

--- a/src/ocaml/plugin/generated/Pulse_Main.ml
+++ b/src/ocaml/plugin/generated/Pulse_Main.ml
@@ -1094,7 +1094,7 @@ let (check_pulse :
                      (Obj.magic
                         (FStar_Range.mk_range "Pulse.Main.fst"
                            (Prims.of_int (109)) (Prims.of_int (6))
-                           (Prims.of_int (121)) (Prims.of_int (36)))))
+                           (Prims.of_int (125)) (Prims.of_int (36)))))
                   (FStar_Tactics_Effect.lift_div_tac
                      (fun uu___ ->
                         Pulse_ASTBuilder.parse_pulse env namespaces
@@ -1104,134 +1104,146 @@ let (check_pulse :
                         match uu___ with
                         | FStar_Pervasives.Inl st_term ->
                             Obj.magic
-                              (main st_term Pulse_Syntax_Base.tm_emp env)
-                        | FStar_Pervasives.Inr (msg, range) ->
+                              (Obj.repr
+                                 (main st_term Pulse_Syntax_Base.tm_emp env))
+                        | FStar_Pervasives.Inr (FStar_Pervasives_Native.None)
+                            ->
                             Obj.magic
-                              (FStar_Tactics_Effect.tac_bind
-                                 (FStar_Sealed.seal
-                                    (Obj.magic
-                                       (FStar_Range.mk_range "Pulse.Main.fst"
-                                          (Prims.of_int (114))
-                                          (Prims.of_int (10))
-                                          (Prims.of_int (118))
-                                          (Prims.of_int (21)))))
-                                 (FStar_Sealed.seal
-                                    (Obj.magic
-                                       (FStar_Range.mk_range "Pulse.Main.fst"
-                                          (Prims.of_int (120))
-                                          (Prims.of_int (8))
-                                          (Prims.of_int (121))
-                                          (Prims.of_int (36)))))
-                                 (Obj.magic
-                                    (FStar_Tactics_Effect.tac_bind
-                                       (FStar_Sealed.seal
-                                          (Obj.magic
-                                             (FStar_Range.mk_range
-                                                "Pulse.Main.fst"
-                                                (Prims.of_int (115))
-                                                (Prims.of_int (19))
-                                                (Prims.of_int (115))
-                                                (Prims.of_int (74)))))
-                                       (FStar_Sealed.seal
-                                          (Obj.magic
-                                             (FStar_Range.mk_range
-                                                "FStar.Issue.fsti"
-                                                (Prims.of_int (49))
-                                                (Prims.of_int (4))
-                                                (Prims.of_int (49))
-                                                (Prims.of_int (65)))))
+                              (Obj.repr
+                                 (FStar_Tactics_V2_Derived.fail
+                                    "Pulse parser failed"))
+                        | FStar_Pervasives.Inr (FStar_Pervasives_Native.Some
+                            (msg, range)) ->
+                            Obj.magic
+                              (Obj.repr
+                                 (FStar_Tactics_Effect.tac_bind
+                                    (FStar_Sealed.seal
                                        (Obj.magic
-                                          (FStar_Tactics_Effect.tac_bind
-                                             (FStar_Sealed.seal
-                                                (Obj.magic
-                                                   (FStar_Range.mk_range
-                                                      "Pulse.Main.fst"
-                                                      (Prims.of_int (115))
-                                                      (Prims.of_int (19))
-                                                      (Prims.of_int (115))
-                                                      (Prims.of_int (74)))))
-                                             (FStar_Sealed.seal
-                                                (Obj.magic
-                                                   (FStar_Range.mk_range
-                                                      "Pulse.Main.fst"
-                                                      (Prims.of_int (115))
-                                                      (Prims.of_int (19))
-                                                      (Prims.of_int (115))
-                                                      (Prims.of_int (74)))))
+                                          (FStar_Range.mk_range
+                                             "Pulse.Main.fst"
+                                             (Prims.of_int (118))
+                                             (Prims.of_int (10))
+                                             (Prims.of_int (122))
+                                             (Prims.of_int (21)))))
+                                    (FStar_Sealed.seal
+                                       (Obj.magic
+                                          (FStar_Range.mk_range
+                                             "Pulse.Main.fst"
+                                             (Prims.of_int (124))
+                                             (Prims.of_int (8))
+                                             (Prims.of_int (125))
+                                             (Prims.of_int (36)))))
+                                    (Obj.magic
+                                       (FStar_Tactics_Effect.tac_bind
+                                          (FStar_Sealed.seal
                                              (Obj.magic
-                                                (FStar_Tactics_Effect.tac_bind
-                                                   (FStar_Sealed.seal
-                                                      (Obj.magic
-                                                         (FStar_Range.mk_range
-                                                            "Pulse.Main.fst"
-                                                            (Prims.of_int (115))
-                                                            (Prims.of_int (44))
-                                                            (Prims.of_int (115))
-                                                            (Prims.of_int (69)))))
-                                                   (FStar_Sealed.seal
-                                                      (Obj.magic
-                                                         (FStar_Range.mk_range
-                                                            "FStar.Printf.fst"
-                                                            (Prims.of_int (121))
-                                                            (Prims.of_int (8))
-                                                            (Prims.of_int (123))
-                                                            (Prims.of_int (44)))))
+                                                (FStar_Range.mk_range
+                                                   "Pulse.Main.fst"
+                                                   (Prims.of_int (119))
+                                                   (Prims.of_int (19))
+                                                   (Prims.of_int (119))
+                                                   (Prims.of_int (74)))))
+                                          (FStar_Sealed.seal
+                                             (Obj.magic
+                                                (FStar_Range.mk_range
+                                                   "FStar.Issue.fsti"
+                                                   (Prims.of_int (49))
+                                                   (Prims.of_int (4))
+                                                   (Prims.of_int (49))
+                                                   (Prims.of_int (65)))))
+                                          (Obj.magic
+                                             (FStar_Tactics_Effect.tac_bind
+                                                (FStar_Sealed.seal
                                                    (Obj.magic
-                                                      (FStar_Tactics_V2_Builtins.range_to_string
-                                                         range))
-                                                   (fun uu___1 ->
-                                                      FStar_Tactics_Effect.lift_div_tac
-                                                        (fun uu___2 ->
-                                                           fun x ->
-                                                             Prims.strcat
-                                                               (Prims.strcat
-                                                                  ""
+                                                      (FStar_Range.mk_range
+                                                         "Pulse.Main.fst"
+                                                         (Prims.of_int (119))
+                                                         (Prims.of_int (19))
+                                                         (Prims.of_int (119))
+                                                         (Prims.of_int (74)))))
+                                                (FStar_Sealed.seal
+                                                   (Obj.magic
+                                                      (FStar_Range.mk_range
+                                                         "Pulse.Main.fst"
+                                                         (Prims.of_int (119))
+                                                         (Prims.of_int (19))
+                                                         (Prims.of_int (119))
+                                                         (Prims.of_int (74)))))
+                                                (Obj.magic
+                                                   (FStar_Tactics_Effect.tac_bind
+                                                      (FStar_Sealed.seal
+                                                         (Obj.magic
+                                                            (FStar_Range.mk_range
+                                                               "Pulse.Main.fst"
+                                                               (Prims.of_int (119))
+                                                               (Prims.of_int (44))
+                                                               (Prims.of_int (119))
+                                                               (Prims.of_int (69)))))
+                                                      (FStar_Sealed.seal
+                                                         (Obj.magic
+                                                            (FStar_Range.mk_range
+                                                               "FStar.Printf.fst"
+                                                               (Prims.of_int (121))
+                                                               (Prims.of_int (8))
+                                                               (Prims.of_int (123))
+                                                               (Prims.of_int (44)))))
+                                                      (Obj.magic
+                                                         (FStar_Tactics_V2_Builtins.range_to_string
+                                                            range))
+                                                      (fun uu___1 ->
+                                                         FStar_Tactics_Effect.lift_div_tac
+                                                           (fun uu___2 ->
+                                                              fun x ->
+                                                                Prims.strcat
                                                                   (Prims.strcat
+                                                                    ""
+                                                                    (Prims.strcat
                                                                     uu___1
                                                                     ": "))
-                                                               (Prims.strcat
-                                                                  x "")))))
-                                             (fun uu___1 ->
-                                                FStar_Tactics_Effect.lift_div_tac
-                                                  (fun uu___2 -> uu___1 msg))))
-                                       (fun uu___1 ->
-                                          FStar_Tactics_Effect.lift_div_tac
-                                            (fun uu___2 ->
-                                               FStar_Issue.mk_issue_doc
-                                                 "Error"
-                                                 [FStar_Pprint.arbitrary_string
-                                                    uu___1]
-                                                 (FStar_Pervasives_Native.Some
-                                                    range)
-                                                 FStar_Pervasives_Native.None
-                                                 []))))
-                                 (fun uu___1 ->
-                                    (fun i ->
-                                       Obj.magic
-                                         (FStar_Tactics_Effect.tac_bind
-                                            (FStar_Sealed.seal
+                                                                  (Prims.strcat
+                                                                    x "")))))
+                                                (fun uu___1 ->
+                                                   FStar_Tactics_Effect.lift_div_tac
+                                                     (fun uu___2 ->
+                                                        uu___1 msg))))
+                                          (fun uu___1 ->
+                                             FStar_Tactics_Effect.lift_div_tac
+                                               (fun uu___2 ->
+                                                  FStar_Issue.mk_issue_doc
+                                                    "Error"
+                                                    [FStar_Pprint.arbitrary_string
+                                                       uu___1]
+                                                    (FStar_Pervasives_Native.Some
+                                                       range)
+                                                    FStar_Pervasives_Native.None
+                                                    []))))
+                                    (fun uu___1 ->
+                                       (fun i ->
+                                          Obj.magic
+                                            (FStar_Tactics_Effect.tac_bind
+                                               (FStar_Sealed.seal
+                                                  (Obj.magic
+                                                     (FStar_Range.mk_range
+                                                        "Pulse.Main.fst"
+                                                        (Prims.of_int (124))
+                                                        (Prims.of_int (8))
+                                                        (Prims.of_int (124))
+                                                        (Prims.of_int (24)))))
+                                               (FStar_Sealed.seal
+                                                  (Obj.magic
+                                                     (FStar_Range.mk_range
+                                                        "Pulse.Main.fst"
+                                                        (Prims.of_int (125))
+                                                        (Prims.of_int (8))
+                                                        (Prims.of_int (125))
+                                                        (Prims.of_int (36)))))
                                                (Obj.magic
-                                                  (FStar_Range.mk_range
-                                                     "Pulse.Main.fst"
-                                                     (Prims.of_int (120))
-                                                     (Prims.of_int (8))
-                                                     (Prims.of_int (120))
-                                                     (Prims.of_int (24)))))
-                                            (FStar_Sealed.seal
-                                               (Obj.magic
-                                                  (FStar_Range.mk_range
-                                                     "Pulse.Main.fst"
-                                                     (Prims.of_int (121))
-                                                     (Prims.of_int (8))
-                                                     (Prims.of_int (121))
-                                                     (Prims.of_int (36)))))
-                                            (Obj.magic
-                                               (FStar_Tactics_V2_Builtins.log_issues
-                                                  [i]))
-                                            (fun uu___1 ->
-                                               FStar_Tactics_V2_Derived.fail
-                                                 "Pulse parser failed")))
-                                      uu___1))) uu___)
+                                                  (FStar_Tactics_V2_Builtins.log_issues
+                                                     [i]))
+                                               (fun uu___1 ->
+                                                  FStar_Tactics_V2_Derived.fail
+                                                    "Pulse parser failed")))
+                                         uu___1)))) uu___)
 let _ =
   FStar_Tactics_Native.register_tactic "Pulse.Main.check_pulse"
     (Prims.of_int (8))

--- a/src/syntax_extension/Pulse.Parser.fsti
+++ b/src/syntax_extension/Pulse.Parser.fsti
@@ -8,5 +8,5 @@ val parse_peek_id (contents:string)
 val parse_decl (contents:string)
                (r:FStar.Compiler.Range.range)
   : either PulseSugar.decl
-           (string & FStar.Compiler.Range.range)
+           (option (string & FStar.Compiler.Range.range))
 

--- a/src/syntax_extension/PulseDesugar.fsti
+++ b/src/syntax_extension/PulseDesugar.fsti
@@ -1,0 +1,27 @@
+module PulseDesugar
+
+open FStar.Compiler.Effect
+module Sugar = PulseSugar
+module SW = PulseSyntaxWrapper
+module TcEnv = FStar.TypeChecker.Env
+module R = FStar.Compiler.Range
+
+// An error can be "None", which means all relevant
+// errors were already logged via the error API.
+type error = option (string & R.range)
+
+let err a = nat -> either a error & nat
+
+new
+val env_t : Type0
+
+val desugar_decl (env:env_t)
+                 (p:Sugar.decl)
+  : err SW.st_term
+
+let name = list string
+
+val initialize_env (env:TcEnv.env)
+                   (open_namespaces: list name)
+                   (module_abbrevs: list (string & name))
+  : env_t

--- a/src/syntax_extension/Pulse_ASTBuilder.fst
+++ b/src/syntax_extension/Pulse_ASTBuilder.fst
@@ -73,7 +73,7 @@ let parse_pulse (env:TcEnv.env)
                 (content:string)
                 (file_name:string)
                 (line col:int)
-  : either PulseSyntaxWrapper.st_term (string & R.range)
+  : either PulseSyntaxWrapper.st_term (option (string & R.range))
   = let namespaces = L.map Ident.path_of_text namespaces in
     let module_abbrevs = L.map (fun (x, l) -> x, Ident.path_of_text l) module_abbrevs in
     let env = D.initialize_env env namespaces module_abbrevs in


### PR DESCRIPTION
This fixes desugaring errors to only highlight the offending location, coming from F*. Instead of adding another error saying "Failed to desugar Pulse term", we just add that string to the context of the error we got back from F*. This is especially useful when a typo is made inside a big F* term within Pulse.

Before (here there are two overlapped errors. Hovering over `fb` will print the correct "Identifier not found" message, but there's no visual indication):
<img width="342" alt="Screenshot 2023-09-18 153116" src="https://github.com/FStarLang/steel/assets/4195583/26fd21dc-b83f-4f5d-9c99-5c25f8d3f003">


After:
<img width="355" alt="Screenshot 2023-09-18 154001" src="https://github.com/FStarLang/steel/assets/4195583/0b9b7afb-b7d0-470b-a6b4-df3e4c74ca7c">

