### PR TITLE
Pretty printing errors

### DIFF
--- a/lib/steel/pulse/Pulse.Checker.Prover.fst
+++ b/lib/steel/pulse/Pulse.Checker.Prover.fst
@@ -167,15 +167,16 @@ let rec prover
           let open Pulse.PP in
           let msg = [
             text "Error in proving precondition";
-            doc_of_string "Cannot prove:" ^^
+            text "Cannot prove:" ^^
                 indent (pp q);
-            doc_of_string "In the context:" ^^
-                indent (pp (list_as_vprop pst.remaining_ctxt));
-            doc_of_string "The prover was started with goal:" ^^
-                indent (pp preamble.goals);
-            doc_of_string "and initial context:" ^^
-                indent (pp preamble.ctxt);
-          ]
+            text "In the context:" ^^
+                indent (pp (list_as_vprop pst.remaining_ctxt))
+          ] @ (if Pulse.Config.debug_flag "initial_solver_state" then [
+                text "The prover was started with goal:" ^^
+                    indent (pp preamble.goals);
+                text "and initial context:" ^^
+                    indent (pp preamble.ctxt);
+               ] else [])
           in
           // GM: I feel I should use (Some q.range) instead of None, but that makes
           // several error locations worse.
@@ -398,6 +399,9 @@ let prove_post_hint (#g:env) (#ctxt:vprop)
           text "Error in proving postcondition";
           text "Inferred postcondition additionally contains" ^^
             indent (pp remaining_ctxt);
+          (if Tm_Star? remaining_ctxt.t
+           then text "Did you forget to free these resources?"
+           else text "Did you forget to free this resource?");
         ]
       | Some d ->
         let k_post

--- a/lib/steel/pulse/Pulse.Config.fst
+++ b/lib/steel/pulse/Pulse.Config.fst
@@ -1,4 +1,10 @@
 module Pulse.Config
 
+open FStar.Tactics.V2
+
 (* This is currently unused, we use the --ext option instead. *)
 let join_goals : bool = false
+
+let debug_flag (s:string) : Tac bool =
+  let v = ext_getv ("pulse:" ^ s) in
+  v <> "" && v <> "0" && v <> "false"

--- a/lib/steel/pulse/Pulse.Config.fsti
+++ b/lib/steel/pulse/Pulse.Config.fsti
@@ -1,3 +1,10 @@
 module Pulse.Config
 
+open FStar.Tactics.V2
+
 val join_goals : bool
+
+(* Checks if a boolean debug flag `s` is enabled, i.e.
+if the extension option `pulse:s` was given, and its value
+is not "0" or "false". *)
+val debug_flag : string -> Tac bool

--- a/lib/steel/pulse/Pulse.PP.fst
+++ b/lib/steel/pulse/Pulse.PP.fst
@@ -1,0 +1,71 @@
+module Pulse.PP
+
+include FStar.Stubs.Pprint
+
+open FStar.Tactics
+open FStar.Tactics.Typeclasses
+open FStar.Stubs.Pprint
+open Pulse.Typing
+open Pulse.Syntax.Base
+open Pulse.Syntax.Printer
+
+open Pulse.Show
+
+(* A helper to create wrapped text *)
+val text : string -> FStar.Stubs.Pprint.document
+let text (s:string) : FStar.Stubs.Pprint.document =
+  flow (break_ 1) (words s)
+
+class printable (a:Type) = {
+  pp : a -> Tac document;
+}
+
+(* Repurposing a show instance *)
+let from_show #a {| d : tac_showable a |} : printable a = {
+  pp = (fun x -> arbitrary_string (show x));
+}
+
+instance _ : printable string = from_show
+instance _ : printable unit   = from_show
+instance _ : printable bool   = from_show
+instance _ : printable int    = from_show
+
+instance _ : printable ctag = from_show
+
+instance showable_option (a:Type) (_ : printable a) : printable (option a) = {
+  pp = (function None -> doc_of_string "None"
+                 | Some v -> doc_of_string "Some" ^/^ pp v);
+}
+
+// Cannot use Pprint.separate_map, it takes a pure func
+private
+let rec separate_map (sep: document) (f : 'a -> Tac document) (l : list 'a) : Tac document =
+  match l with
+  | [] -> empty
+  | [x] -> f x
+  | x::xs -> f x ^^ sep ^/^ separate_map sep f xs
+
+instance showable_list (a:Type) (_ : printable a) : printable (list a) = {
+  pp = (fun l -> brackets (separate_map comma pp l))
+}
+
+instance _ : printable term = from_show
+instance _ : printable universe = from_show
+instance _ : printable comp = from_show
+
+instance _ : printable env = {
+  pp = Pulse.Typing.Env.env_to_doc;
+}
+
+let pp_record (flds : list (string & document)) : Tac document =
+  braces (
+    separate_map (doc_of_string ";") (fun (s, d) -> doc_of_string s ^/^ equals ^/^ d) flds)
+
+instance _ : printable post_hint_t = {
+  pp = (fun (h:post_hint_t) ->
+          pp_record [ "g", pp h.g
+                    ; "ctag_hint", pp h.ctag_hint
+                    ; "ret_ty", pp h.ret_ty
+                    ; "u", pp h.u
+                    ; "post", pp h.post ]);
+}

--- a/lib/steel/pulse/Pulse.PP.fst
+++ b/lib/steel/pulse/Pulse.PP.fst
@@ -16,6 +16,19 @@ val text : string -> FStar.Stubs.Pprint.document
 let text (s:string) : FStar.Stubs.Pprint.document =
   flow (break_ 1) (words s)
 
+(* Nests a document 2 levels deep, as a block. It inserts a hardline
+before the doc, so if you want to format something as
+
+  hdr
+    subdoc
+  tail
+
+  you should write  hdr ^^ indent (subdoc) ^/^ tail.  Note the ^^ vs ^/^.
+*)
+val indent : document -> document
+let indent d =
+  nest 2 (hardline ^^ align d)
+
 class printable (a:Type) = {
   pp : a -> Tac document;
 }

--- a/lib/steel/pulse/Pulse.RuntimeUtils.fsti
+++ b/lib/steel/pulse/Pulse.RuntimeUtils.fsti
@@ -3,7 +3,6 @@ open FStar.Tactics
 module T = FStar.Tactics
 type context = FStar.Sealed.Inhabited.sealed #(list (string & option range)) []
 val extend_context (tag:string) (r:option range) (ctx:context) : context
-val is_pulse_option_set (x:string) : bool
 val debug_at_level_no_module (s:string) : bool
 val debug_at_level (g:env) (s:string) : bool
 val print_exn (e:exn) : string

--- a/lib/steel/pulse/Pulse.Show.fst
+++ b/lib/steel/pulse/Pulse.Show.fst
@@ -15,7 +15,7 @@ instance _ : tac_showable string = {
 }
 
 instance _ : tac_showable unit = {
-  show = (fun () -> "");
+  show = (fun () -> "()");
 }
 
 instance _ : tac_showable bool = {

--- a/lib/steel/pulse/Pulse.Syntax.Printer.fst
+++ b/lib/steel/pulse/Pulse.Syntax.Printer.fst
@@ -82,6 +82,39 @@ let rec term_to_string' (level:string) (t:term)
       T.term_to_string t
 let term_to_string t = term_to_string' "" t
 
+let rec term_to_doc t
+  : T.Tac document
+  = match t.t with
+    | Tm_Emp -> doc_of_string "emp"
+
+    | Tm_Pure p -> doc_of_string "pure" ^/^ parens (term_to_doc p)
+    | Tm_Star p1 p2 ->
+      infix 2 1 (doc_of_string "**")
+                (term_to_doc p1)
+                (term_to_doc p2)
+
+    | Tm_ExistsSL _ b body ->
+      parens (doc_of_string "exists" ^/^ parens (doc_of_string (T.unseal b.binder_ppname.name)
+                                                  ^^ doc_of_string ":"
+                                                  ^^ term_to_doc b.binder_ty)
+              ^^ doc_of_string "."
+              ^/^ term_to_doc body)
+
+    | Tm_ForallSL u b body ->
+      parens (doc_of_string "forall" ^/^ parens (doc_of_string (T.unseal b.binder_ppname.name)
+                                                  ^^ doc_of_string ":"
+                                                  ^^ term_to_doc b.binder_ty)
+              ^^ doc_of_string "."
+              ^/^ term_to_doc body)
+
+    | Tm_VProp -> doc_of_string "vprop"
+    | Tm_Inames -> doc_of_string "inames"
+    | Tm_EmpInames -> doc_of_string "emp_inames"
+    | Tm_Unknown -> doc_of_string "_"
+    | Tm_FStar t ->
+      // Should call term_to_doc when available
+      doc_of_string (T.term_to_string t)
+
 let binder_to_string (b:binder)
   : T.Tac string
   = sprintf "%s:%s" 

--- a/lib/steel/pulse/Pulse.Syntax.Printer.fsti
+++ b/lib/steel/pulse/Pulse.Syntax.Printer.fsti
@@ -2,6 +2,7 @@ module Pulse.Syntax.Printer
 open Pulse.Syntax.Base
 module R = FStar.Reflection.V2
 module T = FStar.Tactics.V2
+open FStar.Stubs.Pprint
 
 val tot_or_ghost_to_string (eff:T.tot_or_ghost) : string
 val name_to_string (f:R.name) : string
@@ -9,6 +10,7 @@ val name_to_string (f:R.name) : string
 val univ_to_string (u:universe) : string
 val qual_to_string (q:option qualifier) : string
 val term_to_string (t:term) : T.Tac string
+val term_to_doc (t:term) : T.Tac document
 val binder_to_string (b:binder) : T.Tac string
 val ctag_to_string (c:ctag) : string
 val comp_to_string (c:comp) : T.Tac string

--- a/lib/steel/pulse/Pulse.Typing.Env.fst
+++ b/lib/steel/pulse/Pulse.Typing.Env.fst
@@ -351,7 +351,7 @@ let env_to_doc (e:env) : T.Tac document =
   let pp1 : ((var & typ) & ppname) -> T.Tac document =
     fun ((n, t), x) ->
       doc_of_string (T.unseal x.name) ^^ doc_of_string "#" ^^ doc_of_string (string_of_int n)
-        ^^ Pulse.Syntax.Printer.term_to_doc t
+        ^^ doc_of_string " : " ^^ Pulse.Syntax.Printer.term_to_doc t
   in
   brackets (separate_map comma pp1 (T.zip e.bs e.names))
 
@@ -366,8 +366,9 @@ let get_range (g:env) (r:option range) : T.Tac range =
 let fail_doc (#a:Type) (g:env) (r:option range) (msg:list Pprint.document) =
   let r = get_range g r in
   let msg =
+    let indent d = nest 2 (hardline ^^ align d) in
     if Pulse.Config.debug_flag "env_on_err"
-    then msg @ [doc_of_string "In environment" ^/^ env_to_doc g]
+    then msg @ [doc_of_string "In typing environment:" ^^ indent (env_to_doc g)]
     else msg
   in
   let issue = FStar.Issue.mk_issue_doc "Error" msg (Some r) None (ctxt_to_list g) in

--- a/lib/steel/pulse/Pulse.Typing.Env.fst
+++ b/lib/steel/pulse/Pulse.Typing.Env.fst
@@ -363,23 +363,32 @@ let get_range (g:env) (r:option range) : T.Tac range =
       then range_of_env g
       else r
 
-let fail (#a:Type) (g:env) (r:option range) (msg:string) =
+let fail_doc (#a:Type) (g:env) (r:option range) (msg:list Pprint.document) =
   let r = get_range g r in
   let msg =
     if RU.is_pulse_option_set "env_on_err"
-    then Printf.sprintf "%s\nIn environment\n%s\n" msg (env_to_string g)
+    then msg @ [doc_of_string "In environment" ^/^ env_to_doc g]
     else msg
   in
-  let issue = FStar.Issue.mk_issue "Error" msg (Some r) None (ctxt_to_list g) in
+  let issue = FStar.Issue.mk_issue_doc "Error" msg (Some r) None (ctxt_to_list g) in
   T.log_issues [issue];
   T.fail "Pulse checker failed"
 
-let warn (g:env) (r:option range) (msg:string) : T.Tac unit =
+let warn_doc (g:env) (r:option range) (msg:list Pprint.document) : T.Tac unit =
   let r = get_range g r in
-  let issue = FStar.Issue.mk_issue "Warning" msg (Some r) None (ctxt_to_list g) in
+  let issue = FStar.Issue.mk_issue_doc "Warning" msg (Some r) None (ctxt_to_list g) in
   T.log_issues [issue]
 
-let info (g:env) (r:option range) (msg:string) =
+let info_doc (g:env) (r:option range) (msg:list Pprint.document) =
   let r = get_range g r in
-  let issue = FStar.Issue.mk_issue "Info" msg (Some r) None (ctxt_to_list g) in
+  let issue = FStar.Issue.mk_issue_doc "Info" msg (Some r) None (ctxt_to_list g) in
   T.log_issues [issue]
+
+let fail (#a:Type) (g:env) (r:option range) (msg:string) =
+  fail_doc g r [Pprint.arbitrary_string msg]
+
+let warn (g:env) (r:option range) (msg:string) : T.Tac unit =
+  warn_doc g r [Pprint.arbitrary_string msg]
+
+let info (g:env) (r:option range) (msg:string) =
+  info_doc g r [Pprint.arbitrary_string msg]

--- a/lib/steel/pulse/Pulse.Typing.Env.fst
+++ b/lib/steel/pulse/Pulse.Typing.Env.fst
@@ -366,7 +366,7 @@ let get_range (g:env) (r:option range) : T.Tac range =
 let fail_doc (#a:Type) (g:env) (r:option range) (msg:list Pprint.document) =
   let r = get_range g r in
   let msg =
-    if RU.is_pulse_option_set "env_on_err"
+    if Pulse.Config.debug_flag "env_on_err"
     then msg @ [doc_of_string "In environment" ^/^ env_to_doc g]
     else msg
   in

--- a/lib/steel/pulse/Pulse.Typing.Env.fsti
+++ b/lib/steel/pulse/Pulse.Typing.Env.fsti
@@ -8,6 +8,7 @@ module L = FStar.List.Tot
 
 module RT = FStar.Reflection.Typing
 module T = FStar.Tactics.V2
+module Pprint = FStar.Stubs.Pprint
 
 type binding = var & typ
 type env_bindings = list binding
@@ -177,6 +178,7 @@ val print_context (g:env) : T.Tac string
 val print_issue (g:env) (i:FStar.Issue.issue) : T.Tac string 
 val print_issues (g:env) (i:list FStar.Issue.issue) : T.Tac string
 val env_to_string (g:env) : T.Tac string
+val env_to_doc (g:env) : T.Tac FStar.Stubs.Pprint.document
 val get_range (g:env) (r:option range) : T.Tac range
 val fail (#a:Type) (g:env) (r:option range) (msg:string) 
   : T.TAC a (fun _ post -> forall ex ps. post FStar.Tactics.Result.(Failed ex ps))

--- a/lib/steel/pulse/Pulse.Typing.Env.fsti
+++ b/lib/steel/pulse/Pulse.Typing.Env.fsti
@@ -180,6 +180,17 @@ val print_issues (g:env) (i:list FStar.Issue.issue) : T.Tac string
 val env_to_string (g:env) : T.Tac string
 val env_to_doc (g:env) : T.Tac FStar.Stubs.Pprint.document
 val get_range (g:env) (r:option range) : T.Tac range
+
+val fail_doc (#a:Type) (g:env) (r:option range) (msg:list Pprint.document)
+  : T.TacH a (requires fun _ -> True) (ensures fun _ r -> FStar.Tactics.Result.Failed? r)
+
+val warn_doc (g:env) (r:option range) (msg:list Pprint.document)
+  : T.Tac unit
+
+val info_doc (g:env) (r:option range) (msg:list Pprint.document)
+  : T.Tac unit
+
+
 val fail (#a:Type) (g:env) (r:option range) (msg:string) 
   : T.TAC a (fun _ post -> forall ex ps. post FStar.Tactics.Result.(Failed ex ps))
 

--- a/src/ocaml/plugin/Pulse_RuntimeUtils.ml
+++ b/src/ocaml/plugin/Pulse_RuntimeUtils.ml
@@ -21,8 +21,3 @@ let unfold_def (g:FStar_Reflection_Types.env) (head:string) (names:string list) 
              UnfoldOnly (FStar_Ident.lid_of_str head::List.map FStar_Ident.lid_of_str names)] g t)
 let env_set_range (e:FStar_Reflection_Types.env) (r:FStar_Range.range) =
    FStar_TypeChecker_Env.set_range e r
-
-let is_pulse_option_set (x:string) : bool =
-  let key = ("pulse:"^x) in
-  let value = FStar_Options.ext_getv key in
-  value <> ""

--- a/src/ocaml/plugin/generated/Pulse_Checker_Prover.ml
+++ b/src/ocaml/plugin/generated/Pulse_Checker_Prover.ml
@@ -305,7 +305,7 @@ let rec (prove_pures :
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Checker.Prover.fst"
                                 (Prims.of_int (97)) (Prims.of_int (4))
-                                (Prims.of_int (105)) (Prims.of_int (12)))))
+                                (Prims.of_int (109)) (Prims.of_int (12)))))
                        (Obj.magic
                           (Pulse_Checker_Prover_IntroPure.intro_pure preamble
                              pst p unsolved' ()))
@@ -319,50 +319,71 @@ let rec (prove_pures :
                                          (Obj.magic
                                             (FStar_Range.mk_range
                                                "Pulse.Checker.Prover.fst"
-                                               (Prims.of_int (99))
-                                               (Prims.of_int (24))
-                                               (Prims.of_int (99))
-                                               (Prims.of_int (100)))))
+                                               (Prims.of_int (100))
+                                               (Prims.of_int (28))
+                                               (Prims.of_int (103))
+                                               (Prims.of_int (8)))))
                                       (FStar_Sealed.seal
                                          (Obj.magic
                                             (FStar_Range.mk_range
                                                "Pulse.Checker.Prover.fst"
-                                               (Prims.of_int (99))
+                                               (Prims.of_int (100))
                                                (Prims.of_int (7))
-                                               (Prims.of_int (99))
-                                               (Prims.of_int (100)))))
+                                               (Prims.of_int (103))
+                                               (Prims.of_int (8)))))
                                       (Obj.magic
                                          (FStar_Tactics_Effect.tac_bind
                                             (FStar_Sealed.seal
                                                (Obj.magic
                                                   (FStar_Range.mk_range
                                                      "Pulse.Checker.Prover.fst"
-                                                     (Prims.of_int (99))
-                                                     (Prims.of_int (79))
-                                                     (Prims.of_int (99))
-                                                     (Prims.of_int (99)))))
+                                                     (Prims.of_int (101))
+                                                     (Prims.of_int (9))
+                                                     (Prims.of_int (102))
+                                                     (Prims.of_int (15)))))
                                             (FStar_Sealed.seal
                                                (Obj.magic
                                                   (FStar_Range.mk_range
-                                                     "prims.fst"
-                                                     (Prims.of_int (590))
-                                                     (Prims.of_int (19))
-                                                     (Prims.of_int (590))
-                                                     (Prims.of_int (31)))))
+                                                     "Pulse.Checker.Prover.fst"
+                                                     (Prims.of_int (100))
+                                                     (Prims.of_int (28))
+                                                     (Prims.of_int (103))
+                                                     (Prims.of_int (8)))))
                                             (Obj.magic
-                                               (Pulse_Syntax_Printer.term_to_string
-                                                  p))
+                                               (FStar_Tactics_Effect.tac_bind
+                                                  (FStar_Sealed.seal
+                                                     (Obj.magic
+                                                        (FStar_Range.mk_range
+                                                           "Pulse.Checker.Prover.fst"
+                                                           (Prims.of_int (102))
+                                                           (Prims.of_int (11))
+                                                           (Prims.of_int (102))
+                                                           (Prims.of_int (15)))))
+                                                  (FStar_Sealed.seal
+                                                     (Obj.magic
+                                                        (FStar_Range.mk_range
+                                                           "Pulse.Checker.Prover.fst"
+                                                           (Prims.of_int (101))
+                                                           (Prims.of_int (9))
+                                                           (Prims.of_int (102))
+                                                           (Prims.of_int (15)))))
+                                                  (Obj.magic
+                                                     (Pulse_PP.pp
+                                                        Pulse_PP.uu___44 p))
+                                                  (fun uu___1 ->
+                                                     FStar_Tactics_Effect.lift_div_tac
+                                                       (fun uu___2 ->
+                                                          FStar_Pprint.op_Hat_Slash_Hat
+                                                            (Pulse_PP.text
+                                                               "Cannot prove pure proposition")
+                                                            uu___1))))
                                             (fun uu___1 ->
                                                FStar_Tactics_Effect.lift_div_tac
-                                                 (fun uu___2 ->
-                                                    Prims.strcat
-                                                      "prover error: cannot prove pure "
-                                                      (Prims.strcat uu___1
-                                                         "\n")))))
+                                                 (fun uu___2 -> [uu___1]))))
                                       (fun uu___1 ->
                                          (fun uu___1 ->
                                             Obj.magic
-                                              (Pulse_Typing_Env.fail
+                                              (Pulse_Typing_Env.fail_doc
                                                  pst.Pulse_Checker_Prover_Base.pg
                                                  FStar_Pervasives_Native.None
                                                  uu___1)) uu___1))
@@ -373,17 +394,17 @@ let rec (prove_pures :
                                          (Obj.magic
                                             (FStar_Range.mk_range
                                                "Pulse.Checker.Prover.fst"
-                                               (Prims.of_int (101))
+                                               (Prims.of_int (105))
                                                (Prims.of_int (18))
-                                               (Prims.of_int (101))
+                                               (Prims.of_int (105))
                                                (Prims.of_int (34)))))
                                       (FStar_Sealed.seal
                                          (Obj.magic
                                             (FStar_Range.mk_range
                                                "Pulse.Checker.Prover.fst"
-                                               (Prims.of_int (101))
+                                               (Prims.of_int (105))
                                                (Prims.of_int (11))
-                                               (Prims.of_int (101))
+                                               (Prims.of_int (105))
                                                (Prims.of_int (15)))))
                                       (Obj.magic (prove_pures preamble pst1))
                                       (fun pst2 ->
@@ -396,21 +417,21 @@ let rec (prove_pures :
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Checker.Prover.fst"
-                                (Prims.of_int (108)) (Prims.of_int (6))
-                                (Prims.of_int (109)) (Prims.of_int (48)))))
+                                (Prims.of_int (112)) (Prims.of_int (6))
+                                (Prims.of_int (113)) (Prims.of_int (48)))))
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Checker.Prover.fst"
-                                (Prims.of_int (107)) (Prims.of_int (4))
-                                (Prims.of_int (109)) (Prims.of_int (48)))))
+                                (Prims.of_int (111)) (Prims.of_int (4))
+                                (Prims.of_int (113)) (Prims.of_int (48)))))
                        (Obj.magic
                           (FStar_Tactics_Effect.tac_bind
                              (FStar_Sealed.seal
                                 (Obj.magic
                                    (FStar_Range.mk_range
                                       "Pulse.Checker.Prover.fst"
-                                      (Prims.of_int (109)) (Prims.of_int (9))
-                                      (Prims.of_int (109))
+                                      (Prims.of_int (113)) (Prims.of_int (9))
+                                      (Prims.of_int (113))
                                       (Prims.of_int (47)))))
                              (FStar_Sealed.seal
                                 (Obj.magic
@@ -449,12 +470,12 @@ let rec (prover :
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.Prover.fst"
-                 (Prims.of_int (118)) (Prims.of_int (2)) (Prims.of_int (121))
+                 (Prims.of_int (122)) (Prims.of_int (2)) (Prims.of_int (125))
                  (Prims.of_int (55)))))
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.Prover.fst"
-                 (Prims.of_int (123)) (Prims.of_int (2)) (Prims.of_int (178))
+                 (Prims.of_int (127)) (Prims.of_int (2)) (Prims.of_int (183))
                  (Prims.of_int (32)))))
         (Obj.magic
            (Pulse_Checker_Prover_Util.debug_prover
@@ -464,13 +485,13 @@ let rec (prover :
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Checker.Prover.fst"
-                            (Prims.of_int (121)) (Prims.of_int (6))
-                            (Prims.of_int (121)) (Prims.of_int (54)))))
+                            (Prims.of_int (125)) (Prims.of_int (6))
+                            (Prims.of_int (125)) (Prims.of_int (54)))))
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Checker.Prover.fst"
-                            (Prims.of_int (119)) (Prims.of_int (4))
-                            (Prims.of_int (121)) (Prims.of_int (54)))))
+                            (Prims.of_int (123)) (Prims.of_int (4))
+                            (Prims.of_int (125)) (Prims.of_int (54)))))
                    (Obj.magic
                       (Pulse_Syntax_Printer.term_to_string
                          (Pulse_Typing_Combinators.list_as_vprop
@@ -483,17 +504,17 @@ let rec (prover :
                                  (Obj.magic
                                     (FStar_Range.mk_range
                                        "Pulse.Checker.Prover.fst"
-                                       (Prims.of_int (119))
+                                       (Prims.of_int (123))
                                        (Prims.of_int (4))
-                                       (Prims.of_int (121))
+                                       (Prims.of_int (125))
                                        (Prims.of_int (54)))))
                               (FStar_Sealed.seal
                                  (Obj.magic
                                     (FStar_Range.mk_range
                                        "Pulse.Checker.Prover.fst"
-                                       (Prims.of_int (119))
+                                       (Prims.of_int (123))
                                        (Prims.of_int (4))
-                                       (Prims.of_int (121))
+                                       (Prims.of_int (125))
                                        (Prims.of_int (54)))))
                               (Obj.magic
                                  (FStar_Tactics_Effect.tac_bind
@@ -501,9 +522,9 @@ let rec (prover :
                                        (Obj.magic
                                           (FStar_Range.mk_range
                                              "Pulse.Checker.Prover.fst"
-                                             (Prims.of_int (120))
+                                             (Prims.of_int (124))
                                              (Prims.of_int (6))
-                                             (Prims.of_int (120))
+                                             (Prims.of_int (124))
                                              (Prims.of_int (60)))))
                                     (FStar_Sealed.seal
                                        (Obj.magic
@@ -546,14 +567,14 @@ let rec (prover :
                              (Obj.magic
                                 (FStar_Range.mk_range
                                    "Pulse.Checker.Prover.fst"
-                                   (Prims.of_int (126)) (Prims.of_int (14))
-                                   (Prims.of_int (126)) (Prims.of_int (45)))))
+                                   (Prims.of_int (130)) (Prims.of_int (14))
+                                   (Prims.of_int (130)) (Prims.of_int (45)))))
                           (FStar_Sealed.seal
                              (Obj.magic
                                 (FStar_Range.mk_range
                                    "Pulse.Checker.Prover.fst"
-                                   (Prims.of_int (128)) (Prims.of_int (4))
-                                   (Prims.of_int (178)) (Prims.of_int (32)))))
+                                   (Prims.of_int (132)) (Prims.of_int (4))
+                                   (Prims.of_int (183)) (Prims.of_int (32)))))
                           (Obj.magic
                              (Pulse_Checker_Prover_ElimExists.elim_exists_pst
                                 preamble pst0))
@@ -565,17 +586,17 @@ let rec (prover :
                                         (Obj.magic
                                            (FStar_Range.mk_range
                                               "Pulse.Checker.Prover.fst"
-                                              (Prims.of_int (128))
+                                              (Prims.of_int (132))
                                               (Prims.of_int (4))
-                                              (Prims.of_int (130))
+                                              (Prims.of_int (134))
                                               (Prims.of_int (62)))))
                                      (FStar_Sealed.seal
                                         (Obj.magic
                                            (FStar_Range.mk_range
                                               "Pulse.Checker.Prover.fst"
-                                              (Prims.of_int (130))
+                                              (Prims.of_int (134))
                                               (Prims.of_int (63))
-                                              (Prims.of_int (178))
+                                              (Prims.of_int (183))
                                               (Prims.of_int (32)))))
                                      (Obj.magic
                                         (Pulse_Checker_Prover_Util.debug_prover
@@ -586,9 +607,9 @@ let rec (prover :
                                                    (Obj.magic
                                                       (FStar_Range.mk_range
                                                          "Pulse.Checker.Prover.fst"
-                                                         (Prims.of_int (130))
+                                                         (Prims.of_int (134))
                                                          (Prims.of_int (8))
-                                                         (Prims.of_int (130))
+                                                         (Prims.of_int (134))
                                                          (Prims.of_int (61)))))
                                                 (FStar_Sealed.seal
                                                    (Obj.magic
@@ -617,17 +638,17 @@ let rec (prover :
                                                    (Obj.magic
                                                       (FStar_Range.mk_range
                                                          "Pulse.Checker.Prover.fst"
-                                                         (Prims.of_int (132))
+                                                         (Prims.of_int (136))
                                                          (Prims.of_int (14))
-                                                         (Prims.of_int (132))
+                                                         (Prims.of_int (136))
                                                          (Prims.of_int (40)))))
                                                 (FStar_Sealed.seal
                                                    (Obj.magic
                                                       (FStar_Range.mk_range
                                                          "Pulse.Checker.Prover.fst"
-                                                         (Prims.of_int (134))
+                                                         (Prims.of_int (138))
                                                          (Prims.of_int (4))
-                                                         (Prims.of_int (178))
+                                                         (Prims.of_int (183))
                                                          (Prims.of_int (32)))))
                                                 (Obj.magic
                                                    (Pulse_Checker_Prover_ElimPure.elim_pure_pst
@@ -640,17 +661,17 @@ let rec (prover :
                                                               (Obj.magic
                                                                  (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (134))
+                                                                    (Prims.of_int (138))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (136))
+                                                                    (Prims.of_int (140))
                                                                     (Prims.of_int (62)))))
                                                            (FStar_Sealed.seal
                                                               (Obj.magic
                                                                  (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (136))
+                                                                    (Prims.of_int (140))
                                                                     (Prims.of_int (63))
-                                                                    (Prims.of_int (178))
+                                                                    (Prims.of_int (183))
                                                                     (Prims.of_int (32)))))
                                                            (Obj.magic
                                                               (Pulse_Checker_Prover_Util.debug_prover
@@ -662,9 +683,9 @@ let rec (prover :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (136))
+                                                                    (Prims.of_int (140))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (136))
+                                                                    (Prims.of_int (140))
                                                                     (Prims.of_int (61)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -696,17 +717,17 @@ let rec (prover :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (138))
+                                                                    (Prims.of_int (142))
                                                                     (Prims.of_int (29))
-                                                                    (Prims.of_int (138))
+                                                                    (Prims.of_int (142))
                                                                     (Prims.of_int (82)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (136))
+                                                                    (Prims.of_int (140))
                                                                     (Prims.of_int (63))
-                                                                    (Prims.of_int (178))
+                                                                    (Prims.of_int (183))
                                                                     (Prims.of_int (32)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -733,17 +754,17 @@ let rec (prover :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (140))
+                                                                    (Prims.of_int (144))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (142))
+                                                                    (Prims.of_int (146))
                                                                     (Prims.of_int (87)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (142))
+                                                                    (Prims.of_int (146))
                                                                     (Prims.of_int (88))
-                                                                    (Prims.of_int (178))
+                                                                    (Prims.of_int (183))
                                                                     (Prims.of_int (32)))))
                                                                     (Obj.magic
                                                                     (Pulse_Checker_Prover_Util.debug_prover
@@ -755,17 +776,17 @@ let rec (prover :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (142))
+                                                                    (Prims.of_int (146))
                                                                     (Prims.of_int (47))
-                                                                    (Prims.of_int (142))
+                                                                    (Prims.of_int (146))
                                                                     (Prims.of_int (86)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (141))
+                                                                    (Prims.of_int (145))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (142))
+                                                                    (Prims.of_int (146))
                                                                     (Prims.of_int (86)))))
                                                                     (Obj.magic
                                                                     (Pulse_Syntax_Printer.term_to_string
@@ -781,17 +802,17 @@ let rec (prover :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (141))
+                                                                    (Prims.of_int (145))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (142))
+                                                                    (Prims.of_int (146))
                                                                     (Prims.of_int (86)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (141))
+                                                                    (Prims.of_int (145))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (142))
+                                                                    (Prims.of_int (146))
                                                                     (Prims.of_int (86)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -799,9 +820,9 @@ let rec (prover :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (142))
+                                                                    (Prims.of_int (146))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (142))
+                                                                    (Prims.of_int (146))
                                                                     (Prims.of_int (46)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -847,17 +868,17 @@ let rec (prover :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (144))
+                                                                    (Prims.of_int (148))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (144))
+                                                                    (Prims.of_int (148))
                                                                     (Prims.of_int (49)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (146))
+                                                                    (Prims.of_int (150))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (178))
+                                                                    (Prims.of_int (183))
                                                                     (Prims.of_int (32)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -878,17 +899,17 @@ let rec (prover :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (146))
+                                                                    (Prims.of_int (150))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (148))
+                                                                    (Prims.of_int (152))
                                                                     (Prims.of_int (56)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (150))
+                                                                    (Prims.of_int (154))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (178))
+                                                                    (Prims.of_int (183))
                                                                     (Prims.of_int (32)))))
                                                                     (Obj.magic
                                                                     (Pulse_Checker_Prover_Util.debug_prover
@@ -900,9 +921,9 @@ let rec (prover :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (148))
+                                                                    (Prims.of_int (152))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (148))
+                                                                    (Prims.of_int (152))
                                                                     (Prims.of_int (55)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -958,17 +979,17 @@ let rec (prover :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (154))
+                                                                    (Prims.of_int (158))
                                                                     (Prims.of_int (33))
-                                                                    (Prims.of_int (154))
+                                                                    (Prims.of_int (158))
                                                                     (Prims.of_int (85)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (153))
+                                                                    (Prims.of_int (157))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (178))
+                                                                    (Prims.of_int (183))
                                                                     (Prims.of_int (32)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -995,17 +1016,17 @@ let rec (prover :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (155))
+                                                                    (Prims.of_int (159))
                                                                     (Prims.of_int (16))
-                                                                    (Prims.of_int (155))
+                                                                    (Prims.of_int (159))
                                                                     (Prims.of_int (53)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (156))
+                                                                    (Prims.of_int (160))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (178))
+                                                                    (Prims.of_int (183))
                                                                     (Prims.of_int (32)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -1044,17 +1065,17 @@ let rec (prover :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (159))
+                                                                    (Prims.of_int (163))
                                                                     (Prims.of_int (22))
-                                                                    (Prims.of_int (159))
+                                                                    (Prims.of_int (163))
                                                                     (Prims.of_int (43)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (160))
+                                                                    (Prims.of_int (164))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (178))
+                                                                    (Prims.of_int (183))
                                                                     (Prims.of_int (32)))))
                                                                     (Obj.magic
                                                                     (match_q
@@ -1078,17 +1099,17 @@ let rec (prover :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (164))
+                                                                    (Prims.of_int (168))
                                                                     (Prims.of_int (20))
-                                                                    (Prims.of_int (173))
+                                                                    (Prims.of_int (178))
                                                                     (Prims.of_int (11)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (177))
+                                                                    (Prims.of_int (182))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (177))
+                                                                    (Prims.of_int (182))
                                                                     (Prims.of_int (34)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1096,17 +1117,17 @@ let rec (prover :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (165))
-                                                                    (Prims.of_int (12))
-                                                                    (Prims.of_int (166))
-                                                                    (Prims.of_int (30)))))
+                                                                    (Prims.of_int (168))
+                                                                    (Prims.of_int (20))
+                                                                    (Prims.of_int (178))
+                                                                    (Prims.of_int (11)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (164))
+                                                                    (Prims.of_int (168))
                                                                     (Prims.of_int (20))
-                                                                    (Prims.of_int (173))
+                                                                    (Prims.of_int (178))
                                                                     (Prims.of_int (11)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1114,39 +1135,57 @@ let rec (prover :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (166))
-                                                                    (Prims.of_int (16))
-                                                                    (Prims.of_int (166))
-                                                                    (Prims.of_int (30)))))
+                                                                    (Prims.of_int (170))
+                                                                    (Prims.of_int (12))
+                                                                    (Prims.of_int (171))
+                                                                    (Prims.of_int (29)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (165))
-                                                                    (Prims.of_int (12))
-                                                                    (Prims.of_int (166))
-                                                                    (Prims.of_int (30)))))
+                                                                    (Prims.of_int (168))
+                                                                    (Prims.of_int (20))
+                                                                    (Prims.of_int (178))
+                                                                    (Prims.of_int (11)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (166))
-                                                                    (Prims.of_int (24))
-                                                                    (Prims.of_int (166))
-                                                                    (Prims.of_int (30)))))
+                                                                    (Prims.of_int (171))
+                                                                    (Prims.of_int (16))
+                                                                    (Prims.of_int (171))
+                                                                    (Prims.of_int (29)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (166))
+                                                                    (Prims.of_int (170))
+                                                                    (Prims.of_int (12))
+                                                                    (Prims.of_int (171))
+                                                                    (Prims.of_int (29)))))
+                                                                    (Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Prover.fst"
+                                                                    (Prims.of_int (171))
+                                                                    (Prims.of_int (23))
+                                                                    (Prims.of_int (171))
+                                                                    (Prims.of_int (29)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Prover.fst"
+                                                                    (Prims.of_int (171))
                                                                     (Prims.of_int (16))
-                                                                    (Prims.of_int (166))
-                                                                    (Prims.of_int (30)))))
+                                                                    (Prims.of_int (171))
+                                                                    (Prims.of_int (29)))))
                                                                     (Obj.magic
                                                                     (Pulse_PP.pp
-                                                                    Pulse_PP.uu___42
+                                                                    Pulse_PP.uu___44
                                                                     q))
                                                                     (fun
                                                                     uu___9 ->
@@ -1154,7 +1193,7 @@ let rec (prover :
                                                                     (fun
                                                                     uu___10
                                                                     ->
-                                                                    FStar_Pprint.bquotes
+                                                                    Pulse_PP.indent
                                                                     uu___9))))
                                                                     (fun
                                                                     uu___9 ->
@@ -1162,9 +1201,9 @@ let rec (prover :
                                                                     (fun
                                                                     uu___10
                                                                     ->
-                                                                    FStar_Pprint.op_Hat_Slash_Hat
+                                                                    FStar_Pprint.op_Hat_Hat
                                                                     (FStar_Pprint.doc_of_string
-                                                                    "Cannot prove vprop")
+                                                                    "Cannot prove:")
                                                                     uu___9))))
                                                                     (fun
                                                                     uu___9 ->
@@ -1176,17 +1215,17 @@ let rec (prover :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (164))
+                                                                    (Prims.of_int (168))
                                                                     (Prims.of_int (20))
-                                                                    (Prims.of_int (173))
+                                                                    (Prims.of_int (178))
                                                                     (Prims.of_int (11)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (164))
+                                                                    (Prims.of_int (168))
                                                                     (Prims.of_int (20))
-                                                                    (Prims.of_int (173))
+                                                                    (Prims.of_int (178))
                                                                     (Prims.of_int (11)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1194,17 +1233,17 @@ let rec (prover :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (167))
+                                                                    (Prims.of_int (172))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (168))
-                                                                    (Prims.of_int (63)))))
+                                                                    (Prims.of_int (173))
+                                                                    (Prims.of_int (62)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (164))
+                                                                    (Prims.of_int (168))
                                                                     (Prims.of_int (20))
-                                                                    (Prims.of_int (173))
+                                                                    (Prims.of_int (178))
                                                                     (Prims.of_int (11)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1212,39 +1251,39 @@ let rec (prover :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (168))
+                                                                    (Prims.of_int (173))
                                                                     (Prims.of_int (16))
-                                                                    (Prims.of_int (168))
-                                                                    (Prims.of_int (63)))))
+                                                                    (Prims.of_int (173))
+                                                                    (Prims.of_int (62)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (167))
+                                                                    (Prims.of_int (172))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (168))
-                                                                    (Prims.of_int (63)))))
+                                                                    (Prims.of_int (173))
+                                                                    (Prims.of_int (62)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (168))
-                                                                    (Prims.of_int (24))
-                                                                    (Prims.of_int (168))
-                                                                    (Prims.of_int (63)))))
+                                                                    (Prims.of_int (173))
+                                                                    (Prims.of_int (23))
+                                                                    (Prims.of_int (173))
+                                                                    (Prims.of_int (62)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (168))
+                                                                    (Prims.of_int (173))
                                                                     (Prims.of_int (16))
-                                                                    (Prims.of_int (168))
-                                                                    (Prims.of_int (63)))))
+                                                                    (Prims.of_int (173))
+                                                                    (Prims.of_int (62)))))
                                                                     (Obj.magic
                                                                     (Pulse_PP.pp
-                                                                    Pulse_PP.uu___42
+                                                                    Pulse_PP.uu___44
                                                                     (Pulse_Typing_Combinators.list_as_vprop
                                                                     pst3.Pulse_Checker_Prover_Base.remaining_ctxt)))
                                                                     (fun
@@ -1254,7 +1293,7 @@ let rec (prover :
                                                                     (fun
                                                                     uu___11
                                                                     ->
-                                                                    FStar_Pprint.bquotes
+                                                                    Pulse_PP.indent
                                                                     uu___10))))
                                                                     (fun
                                                                     uu___10
@@ -1263,9 +1302,9 @@ let rec (prover :
                                                                     (fun
                                                                     uu___11
                                                                     ->
-                                                                    FStar_Pprint.op_Hat_Slash_Hat
+                                                                    FStar_Pprint.op_Hat_Hat
                                                                     (FStar_Pprint.doc_of_string
-                                                                    "In the context")
+                                                                    "In the context:")
                                                                     uu___10))))
                                                                     (fun
                                                                     uu___10
@@ -1279,17 +1318,17 @@ let rec (prover :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (164))
+                                                                    (Prims.of_int (168))
                                                                     (Prims.of_int (20))
-                                                                    (Prims.of_int (173))
+                                                                    (Prims.of_int (178))
                                                                     (Prims.of_int (11)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (164))
+                                                                    (Prims.of_int (168))
                                                                     (Prims.of_int (20))
-                                                                    (Prims.of_int (173))
+                                                                    (Prims.of_int (178))
                                                                     (Prims.of_int (11)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1297,17 +1336,17 @@ let rec (prover :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (169))
+                                                                    (Prims.of_int (174))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (170))
-                                                                    (Prims.of_int (43)))))
+                                                                    (Prims.of_int (175))
+                                                                    (Prims.of_int (42)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (164))
+                                                                    (Prims.of_int (168))
                                                                     (Prims.of_int (20))
-                                                                    (Prims.of_int (173))
+                                                                    (Prims.of_int (178))
                                                                     (Prims.of_int (11)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1315,39 +1354,39 @@ let rec (prover :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (170))
+                                                                    (Prims.of_int (175))
                                                                     (Prims.of_int (16))
-                                                                    (Prims.of_int (170))
-                                                                    (Prims.of_int (43)))))
+                                                                    (Prims.of_int (175))
+                                                                    (Prims.of_int (42)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (169))
+                                                                    (Prims.of_int (174))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (170))
-                                                                    (Prims.of_int (43)))))
+                                                                    (Prims.of_int (175))
+                                                                    (Prims.of_int (42)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (170))
-                                                                    (Prims.of_int (24))
-                                                                    (Prims.of_int (170))
-                                                                    (Prims.of_int (43)))))
+                                                                    (Prims.of_int (175))
+                                                                    (Prims.of_int (23))
+                                                                    (Prims.of_int (175))
+                                                                    (Prims.of_int (42)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (170))
+                                                                    (Prims.of_int (175))
                                                                     (Prims.of_int (16))
-                                                                    (Prims.of_int (170))
-                                                                    (Prims.of_int (43)))))
+                                                                    (Prims.of_int (175))
+                                                                    (Prims.of_int (42)))))
                                                                     (Obj.magic
                                                                     (Pulse_PP.pp
-                                                                    Pulse_PP.uu___42
+                                                                    Pulse_PP.uu___44
                                                                     preamble.Pulse_Checker_Prover_Base.goals))
                                                                     (fun
                                                                     uu___11
@@ -1356,7 +1395,7 @@ let rec (prover :
                                                                     (fun
                                                                     uu___12
                                                                     ->
-                                                                    FStar_Pprint.bquotes
+                                                                    Pulse_PP.indent
                                                                     uu___11))))
                                                                     (fun
                                                                     uu___11
@@ -1365,9 +1404,9 @@ let rec (prover :
                                                                     (fun
                                                                     uu___12
                                                                     ->
-                                                                    FStar_Pprint.op_Hat_Slash_Hat
+                                                                    FStar_Pprint.op_Hat_Hat
                                                                     (FStar_Pprint.doc_of_string
-                                                                    "The prover was started with goal")
+                                                                    "The prover was started with goal:")
                                                                     uu___11))))
                                                                     (fun
                                                                     uu___11
@@ -1381,17 +1420,17 @@ let rec (prover :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (164))
+                                                                    (Prims.of_int (168))
                                                                     (Prims.of_int (20))
-                                                                    (Prims.of_int (173))
+                                                                    (Prims.of_int (178))
                                                                     (Prims.of_int (11)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (164))
+                                                                    (Prims.of_int (168))
                                                                     (Prims.of_int (20))
-                                                                    (Prims.of_int (173))
+                                                                    (Prims.of_int (178))
                                                                     (Prims.of_int (11)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1399,17 +1438,17 @@ let rec (prover :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (171))
+                                                                    (Prims.of_int (176))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (172))
-                                                                    (Prims.of_int (42)))))
+                                                                    (Prims.of_int (177))
+                                                                    (Prims.of_int (41)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (164))
+                                                                    (Prims.of_int (168))
                                                                     (Prims.of_int (20))
-                                                                    (Prims.of_int (173))
+                                                                    (Prims.of_int (178))
                                                                     (Prims.of_int (11)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1417,39 +1456,39 @@ let rec (prover :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (172))
+                                                                    (Prims.of_int (177))
                                                                     (Prims.of_int (16))
-                                                                    (Prims.of_int (172))
-                                                                    (Prims.of_int (42)))))
+                                                                    (Prims.of_int (177))
+                                                                    (Prims.of_int (41)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (171))
+                                                                    (Prims.of_int (176))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (172))
-                                                                    (Prims.of_int (42)))))
+                                                                    (Prims.of_int (177))
+                                                                    (Prims.of_int (41)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (172))
-                                                                    (Prims.of_int (24))
-                                                                    (Prims.of_int (172))
-                                                                    (Prims.of_int (42)))))
+                                                                    (Prims.of_int (177))
+                                                                    (Prims.of_int (23))
+                                                                    (Prims.of_int (177))
+                                                                    (Prims.of_int (41)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (172))
+                                                                    (Prims.of_int (177))
                                                                     (Prims.of_int (16))
-                                                                    (Prims.of_int (172))
-                                                                    (Prims.of_int (42)))))
+                                                                    (Prims.of_int (177))
+                                                                    (Prims.of_int (41)))))
                                                                     (Obj.magic
                                                                     (Pulse_PP.pp
-                                                                    Pulse_PP.uu___42
+                                                                    Pulse_PP.uu___44
                                                                     preamble.Pulse_Checker_Prover_Base.ctxt))
                                                                     (fun
                                                                     uu___12
@@ -1458,7 +1497,7 @@ let rec (prover :
                                                                     (fun
                                                                     uu___13
                                                                     ->
-                                                                    FStar_Pprint.bquotes
+                                                                    Pulse_PP.indent
                                                                     uu___12))))
                                                                     (fun
                                                                     uu___12
@@ -1467,9 +1506,9 @@ let rec (prover :
                                                                     (fun
                                                                     uu___13
                                                                     ->
-                                                                    FStar_Pprint.op_Hat_Slash_Hat
+                                                                    FStar_Pprint.op_Hat_Hat
                                                                     (FStar_Pprint.doc_of_string
-                                                                    "and initial context")
+                                                                    "and initial context:")
                                                                     uu___12))))
                                                                     (fun
                                                                     uu___12
@@ -1511,6 +1550,15 @@ let rec (prover :
                                                                     ::
                                                                     uu___10))))
                                                                     uu___9)))
+                                                                    (fun
+                                                                    uu___9 ->
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___10
+                                                                    ->
+                                                                    (Pulse_PP.text
+                                                                    "Error in proving precondition")
+                                                                    :: uu___9))))
                                                                     (fun
                                                                     uu___9 ->
                                                                     (fun msg
@@ -1580,13 +1628,13 @@ let (prove :
                 (FStar_Sealed.seal
                    (Obj.magic
                       (FStar_Range.mk_range "Pulse.Checker.Prover.fst"
-                         (Prims.of_int (202)) (Prims.of_int (2))
-                         (Prims.of_int (204)) (Prims.of_int (55)))))
+                         (Prims.of_int (207)) (Prims.of_int (2))
+                         (Prims.of_int (209)) (Prims.of_int (55)))))
                 (FStar_Sealed.seal
                    (Obj.magic
                       (FStar_Range.mk_range "Pulse.Checker.Prover.fst"
-                         (Prims.of_int (204)) (Prims.of_int (56))
-                         (Prims.of_int (271)) (Prims.of_int (97)))))
+                         (Prims.of_int (209)) (Prims.of_int (56))
+                         (Prims.of_int (276)) (Prims.of_int (97)))))
                 (Obj.magic
                    (Pulse_Checker_Prover_Util.debug_prover g
                       (fun uu___ ->
@@ -1595,14 +1643,14 @@ let (prove :
                               (Obj.magic
                                  (FStar_Range.mk_range
                                     "Pulse.Checker.Prover.fst"
-                                    (Prims.of_int (204)) (Prims.of_int (30))
-                                    (Prims.of_int (204)) (Prims.of_int (54)))))
+                                    (Prims.of_int (209)) (Prims.of_int (30))
+                                    (Prims.of_int (209)) (Prims.of_int (54)))))
                            (FStar_Sealed.seal
                               (Obj.magic
                                  (FStar_Range.mk_range
                                     "Pulse.Checker.Prover.fst"
-                                    (Prims.of_int (203)) (Prims.of_int (4))
-                                    (Prims.of_int (204)) (Prims.of_int (54)))))
+                                    (Prims.of_int (208)) (Prims.of_int (4))
+                                    (Prims.of_int (209)) (Prims.of_int (54)))))
                            (Obj.magic
                               (Pulse_Syntax_Printer.term_to_string goals))
                            (fun uu___1 ->
@@ -1613,17 +1661,17 @@ let (prove :
                                          (Obj.magic
                                             (FStar_Range.mk_range
                                                "Pulse.Checker.Prover.fst"
-                                               (Prims.of_int (203))
+                                               (Prims.of_int (208))
                                                (Prims.of_int (4))
-                                               (Prims.of_int (204))
+                                               (Prims.of_int (209))
                                                (Prims.of_int (54)))))
                                       (FStar_Sealed.seal
                                          (Obj.magic
                                             (FStar_Range.mk_range
                                                "Pulse.Checker.Prover.fst"
-                                               (Prims.of_int (203))
+                                               (Prims.of_int (208))
                                                (Prims.of_int (4))
-                                               (Prims.of_int (204))
+                                               (Prims.of_int (209))
                                                (Prims.of_int (54)))))
                                       (Obj.magic
                                          (FStar_Tactics_Effect.tac_bind
@@ -1631,9 +1679,9 @@ let (prove :
                                                (Obj.magic
                                                   (FStar_Range.mk_range
                                                      "Pulse.Checker.Prover.fst"
-                                                     (Prims.of_int (204))
+                                                     (Prims.of_int (209))
                                                      (Prims.of_int (6))
-                                                     (Prims.of_int (204))
+                                                     (Prims.of_int (209))
                                                      (Prims.of_int (29)))))
                                             (FStar_Sealed.seal
                                                (Obj.magic
@@ -1669,14 +1717,14 @@ let (prove :
                               (Obj.magic
                                  (FStar_Range.mk_range
                                     "Pulse.Checker.Prover.fst"
-                                    (Prims.of_int (206)) (Prims.of_int (15))
-                                    (Prims.of_int (206)) (Prims.of_int (33)))))
+                                    (Prims.of_int (211)) (Prims.of_int (15))
+                                    (Prims.of_int (211)) (Prims.of_int (33)))))
                            (FStar_Sealed.seal
                               (Obj.magic
                                  (FStar_Range.mk_range
                                     "Pulse.Checker.Prover.fst"
-                                    (Prims.of_int (220)) (Prims.of_int (6))
-                                    (Prims.of_int (271)) (Prims.of_int (97)))))
+                                    (Prims.of_int (225)) (Prims.of_int (6))
+                                    (Prims.of_int (276)) (Prims.of_int (97)))))
                            (FStar_Tactics_Effect.lift_div_tac
                               (fun uu___1 ->
                                  Pulse_Typing_Combinators.vprop_as_list ctxt))
@@ -1688,17 +1736,17 @@ let (prove :
                                          (Obj.magic
                                             (FStar_Range.mk_range
                                                "Pulse.Checker.Prover.fst"
-                                               (Prims.of_int (221))
+                                               (Prims.of_int (226))
                                                (Prims.of_int (61))
-                                               (Prims.of_int (221))
+                                               (Prims.of_int (226))
                                                (Prims.of_int (69)))))
                                       (FStar_Sealed.seal
                                          (Obj.magic
                                             (FStar_Range.mk_range
                                                "Pulse.Checker.Prover.fst"
-                                               (Prims.of_int (221))
+                                               (Prims.of_int (226))
                                                (Prims.of_int (72))
-                                               (Prims.of_int (271))
+                                               (Prims.of_int (276))
                                                (Prims.of_int (97)))))
                                       (FStar_Tactics_Effect.lift_div_tac
                                          (fun uu___1 -> ()))
@@ -1710,17 +1758,17 @@ let (prove :
                                                     (Obj.magic
                                                        (FStar_Range.mk_range
                                                           "Pulse.Checker.Prover.fst"
-                                                          (Prims.of_int (223))
+                                                          (Prims.of_int (228))
                                                           (Prims.of_int (6))
-                                                          (Prims.of_int (227))
+                                                          (Prims.of_int (232))
                                                           (Prims.of_int (12)))))
                                                  (FStar_Sealed.seal
                                                     (Obj.magic
                                                        (FStar_Range.mk_range
                                                           "Pulse.Checker.Prover.fst"
-                                                          (Prims.of_int (230))
+                                                          (Prims.of_int (235))
                                                           (Prims.of_int (43))
-                                                          (Prims.of_int (271))
+                                                          (Prims.of_int (276))
                                                           (Prims.of_int (97)))))
                                                  (FStar_Tactics_Effect.lift_div_tac
                                                     (fun uu___1 ->
@@ -1745,17 +1793,17 @@ let (prove :
                                                                (Obj.magic
                                                                   (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (232))
+                                                                    (Prims.of_int (237))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (241))
+                                                                    (Prims.of_int (246))
                                                                     (Prims.of_int (21)))))
                                                             (FStar_Sealed.seal
                                                                (Obj.magic
                                                                   (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (242))
+                                                                    (Prims.of_int (247))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (271))
+                                                                    (Prims.of_int (276))
                                                                     (Prims.of_int (97)))))
                                                             (FStar_Tactics_Effect.lift_div_tac
                                                                (fun uu___1 ->
@@ -1814,17 +1862,17 @@ let (prove :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (244))
+                                                                    (Prims.of_int (249))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (244))
+                                                                    (Prims.of_int (249))
                                                                     (Prims.of_int (25)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (244))
+                                                                    (Prims.of_int (249))
                                                                     (Prims.of_int (28))
-                                                                    (Prims.of_int (271))
+                                                                    (Prims.of_int (276))
                                                                     (Prims.of_int (97)))))
                                                                     (Obj.magic
                                                                     (prover
@@ -1840,17 +1888,17 @@ let (prove :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (247))
+                                                                    (Prims.of_int (252))
                                                                     (Prims.of_int (65))
-                                                                    (Prims.of_int (253))
+                                                                    (Prims.of_int (258))
                                                                     (Prims.of_int (22)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (271))
+                                                                    (Prims.of_int (276))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (271))
+                                                                    (Prims.of_int (276))
                                                                     (Prims.of_int (97)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1858,17 +1906,17 @@ let (prove :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (248))
+                                                                    (Prims.of_int (253))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (248))
+                                                                    (Prims.of_int (253))
                                                                     (Prims.of_int (54)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (249))
+                                                                    (Prims.of_int (254))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (253))
+                                                                    (Prims.of_int (258))
                                                                     (Prims.of_int (22)))))
                                                                     (Obj.magic
                                                                     (Pulse_Checker_Prover_Substs.ss_to_nt_substs
@@ -1969,13 +2017,13 @@ let (try_frame_pre_uvs :
                     (FStar_Sealed.seal
                        (Obj.magic
                           (FStar_Range.mk_range "Pulse.Checker.Prover.fst"
-                             (Prims.of_int (282)) (Prims.of_int (10))
-                             (Prims.of_int (282)) (Prims.of_int (48)))))
+                             (Prims.of_int (287)) (Prims.of_int (10))
+                             (Prims.of_int (287)) (Prims.of_int (48)))))
                     (FStar_Sealed.seal
                        (Obj.magic
                           (FStar_Range.mk_range "Pulse.Checker.Prover.fst"
-                             (Prims.of_int (282)) (Prims.of_int (51))
-                             (Prims.of_int (338)) (Prims.of_int (65)))))
+                             (Prims.of_int (287)) (Prims.of_int (51))
+                             (Prims.of_int (343)) (Prims.of_int (65)))))
                     (FStar_Tactics_Effect.lift_div_tac
                        (fun uu___ ->
                           Pulse_Typing_Env.push_context g "try_frame_pre"
@@ -1988,17 +2036,17 @@ let (try_frame_pre_uvs :
                                   (Obj.magic
                                      (FStar_Range.mk_range
                                         "Pulse.Checker.Prover.fst"
-                                        (Prims.of_int (285))
+                                        (Prims.of_int (290))
                                         (Prims.of_int (4))
-                                        (Prims.of_int (285))
+                                        (Prims.of_int (290))
                                         (Prims.of_int (56)))))
                                (FStar_Sealed.seal
                                   (Obj.magic
                                      (FStar_Range.mk_range
                                         "Pulse.Checker.Prover.fst"
-                                        (Prims.of_int (282))
+                                        (Prims.of_int (287))
                                         (Prims.of_int (51))
-                                        (Prims.of_int (338))
+                                        (Prims.of_int (343))
                                         (Prims.of_int (65)))))
                                (Obj.magic
                                   (prove g1 ctxt () uvs
@@ -2015,17 +2063,17 @@ let (try_frame_pre_uvs :
                                                  (Obj.magic
                                                     (FStar_Range.mk_range
                                                        "Pulse.Checker.Prover.fst"
-                                                       (Prims.of_int (289))
+                                                       (Prims.of_int (294))
                                                        (Prims.of_int (4))
-                                                       (Prims.of_int (289))
+                                                       (Prims.of_int (294))
                                                        (Prims.of_int (49)))))
                                               (FStar_Sealed.seal
                                                  (Obj.magic
                                                     (FStar_Range.mk_range
                                                        "Pulse.Checker.Prover.fst"
-                                                       (Prims.of_int (291))
+                                                       (Prims.of_int (296))
                                                        (Prims.of_int (82))
-                                                       (Prims.of_int (338))
+                                                       (Prims.of_int (343))
                                                        (Prims.of_int (65)))))
                                               (FStar_Tactics_Effect.lift_div_tac
                                                  (fun uu___1 ->
@@ -2039,17 +2087,17 @@ let (try_frame_pre_uvs :
                                                             (Obj.magic
                                                                (FStar_Range.mk_range
                                                                   "Pulse.Checker.Prover.fst"
-                                                                  (Prims.of_int (292))
+                                                                  (Prims.of_int (297))
                                                                   (Prims.of_int (10))
-                                                                  (Prims.of_int (292))
+                                                                  (Prims.of_int (297))
                                                                   (Prims.of_int (35)))))
                                                          (FStar_Sealed.seal
                                                             (Obj.magic
                                                                (FStar_Range.mk_range
                                                                   "Pulse.Checker.Prover.fst"
-                                                                  (Prims.of_int (292))
+                                                                  (Prims.of_int (297))
                                                                   (Prims.of_int (38))
-                                                                  (Prims.of_int (338))
+                                                                  (Prims.of_int (343))
                                                                   (Prims.of_int (65)))))
                                                          (FStar_Tactics_Effect.lift_div_tac
                                                             (fun uu___1 ->
@@ -2064,18 +2112,18 @@ let (try_frame_pre_uvs :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (293))
+                                                                    (Prims.of_int (298))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (293))
+                                                                    (Prims.of_int (298))
                                                                     (Prims.of_int (32)))))
                                                                     (
                                                                     FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (293))
+                                                                    (Prims.of_int (298))
                                                                     (Prims.of_int (35))
-                                                                    (Prims.of_int (338))
+                                                                    (Prims.of_int (343))
                                                                     (Prims.of_int (65)))))
                                                                     (
                                                                     FStar_Tactics_Effect.lift_div_tac
@@ -2094,17 +2142,17 @@ let (try_frame_pre_uvs :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (296))
+                                                                    (Prims.of_int (301))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (296))
+                                                                    (Prims.of_int (301))
                                                                     (Prims.of_int (47)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (296))
+                                                                    (Prims.of_int (301))
                                                                     (Prims.of_int (50))
-                                                                    (Prims.of_int (338))
+                                                                    (Prims.of_int (343))
                                                                     (Prims.of_int (65)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -2122,17 +2170,17 @@ let (try_frame_pre_uvs :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (298))
+                                                                    (Prims.of_int (303))
                                                                     (Prims.of_int (82))
-                                                                    (Prims.of_int (298))
+                                                                    (Prims.of_int (303))
                                                                     (Prims.of_int (102)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (298))
+                                                                    (Prims.of_int (303))
                                                                     (Prims.of_int (105))
-                                                                    (Prims.of_int (338))
+                                                                    (Prims.of_int (343))
                                                                     (Prims.of_int (65)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -2151,17 +2199,17 @@ let (try_frame_pre_uvs :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (300))
+                                                                    (Prims.of_int (305))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (300))
+                                                                    (Prims.of_int (305))
                                                                     (Prims.of_int (18)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (300))
+                                                                    (Prims.of_int (305))
                                                                     (Prims.of_int (21))
-                                                                    (Prims.of_int (338))
+                                                                    (Prims.of_int (343))
                                                                     (Prims.of_int (65)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -2177,17 +2225,17 @@ let (try_frame_pre_uvs :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (301))
+                                                                    (Prims.of_int (306))
                                                                     (Prims.of_int (11))
-                                                                    (Prims.of_int (301))
+                                                                    (Prims.of_int (306))
                                                                     (Prims.of_int (21)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (301))
+                                                                    (Prims.of_int (306))
                                                                     (Prims.of_int (24))
-                                                                    (Prims.of_int (338))
+                                                                    (Prims.of_int (343))
                                                                     (Prims.of_int (65)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -2204,17 +2252,17 @@ let (try_frame_pre_uvs :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (302))
+                                                                    (Prims.of_int (307))
                                                                     (Prims.of_int (11))
-                                                                    (Prims.of_int (302))
+                                                                    (Prims.of_int (307))
                                                                     (Prims.of_int (42)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (303))
+                                                                    (Prims.of_int (308))
                                                                     (Prims.of_int (31))
-                                                                    (Prims.of_int (338))
+                                                                    (Prims.of_int (343))
                                                                     (Prims.of_int (65)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -2233,17 +2281,17 @@ let (try_frame_pre_uvs :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (304))
+                                                                    (Prims.of_int (309))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (304))
+                                                                    (Prims.of_int (309))
                                                                     (Prims.of_int (75)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (304))
+                                                                    (Prims.of_int (309))
                                                                     (Prims.of_int (78))
-                                                                    (Prims.of_int (338))
+                                                                    (Prims.of_int (343))
                                                                     (Prims.of_int (65)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -2265,17 +2313,17 @@ let (try_frame_pre_uvs :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (306))
+                                                                    (Prims.of_int (311))
                                                                     (Prims.of_int (29))
-                                                                    (Prims.of_int (306))
+                                                                    (Prims.of_int (311))
                                                                     (Prims.of_int (73)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (306))
+                                                                    (Prims.of_int (311))
                                                                     (Prims.of_int (76))
-                                                                    (Prims.of_int (338))
+                                                                    (Prims.of_int (343))
                                                                     (Prims.of_int (65)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -2293,17 +2341,17 @@ let (try_frame_pre_uvs :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (311))
+                                                                    (Prims.of_int (316))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (311))
+                                                                    (Prims.of_int (316))
                                                                     (Prims.of_int (81)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (318))
+                                                                    (Prims.of_int (323))
                                                                     (Prims.of_int (35))
-                                                                    (Prims.of_int (338))
+                                                                    (Prims.of_int (343))
                                                                     (Prims.of_int (65)))))
                                                                     (Obj.magic
                                                                     (Pulse_Checker_Base.continuation_elaborator_with_bind
@@ -2395,13 +2443,13 @@ let (try_frame_pre :
                   (FStar_Sealed.seal
                      (Obj.magic
                         (FStar_Range.mk_range "Pulse.Checker.Prover.fst"
-                           (Prims.of_int (346)) (Prims.of_int (12))
-                           (Prims.of_int (346)) (Prims.of_int (32)))))
+                           (Prims.of_int (351)) (Prims.of_int (12))
+                           (Prims.of_int (351)) (Prims.of_int (32)))))
                   (FStar_Sealed.seal
                      (Obj.magic
                         (FStar_Range.mk_range "Pulse.Checker.Prover.fst"
-                           (Prims.of_int (348)) (Prims.of_int (2))
-                           (Prims.of_int (348)) (Prims.of_int (48)))))
+                           (Prims.of_int (353)) (Prims.of_int (2))
+                           (Prims.of_int (353)) (Prims.of_int (48)))))
                   (FStar_Tactics_Effect.lift_div_tac
                      (fun uu___ ->
                         Pulse_Typing_Env.mk_env
@@ -2429,13 +2477,13 @@ let (prove_post_hint :
               (FStar_Sealed.seal
                  (Obj.magic
                     (FStar_Range.mk_range "Pulse.Checker.Prover.fst"
-                       (Prims.of_int (357)) (Prims.of_int (10))
-                       (Prims.of_int (357)) (Prims.of_int (46)))))
+                       (Prims.of_int (362)) (Prims.of_int (10))
+                       (Prims.of_int (362)) (Prims.of_int (46)))))
               (FStar_Sealed.seal
                  (Obj.magic
                     (FStar_Range.mk_range "Pulse.Checker.Prover.fst"
-                       (Prims.of_int (359)) (Prims.of_int (2))
-                       (Prims.of_int (405)) (Prims.of_int (102)))))
+                       (Prims.of_int (364)) (Prims.of_int (2))
+                       (Prims.of_int (414)) (Prims.of_int (102)))))
               (FStar_Tactics_Effect.lift_div_tac
                  (fun uu___ ->
                     Pulse_Typing_Env.push_context g "prove_post_hint" rng))
@@ -2455,17 +2503,17 @@ let (prove_post_hint :
                                    (Obj.magic
                                       (FStar_Range.mk_range
                                          "Pulse.Checker.Prover.fst"
-                                         (Prims.of_int (362))
+                                         (Prims.of_int (367))
                                          (Prims.of_int (79))
-                                         (Prims.of_int (362))
+                                         (Prims.of_int (367))
                                          (Prims.of_int (80)))))
                                 (FStar_Sealed.seal
                                    (Obj.magic
                                       (FStar_Range.mk_range
                                          "Pulse.Checker.Prover.fst"
-                                         (Prims.of_int (361))
+                                         (Prims.of_int (366))
                                          (Prims.of_int (21))
-                                         (Prims.of_int (405))
+                                         (Prims.of_int (414))
                                          (Prims.of_int (102)))))
                                 (FStar_Tactics_Effect.lift_div_tac
                                    (fun uu___ -> r))
@@ -2484,17 +2532,17 @@ let (prove_post_hint :
                                                   (Obj.magic
                                                      (FStar_Range.mk_range
                                                         "Pulse.Checker.Prover.fst"
-                                                        (Prims.of_int (364))
+                                                        (Prims.of_int (369))
                                                         (Prims.of_int (17))
-                                                        (Prims.of_int (364))
+                                                        (Prims.of_int (369))
                                                         (Prims.of_int (44)))))
                                                (FStar_Sealed.seal
                                                   (Obj.magic
                                                      (FStar_Range.mk_range
                                                         "Pulse.Checker.Prover.fst"
-                                                        (Prims.of_int (364))
+                                                        (Prims.of_int (369))
                                                         (Prims.of_int (47))
-                                                        (Prims.of_int (405))
+                                                        (Prims.of_int (414))
                                                         (Prims.of_int (102)))))
                                                (FStar_Tactics_Effect.lift_div_tac
                                                   (fun uu___1 ->
@@ -2508,17 +2556,17 @@ let (prove_post_hint :
                                                              (Obj.magic
                                                                 (FStar_Range.mk_range
                                                                    "Pulse.Checker.Prover.fst"
-                                                                   (Prims.of_int (365))
+                                                                   (Prims.of_int (370))
                                                                    (Prims.of_int (27))
-                                                                   (Prims.of_int (365))
+                                                                   (Prims.of_int (370))
                                                                    (Prims.of_int (66)))))
                                                           (FStar_Sealed.seal
                                                              (Obj.magic
                                                                 (FStar_Range.mk_range
                                                                    "Pulse.Checker.Prover.fst"
-                                                                   (Prims.of_int (368))
+                                                                   (Prims.of_int (373))
                                                                    (Prims.of_int (4))
-                                                                   (Prims.of_int (405))
+                                                                   (Prims.of_int (414))
                                                                    (Prims.of_int (102)))))
                                                           (FStar_Tactics_Effect.lift_div_tac
                                                              (fun uu___1 ->
@@ -2544,39 +2592,119 @@ let (prove_post_hint :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (370))
-                                                                    (Prims.of_int (11))
-                                                                    (Prims.of_int (373))
-                                                                    (Prims.of_int (50)))))
+                                                                    (Prims.of_int (376))
+                                                                    (Prims.of_int (28))
+                                                                    (Prims.of_int (382))
+                                                                    (Prims.of_int (7)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (369))
-                                                                    (Prims.of_int (9))
-                                                                    (Prims.of_int (373))
-                                                                    (Prims.of_int (50)))))
+                                                                    (Prims.of_int (376))
+                                                                    (Prims.of_int (6))
+                                                                    (Prims.of_int (382))
+                                                                    (Prims.of_int (7)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (373))
-                                                                    (Prims.of_int (14))
-                                                                    (Prims.of_int (373))
-                                                                    (Prims.of_int (49)))))
+                                                                    (Prims.of_int (376))
+                                                                    (Prims.of_int (28))
+                                                                    (Prims.of_int (382))
+                                                                    (Prims.of_int (7)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (370))
-                                                                    (Prims.of_int (11))
-                                                                    (Prims.of_int (373))
-                                                                    (Prims.of_int (50)))))
+                                                                    (Prims.of_int (376))
+                                                                    (Prims.of_int (28))
+                                                                    (Prims.of_int (382))
+                                                                    (Prims.of_int (7)))))
                                                                     (Obj.magic
-                                                                    (Pulse_Syntax_Printer.term_to_string
-                                                                    post_hint1.Pulse_Typing.ret_ty))
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Prover.fst"
+                                                                    (Prims.of_int (378))
+                                                                    (Prims.of_int (8))
+                                                                    (Prims.of_int (381))
+                                                                    (Prims.of_int (38)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Prover.fst"
+                                                                    (Prims.of_int (376))
+                                                                    (Prims.of_int (28))
+                                                                    (Prims.of_int (382))
+                                                                    (Prims.of_int (7)))))
+                                                                    (Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Prover.fst"
+                                                                    (Prims.of_int (379))
+                                                                    (Prims.of_int (10))
+                                                                    (Prims.of_int (381))
+                                                                    (Prims.of_int (38)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Prover.fst"
+                                                                    (Prims.of_int (378))
+                                                                    (Prims.of_int (8))
+                                                                    (Prims.of_int (381))
+                                                                    (Prims.of_int (38)))))
+                                                                    (Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Prover.fst"
+                                                                    (Prims.of_int (379))
+                                                                    (Prims.of_int (10))
+                                                                    (Prims.of_int (379))
+                                                                    (Prims.of_int (24)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Prover.fst"
+                                                                    (Prims.of_int (379))
+                                                                    (Prims.of_int (10))
+                                                                    (Prims.of_int (381))
+                                                                    (Prims.of_int (38)))))
+                                                                    (Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Prover.fst"
+                                                                    (Prims.of_int (379))
+                                                                    (Prims.of_int (17))
+                                                                    (Prims.of_int (379))
+                                                                    (Prims.of_int (24)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Prover.fst"
+                                                                    (Prims.of_int (379))
+                                                                    (Prims.of_int (10))
+                                                                    (Prims.of_int (379))
+                                                                    (Prims.of_int (24)))))
+                                                                    (Obj.magic
+                                                                    (Pulse_PP.pp
+                                                                    Pulse_PP.uu___44
+                                                                    ty))
+                                                                    (fun
+                                                                    uu___1 ->
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___2 ->
+                                                                    Pulse_PP.indent
+                                                                    uu___1))))
                                                                     (fun
                                                                     uu___1 ->
                                                                     (fun
@@ -2587,67 +2715,112 @@ let (prove_post_hint :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (370))
-                                                                    (Prims.of_int (11))
-                                                                    (Prims.of_int (373))
-                                                                    (Prims.of_int (50)))))
+                                                                    (Prims.of_int (380))
+                                                                    (Prims.of_int (8))
+                                                                    (Prims.of_int (381))
+                                                                    (Prims.of_int (38)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (370))
-                                                                    (Prims.of_int (11))
-                                                                    (Prims.of_int (373))
-                                                                    (Prims.of_int (50)))))
+                                                                    (Prims.of_int (379))
+                                                                    (Prims.of_int (10))
+                                                                    (Prims.of_int (381))
+                                                                    (Prims.of_int (38)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (372))
-                                                                    (Prims.of_int (14))
-                                                                    (Prims.of_int (372))
-                                                                    (Prims.of_int (35)))))
+                                                                    (Prims.of_int (381))
+                                                                    (Prims.of_int (10))
+                                                                    (Prims.of_int (381))
+                                                                    (Prims.of_int (38)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
-                                                                    "FStar.Printf.fst"
-                                                                    (Prims.of_int (121))
+                                                                    "Pulse.Checker.Prover.fst"
+                                                                    (Prims.of_int (380))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (123))
-                                                                    (Prims.of_int (44)))))
+                                                                    (Prims.of_int (381))
+                                                                    (Prims.of_int (38)))))
                                                                     (Obj.magic
-                                                                    (Pulse_Syntax_Printer.term_to_string
-                                                                    ty))
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Prover.fst"
+                                                                    (Prims.of_int (381))
+                                                                    (Prims.of_int (17))
+                                                                    (Prims.of_int (381))
+                                                                    (Prims.of_int (38)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Prover.fst"
+                                                                    (Prims.of_int (381))
+                                                                    (Prims.of_int (10))
+                                                                    (Prims.of_int (381))
+                                                                    (Prims.of_int (38)))))
+                                                                    (Obj.magic
+                                                                    (Pulse_PP.pp
+                                                                    Pulse_PP.uu___44
+                                                                    post_hint1.Pulse_Typing.ret_ty))
                                                                     (fun
                                                                     uu___2 ->
                                                                     FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
                                                                     uu___3 ->
-                                                                    fun x1 ->
-                                                                    Prims.strcat
-                                                                    (Prims.strcat
-                                                                    "error in proving post hint:comp return type "
-                                                                    (Prims.strcat
-                                                                    uu___2
-                                                                    " does not match the post hint "))
-                                                                    (Prims.strcat
-                                                                    x1 "")))))
+                                                                    Pulse_PP.indent
+                                                                    uu___2))))
                                                                     (fun
                                                                     uu___2 ->
                                                                     FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
                                                                     uu___3 ->
-                                                                    uu___2
-                                                                    uu___1))))
+                                                                    FStar_Pprint.op_Hat_Hat
+                                                                    (Pulse_PP.text
+                                                                    "does not match the expected")
+                                                                    uu___2))))
+                                                                    (fun
+                                                                    uu___2 ->
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___3 ->
+                                                                    FStar_Pprint.op_Hat_Slash_Hat
+                                                                    uu___1
+                                                                    uu___2))))
                                                                     uu___1)))
                                                                     (fun
                                                                     uu___1 ->
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___2 ->
+                                                                    FStar_Pprint.op_Hat_Hat
+                                                                    (Pulse_PP.text
+                                                                    "The return type")
+                                                                    uu___1))))
+                                                                    (fun
+                                                                    uu___1 ->
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___2 ->
+                                                                    [uu___1]))))
+                                                                    (fun
+                                                                    uu___1 ->
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___2 ->
+                                                                    (Pulse_PP.text
+                                                                    "Error in proving postcondition")
+                                                                    :: uu___1))))
+                                                                    (fun
+                                                                    uu___1 ->
                                                                     (fun
                                                                     uu___1 ->
                                                                     Obj.magic
-                                                                    (Pulse_Typing_Env.fail
+                                                                    (Pulse_Typing_Env.fail_doc
                                                                     g1
                                                                     (FStar_Pervasives_Native.Some
                                                                     rng)
@@ -2681,17 +2854,17 @@ let (prove_post_hint :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (378))
+                                                                    (Prims.of_int (387))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (378))
+                                                                    (Prims.of_int (387))
                                                                     (Prims.of_int (90)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (376))
+                                                                    (Prims.of_int (385))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (405))
+                                                                    (Prims.of_int (414))
                                                                     (Prims.of_int (102)))))
                                                                     (Obj.magic
                                                                     (prove g2
@@ -2719,17 +2892,17 @@ let (prove_post_hint :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (383))
+                                                                    (Prims.of_int (392))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (383))
+                                                                    (Prims.of_int (392))
                                                                     (Prims.of_int (27)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (385))
+                                                                    (Prims.of_int (394))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (405))
+                                                                    (Prims.of_int (414))
                                                                     (Prims.of_int (102)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -2756,17 +2929,17 @@ let (prove_post_hint :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (388))
+                                                                    (Prims.of_int (397))
                                                                     (Prims.of_int (30))
-                                                                    (Prims.of_int (392))
+                                                                    (Prims.of_int (401))
                                                                     (Prims.of_int (9)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (388))
+                                                                    (Prims.of_int (397))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (392))
+                                                                    (Prims.of_int (401))
                                                                     (Prims.of_int (9)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -2774,17 +2947,17 @@ let (prove_post_hint :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (388))
+                                                                    (Prims.of_int (397))
                                                                     (Prims.of_int (30))
-                                                                    (Prims.of_int (392))
+                                                                    (Prims.of_int (401))
                                                                     (Prims.of_int (9)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (388))
+                                                                    (Prims.of_int (397))
                                                                     (Prims.of_int (30))
-                                                                    (Prims.of_int (392))
+                                                                    (Prims.of_int (401))
                                                                     (Prims.of_int (9)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -2792,17 +2965,17 @@ let (prove_post_hint :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (390))
+                                                                    (Prims.of_int (399))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (391))
-                                                                    (Prims.of_int (33)))))
+                                                                    (Prims.of_int (400))
+                                                                    (Prims.of_int (38)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (388))
+                                                                    (Prims.of_int (397))
                                                                     (Prims.of_int (30))
-                                                                    (Prims.of_int (392))
+                                                                    (Prims.of_int (401))
                                                                     (Prims.of_int (9)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -2810,30 +2983,55 @@ let (prove_post_hint :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (391))
-                                                                    (Prims.of_int (16))
-                                                                    (Prims.of_int (391))
-                                                                    (Prims.of_int (33)))))
+                                                                    (Prims.of_int (400))
+                                                                    (Prims.of_int (12))
+                                                                    (Prims.of_int (400))
+                                                                    (Prims.of_int (38)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (390))
+                                                                    (Prims.of_int (399))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (391))
-                                                                    (Prims.of_int (33)))))
+                                                                    (Prims.of_int (400))
+                                                                    (Prims.of_int (38)))))
+                                                                    (Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Prover.fst"
+                                                                    (Prims.of_int (400))
+                                                                    (Prims.of_int (19))
+                                                                    (Prims.of_int (400))
+                                                                    (Prims.of_int (38)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Prover.fst"
+                                                                    (Prims.of_int (400))
+                                                                    (Prims.of_int (12))
+                                                                    (Prims.of_int (400))
+                                                                    (Prims.of_int (38)))))
                                                                     (Obj.magic
                                                                     (Pulse_PP.pp
-                                                                    Pulse_PP.uu___42
+                                                                    Pulse_PP.uu___44
                                                                     remaining_ctxt))
                                                                     (fun
                                                                     uu___4 ->
                                                                     FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
                                                                     uu___5 ->
-                                                                    FStar_Pprint.op_Hat_Slash_Hat
+                                                                    Pulse_PP.indent
+                                                                    uu___4))))
+                                                                    (fun
+                                                                    uu___4 ->
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___5 ->
+                                                                    FStar_Pprint.op_Hat_Hat
                                                                     (Pulse_PP.text
-                                                                    "Postcondition contains extra vprops not matched in the post hint")
+                                                                    "Inferred postcondition additionally contains")
                                                                     uu___4))))
                                                                     (fun
                                                                     uu___4 ->
@@ -2847,7 +3045,7 @@ let (prove_post_hint :
                                                                     (fun
                                                                     uu___5 ->
                                                                     (Pulse_PP.text
-                                                                    "Error in proving post hint")
+                                                                    "Error in proving postcondition")
                                                                     :: uu___4))))
                                                                     (fun
                                                                     uu___4 ->

--- a/src/ocaml/plugin/generated/Pulse_Checker_Prover.ml
+++ b/src/ocaml/plugin/generated/Pulse_Checker_Prover.ml
@@ -475,7 +475,7 @@ let rec (prover :
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.Prover.fst"
-                 (Prims.of_int (127)) (Prims.of_int (2)) (Prims.of_int (183))
+                 (Prims.of_int (127)) (Prims.of_int (2)) (Prims.of_int (184))
                  (Prims.of_int (32)))))
         (Obj.magic
            (Pulse_Checker_Prover_Util.debug_prover
@@ -574,7 +574,7 @@ let rec (prover :
                                 (FStar_Range.mk_range
                                    "Pulse.Checker.Prover.fst"
                                    (Prims.of_int (132)) (Prims.of_int (4))
-                                   (Prims.of_int (183)) (Prims.of_int (32)))))
+                                   (Prims.of_int (184)) (Prims.of_int (32)))))
                           (Obj.magic
                              (Pulse_Checker_Prover_ElimExists.elim_exists_pst
                                 preamble pst0))
@@ -596,7 +596,7 @@ let rec (prover :
                                               "Pulse.Checker.Prover.fst"
                                               (Prims.of_int (134))
                                               (Prims.of_int (63))
-                                              (Prims.of_int (183))
+                                              (Prims.of_int (184))
                                               (Prims.of_int (32)))))
                                      (Obj.magic
                                         (Pulse_Checker_Prover_Util.debug_prover
@@ -648,7 +648,7 @@ let rec (prover :
                                                          "Pulse.Checker.Prover.fst"
                                                          (Prims.of_int (138))
                                                          (Prims.of_int (4))
-                                                         (Prims.of_int (183))
+                                                         (Prims.of_int (184))
                                                          (Prims.of_int (32)))))
                                                 (Obj.magic
                                                    (Pulse_Checker_Prover_ElimPure.elim_pure_pst
@@ -671,7 +671,7 @@ let rec (prover :
                                                                     "Pulse.Checker.Prover.fst"
                                                                     (Prims.of_int (140))
                                                                     (Prims.of_int (63))
-                                                                    (Prims.of_int (183))
+                                                                    (Prims.of_int (184))
                                                                     (Prims.of_int (32)))))
                                                            (Obj.magic
                                                               (Pulse_Checker_Prover_Util.debug_prover
@@ -727,7 +727,7 @@ let rec (prover :
                                                                     "Pulse.Checker.Prover.fst"
                                                                     (Prims.of_int (140))
                                                                     (Prims.of_int (63))
-                                                                    (Prims.of_int (183))
+                                                                    (Prims.of_int (184))
                                                                     (Prims.of_int (32)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -764,7 +764,7 @@ let rec (prover :
                                                                     "Pulse.Checker.Prover.fst"
                                                                     (Prims.of_int (146))
                                                                     (Prims.of_int (88))
-                                                                    (Prims.of_int (183))
+                                                                    (Prims.of_int (184))
                                                                     (Prims.of_int (32)))))
                                                                     (Obj.magic
                                                                     (Pulse_Checker_Prover_Util.debug_prover
@@ -878,7 +878,7 @@ let rec (prover :
                                                                     "Pulse.Checker.Prover.fst"
                                                                     (Prims.of_int (150))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (183))
+                                                                    (Prims.of_int (184))
                                                                     (Prims.of_int (32)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -909,7 +909,7 @@ let rec (prover :
                                                                     "Pulse.Checker.Prover.fst"
                                                                     (Prims.of_int (154))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (183))
+                                                                    (Prims.of_int (184))
                                                                     (Prims.of_int (32)))))
                                                                     (Obj.magic
                                                                     (Pulse_Checker_Prover_Util.debug_prover
@@ -989,7 +989,7 @@ let rec (prover :
                                                                     "Pulse.Checker.Prover.fst"
                                                                     (Prims.of_int (157))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (183))
+                                                                    (Prims.of_int (184))
                                                                     (Prims.of_int (32)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -1026,7 +1026,7 @@ let rec (prover :
                                                                     "Pulse.Checker.Prover.fst"
                                                                     (Prims.of_int (160))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (183))
+                                                                    (Prims.of_int (184))
                                                                     (Prims.of_int (32)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -1075,7 +1075,7 @@ let rec (prover :
                                                                     "Pulse.Checker.Prover.fst"
                                                                     (Prims.of_int (164))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (183))
+                                                                    (Prims.of_int (184))
                                                                     (Prims.of_int (32)))))
                                                                     (Obj.magic
                                                                     (match_q
@@ -1101,15 +1101,15 @@ let rec (prover :
                                                                     "Pulse.Checker.Prover.fst"
                                                                     (Prims.of_int (168))
                                                                     (Prims.of_int (20))
-                                                                    (Prims.of_int (178))
-                                                                    (Prims.of_int (11)))))
+                                                                    (Prims.of_int (179))
+                                                                    (Prims.of_int (25)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (182))
+                                                                    (Prims.of_int (183))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (182))
+                                                                    (Prims.of_int (183))
                                                                     (Prims.of_int (34)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1119,7 +1119,7 @@ let rec (prover :
                                                                     "Pulse.Checker.Prover.fst"
                                                                     (Prims.of_int (168))
                                                                     (Prims.of_int (20))
-                                                                    (Prims.of_int (178))
+                                                                    (Prims.of_int (174))
                                                                     (Prims.of_int (11)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -1127,7 +1127,25 @@ let rec (prover :
                                                                     "Pulse.Checker.Prover.fst"
                                                                     (Prims.of_int (168))
                                                                     (Prims.of_int (20))
-                                                                    (Prims.of_int (178))
+                                                                    (Prims.of_int (179))
+                                                                    (Prims.of_int (25)))))
+                                                                    (Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Prover.fst"
+                                                                    (Prims.of_int (168))
+                                                                    (Prims.of_int (20))
+                                                                    (Prims.of_int (174))
+                                                                    (Prims.of_int (11)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Prover.fst"
+                                                                    (Prims.of_int (168))
+                                                                    (Prims.of_int (20))
+                                                                    (Prims.of_int (174))
                                                                     (Prims.of_int (11)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1145,7 +1163,7 @@ let rec (prover :
                                                                     "Pulse.Checker.Prover.fst"
                                                                     (Prims.of_int (168))
                                                                     (Prims.of_int (20))
-                                                                    (Prims.of_int (178))
+                                                                    (Prims.of_int (174))
                                                                     (Prims.of_int (11)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1202,7 +1220,7 @@ let rec (prover :
                                                                     uu___10
                                                                     ->
                                                                     FStar_Pprint.op_Hat_Hat
-                                                                    (FStar_Pprint.doc_of_string
+                                                                    (Pulse_PP.text
                                                                     "Cannot prove:")
                                                                     uu___9))))
                                                                     (fun
@@ -1217,7 +1235,7 @@ let rec (prover :
                                                                     "Pulse.Checker.Prover.fst"
                                                                     (Prims.of_int (168))
                                                                     (Prims.of_int (20))
-                                                                    (Prims.of_int (178))
+                                                                    (Prims.of_int (174))
                                                                     (Prims.of_int (11)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -1225,7 +1243,7 @@ let rec (prover :
                                                                     "Pulse.Checker.Prover.fst"
                                                                     (Prims.of_int (168))
                                                                     (Prims.of_int (20))
-                                                                    (Prims.of_int (178))
+                                                                    (Prims.of_int (174))
                                                                     (Prims.of_int (11)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1243,7 +1261,7 @@ let rec (prover :
                                                                     "Pulse.Checker.Prover.fst"
                                                                     (Prims.of_int (168))
                                                                     (Prims.of_int (20))
-                                                                    (Prims.of_int (178))
+                                                                    (Prims.of_int (174))
                                                                     (Prims.of_int (11)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1303,33 +1321,58 @@ let rec (prover :
                                                                     uu___11
                                                                     ->
                                                                     FStar_Pprint.op_Hat_Hat
-                                                                    (FStar_Pprint.doc_of_string
+                                                                    (Pulse_PP.text
                                                                     "In the context:")
                                                                     uu___10))))
                                                                     (fun
                                                                     uu___10
                                                                     ->
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___11
+                                                                    ->
+                                                                    [uu___10]))))
                                                                     (fun
                                                                     uu___10
                                                                     ->
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___11
+                                                                    -> uu___9
+                                                                    ::
+                                                                    uu___10))))
+                                                                    uu___9)))
+                                                                    (fun
+                                                                    uu___9 ->
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___10
+                                                                    ->
+                                                                    (Pulse_PP.text
+                                                                    "Error in proving precondition")
+                                                                    :: uu___9))))
+                                                                    (fun
+                                                                    uu___9 ->
+                                                                    (fun
+                                                                    uu___9 ->
                                                                     Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (168))
-                                                                    (Prims.of_int (20))
-                                                                    (Prims.of_int (178))
-                                                                    (Prims.of_int (11)))))
+                                                                    (Prims.of_int (174))
+                                                                    (Prims.of_int (14))
+                                                                    (Prims.of_int (179))
+                                                                    (Prims.of_int (25)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
                                                                     (Prims.of_int (168))
                                                                     (Prims.of_int (20))
-                                                                    (Prims.of_int (178))
-                                                                    (Prims.of_int (11)))))
+                                                                    (Prims.of_int (179))
+                                                                    (Prims.of_int (25)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
                                                                     (FStar_Sealed.seal
@@ -1337,53 +1380,84 @@ let rec (prover :
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
                                                                     (Prims.of_int (174))
-                                                                    (Prims.of_int (12))
-                                                                    (Prims.of_int (175))
-                                                                    (Prims.of_int (42)))))
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (168))
-                                                                    (Prims.of_int (20))
-                                                                    (Prims.of_int (178))
-                                                                    (Prims.of_int (11)))))
-                                                                    (Obj.magic
-                                                                    (FStar_Tactics_Effect.tac_bind
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (175))
-                                                                    (Prims.of_int (16))
-                                                                    (Prims.of_int (175))
-                                                                    (Prims.of_int (42)))))
+                                                                    (Prims.of_int (18))
+                                                                    (Prims.of_int (174))
+                                                                    (Prims.of_int (64)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
                                                                     (Prims.of_int (174))
-                                                                    (Prims.of_int (12))
-                                                                    (Prims.of_int (175))
-                                                                    (Prims.of_int (42)))))
+                                                                    (Prims.of_int (14))
+                                                                    (Prims.of_int (179))
+                                                                    (Prims.of_int (25)))))
                                                                     (Obj.magic
+                                                                    (Pulse_Config.debug_flag
+                                                                    "initial_solver_state"))
+                                                                    (fun
+                                                                    uu___10
+                                                                    ->
+                                                                    (fun
+                                                                    uu___10
+                                                                    ->
+                                                                    if
+                                                                    uu___10
+                                                                    then
+                                                                    Obj.magic
+                                                                    (Obj.repr
                                                                     (FStar_Tactics_Effect.tac_bind
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
                                                                     (Prims.of_int (175))
-                                                                    (Prims.of_int (23))
-                                                                    (Prims.of_int (175))
-                                                                    (Prims.of_int (42)))))
+                                                                    (Prims.of_int (16))
+                                                                    (Prims.of_int (176))
+                                                                    (Prims.of_int (46)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Prover.fst"
+                                                                    (Prims.of_int (174))
+                                                                    (Prims.of_int (70))
+                                                                    (Prims.of_int (179))
+                                                                    (Prims.of_int (16)))))
+                                                                    (Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Prover.fst"
+                                                                    (Prims.of_int (176))
+                                                                    (Prims.of_int (20))
+                                                                    (Prims.of_int (176))
+                                                                    (Prims.of_int (46)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
                                                                     (Prims.of_int (175))
                                                                     (Prims.of_int (16))
-                                                                    (Prims.of_int (175))
-                                                                    (Prims.of_int (42)))))
+                                                                    (Prims.of_int (176))
+                                                                    (Prims.of_int (46)))))
+                                                                    (Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Prover.fst"
+                                                                    (Prims.of_int (176))
+                                                                    (Prims.of_int (27))
+                                                                    (Prims.of_int (176))
+                                                                    (Prims.of_int (46)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Prover.fst"
+                                                                    (Prims.of_int (176))
+                                                                    (Prims.of_int (20))
+                                                                    (Prims.of_int (176))
+                                                                    (Prims.of_int (46)))))
                                                                     (Obj.magic
                                                                     (Pulse_PP.pp
                                                                     Pulse_PP.uu___44
@@ -1405,7 +1479,7 @@ let rec (prover :
                                                                     uu___12
                                                                     ->
                                                                     FStar_Pprint.op_Hat_Hat
-                                                                    (FStar_Pprint.doc_of_string
+                                                                    (Pulse_PP.text
                                                                     "The prover was started with goal:")
                                                                     uu___11))))
                                                                     (fun
@@ -1420,36 +1494,18 @@ let rec (prover :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (168))
-                                                                    (Prims.of_int (20))
-                                                                    (Prims.of_int (178))
-                                                                    (Prims.of_int (11)))))
+                                                                    (Prims.of_int (174))
+                                                                    (Prims.of_int (70))
+                                                                    (Prims.of_int (179))
+                                                                    (Prims.of_int (16)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (168))
-                                                                    (Prims.of_int (20))
-                                                                    (Prims.of_int (178))
-                                                                    (Prims.of_int (11)))))
-                                                                    (Obj.magic
-                                                                    (FStar_Tactics_Effect.tac_bind
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (176))
-                                                                    (Prims.of_int (12))
-                                                                    (Prims.of_int (177))
-                                                                    (Prims.of_int (41)))))
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (168))
-                                                                    (Prims.of_int (20))
-                                                                    (Prims.of_int (178))
-                                                                    (Prims.of_int (11)))))
+                                                                    (Prims.of_int (174))
+                                                                    (Prims.of_int (70))
+                                                                    (Prims.of_int (179))
+                                                                    (Prims.of_int (16)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
                                                                     (FStar_Sealed.seal
@@ -1458,34 +1514,52 @@ let rec (prover :
                                                                     "Pulse.Checker.Prover.fst"
                                                                     (Prims.of_int (177))
                                                                     (Prims.of_int (16))
-                                                                    (Prims.of_int (177))
-                                                                    (Prims.of_int (41)))))
+                                                                    (Prims.of_int (178))
+                                                                    (Prims.of_int (45)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (176))
-                                                                    (Prims.of_int (12))
-                                                                    (Prims.of_int (177))
-                                                                    (Prims.of_int (41)))))
+                                                                    (Prims.of_int (174))
+                                                                    (Prims.of_int (70))
+                                                                    (Prims.of_int (179))
+                                                                    (Prims.of_int (16)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (177))
-                                                                    (Prims.of_int (23))
-                                                                    (Prims.of_int (177))
-                                                                    (Prims.of_int (41)))))
+                                                                    (Prims.of_int (178))
+                                                                    (Prims.of_int (20))
+                                                                    (Prims.of_int (178))
+                                                                    (Prims.of_int (45)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
                                                                     (Prims.of_int (177))
                                                                     (Prims.of_int (16))
-                                                                    (Prims.of_int (177))
-                                                                    (Prims.of_int (41)))))
+                                                                    (Prims.of_int (178))
+                                                                    (Prims.of_int (45)))))
+                                                                    (Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Prover.fst"
+                                                                    (Prims.of_int (178))
+                                                                    (Prims.of_int (27))
+                                                                    (Prims.of_int (178))
+                                                                    (Prims.of_int (45)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Prover.fst"
+                                                                    (Prims.of_int (178))
+                                                                    (Prims.of_int (20))
+                                                                    (Prims.of_int (178))
+                                                                    (Prims.of_int (45)))))
                                                                     (Obj.magic
                                                                     (Pulse_PP.pp
                                                                     Pulse_PP.uu___44
@@ -1507,7 +1581,7 @@ let rec (prover :
                                                                     uu___13
                                                                     ->
                                                                     FStar_Pprint.op_Hat_Hat
-                                                                    (FStar_Pprint.doc_of_string
+                                                                    (Pulse_PP.text
                                                                     "and initial context:")
                                                                     uu___12))))
                                                                     (fun
@@ -1529,16 +1603,13 @@ let rec (prover :
                                                                     ::
                                                                     uu___12))))
                                                                     uu___11)))
-                                                                    (fun
-                                                                    uu___11
-                                                                    ->
-                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    else
+                                                                    Obj.magic
+                                                                    (Obj.repr
+                                                                    (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
                                                                     uu___12
-                                                                    ->
-                                                                    uu___10
-                                                                    ::
-                                                                    uu___11))))
+                                                                    -> []))))
                                                                     uu___10)))
                                                                     (fun
                                                                     uu___10
@@ -1546,19 +1617,11 @@ let rec (prover :
                                                                     FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
                                                                     uu___11
-                                                                    -> uu___9
-                                                                    ::
+                                                                    ->
+                                                                    FStar_List_Tot_Base.op_At
+                                                                    uu___9
                                                                     uu___10))))
                                                                     uu___9)))
-                                                                    (fun
-                                                                    uu___9 ->
-                                                                    FStar_Tactics_Effect.lift_div_tac
-                                                                    (fun
-                                                                    uu___10
-                                                                    ->
-                                                                    (Pulse_PP.text
-                                                                    "Error in proving precondition")
-                                                                    :: uu___9))))
                                                                     (fun
                                                                     uu___9 ->
                                                                     (fun msg
@@ -1628,13 +1691,13 @@ let (prove :
                 (FStar_Sealed.seal
                    (Obj.magic
                       (FStar_Range.mk_range "Pulse.Checker.Prover.fst"
-                         (Prims.of_int (207)) (Prims.of_int (2))
-                         (Prims.of_int (209)) (Prims.of_int (55)))))
+                         (Prims.of_int (208)) (Prims.of_int (2))
+                         (Prims.of_int (210)) (Prims.of_int (55)))))
                 (FStar_Sealed.seal
                    (Obj.magic
                       (FStar_Range.mk_range "Pulse.Checker.Prover.fst"
-                         (Prims.of_int (209)) (Prims.of_int (56))
-                         (Prims.of_int (276)) (Prims.of_int (97)))))
+                         (Prims.of_int (210)) (Prims.of_int (56))
+                         (Prims.of_int (277)) (Prims.of_int (97)))))
                 (Obj.magic
                    (Pulse_Checker_Prover_Util.debug_prover g
                       (fun uu___ ->
@@ -1643,14 +1706,14 @@ let (prove :
                               (Obj.magic
                                  (FStar_Range.mk_range
                                     "Pulse.Checker.Prover.fst"
-                                    (Prims.of_int (209)) (Prims.of_int (30))
-                                    (Prims.of_int (209)) (Prims.of_int (54)))))
+                                    (Prims.of_int (210)) (Prims.of_int (30))
+                                    (Prims.of_int (210)) (Prims.of_int (54)))))
                            (FStar_Sealed.seal
                               (Obj.magic
                                  (FStar_Range.mk_range
                                     "Pulse.Checker.Prover.fst"
-                                    (Prims.of_int (208)) (Prims.of_int (4))
-                                    (Prims.of_int (209)) (Prims.of_int (54)))))
+                                    (Prims.of_int (209)) (Prims.of_int (4))
+                                    (Prims.of_int (210)) (Prims.of_int (54)))))
                            (Obj.magic
                               (Pulse_Syntax_Printer.term_to_string goals))
                            (fun uu___1 ->
@@ -1661,17 +1724,17 @@ let (prove :
                                          (Obj.magic
                                             (FStar_Range.mk_range
                                                "Pulse.Checker.Prover.fst"
-                                               (Prims.of_int (208))
-                                               (Prims.of_int (4))
                                                (Prims.of_int (209))
+                                               (Prims.of_int (4))
+                                               (Prims.of_int (210))
                                                (Prims.of_int (54)))))
                                       (FStar_Sealed.seal
                                          (Obj.magic
                                             (FStar_Range.mk_range
                                                "Pulse.Checker.Prover.fst"
-                                               (Prims.of_int (208))
-                                               (Prims.of_int (4))
                                                (Prims.of_int (209))
+                                               (Prims.of_int (4))
+                                               (Prims.of_int (210))
                                                (Prims.of_int (54)))))
                                       (Obj.magic
                                          (FStar_Tactics_Effect.tac_bind
@@ -1679,9 +1742,9 @@ let (prove :
                                                (Obj.magic
                                                   (FStar_Range.mk_range
                                                      "Pulse.Checker.Prover.fst"
-                                                     (Prims.of_int (209))
+                                                     (Prims.of_int (210))
                                                      (Prims.of_int (6))
-                                                     (Prims.of_int (209))
+                                                     (Prims.of_int (210))
                                                      (Prims.of_int (29)))))
                                             (FStar_Sealed.seal
                                                (Obj.magic
@@ -1717,14 +1780,14 @@ let (prove :
                               (Obj.magic
                                  (FStar_Range.mk_range
                                     "Pulse.Checker.Prover.fst"
-                                    (Prims.of_int (211)) (Prims.of_int (15))
-                                    (Prims.of_int (211)) (Prims.of_int (33)))))
+                                    (Prims.of_int (212)) (Prims.of_int (15))
+                                    (Prims.of_int (212)) (Prims.of_int (33)))))
                            (FStar_Sealed.seal
                               (Obj.magic
                                  (FStar_Range.mk_range
                                     "Pulse.Checker.Prover.fst"
-                                    (Prims.of_int (225)) (Prims.of_int (6))
-                                    (Prims.of_int (276)) (Prims.of_int (97)))))
+                                    (Prims.of_int (226)) (Prims.of_int (6))
+                                    (Prims.of_int (277)) (Prims.of_int (97)))))
                            (FStar_Tactics_Effect.lift_div_tac
                               (fun uu___1 ->
                                  Pulse_Typing_Combinators.vprop_as_list ctxt))
@@ -1736,17 +1799,17 @@ let (prove :
                                          (Obj.magic
                                             (FStar_Range.mk_range
                                                "Pulse.Checker.Prover.fst"
-                                               (Prims.of_int (226))
+                                               (Prims.of_int (227))
                                                (Prims.of_int (61))
-                                               (Prims.of_int (226))
+                                               (Prims.of_int (227))
                                                (Prims.of_int (69)))))
                                       (FStar_Sealed.seal
                                          (Obj.magic
                                             (FStar_Range.mk_range
                                                "Pulse.Checker.Prover.fst"
-                                               (Prims.of_int (226))
+                                               (Prims.of_int (227))
                                                (Prims.of_int (72))
-                                               (Prims.of_int (276))
+                                               (Prims.of_int (277))
                                                (Prims.of_int (97)))))
                                       (FStar_Tactics_Effect.lift_div_tac
                                          (fun uu___1 -> ()))
@@ -1758,17 +1821,17 @@ let (prove :
                                                     (Obj.magic
                                                        (FStar_Range.mk_range
                                                           "Pulse.Checker.Prover.fst"
-                                                          (Prims.of_int (228))
+                                                          (Prims.of_int (229))
                                                           (Prims.of_int (6))
-                                                          (Prims.of_int (232))
+                                                          (Prims.of_int (233))
                                                           (Prims.of_int (12)))))
                                                  (FStar_Sealed.seal
                                                     (Obj.magic
                                                        (FStar_Range.mk_range
                                                           "Pulse.Checker.Prover.fst"
-                                                          (Prims.of_int (235))
+                                                          (Prims.of_int (236))
                                                           (Prims.of_int (43))
-                                                          (Prims.of_int (276))
+                                                          (Prims.of_int (277))
                                                           (Prims.of_int (97)))))
                                                  (FStar_Tactics_Effect.lift_div_tac
                                                     (fun uu___1 ->
@@ -1793,17 +1856,17 @@ let (prove :
                                                                (Obj.magic
                                                                   (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (237))
+                                                                    (Prims.of_int (238))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (246))
+                                                                    (Prims.of_int (247))
                                                                     (Prims.of_int (21)))))
                                                             (FStar_Sealed.seal
                                                                (Obj.magic
                                                                   (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (247))
+                                                                    (Prims.of_int (248))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (276))
+                                                                    (Prims.of_int (277))
                                                                     (Prims.of_int (97)))))
                                                             (FStar_Tactics_Effect.lift_div_tac
                                                                (fun uu___1 ->
@@ -1862,17 +1925,17 @@ let (prove :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (249))
+                                                                    (Prims.of_int (250))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (249))
+                                                                    (Prims.of_int (250))
                                                                     (Prims.of_int (25)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (249))
+                                                                    (Prims.of_int (250))
                                                                     (Prims.of_int (28))
-                                                                    (Prims.of_int (276))
+                                                                    (Prims.of_int (277))
                                                                     (Prims.of_int (97)))))
                                                                     (Obj.magic
                                                                     (prover
@@ -1888,17 +1951,17 @@ let (prove :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (252))
+                                                                    (Prims.of_int (253))
                                                                     (Prims.of_int (65))
-                                                                    (Prims.of_int (258))
+                                                                    (Prims.of_int (259))
                                                                     (Prims.of_int (22)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (276))
+                                                                    (Prims.of_int (277))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (276))
+                                                                    (Prims.of_int (277))
                                                                     (Prims.of_int (97)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1906,17 +1969,17 @@ let (prove :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (253))
+                                                                    (Prims.of_int (254))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (253))
+                                                                    (Prims.of_int (254))
                                                                     (Prims.of_int (54)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (254))
+                                                                    (Prims.of_int (255))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (258))
+                                                                    (Prims.of_int (259))
                                                                     (Prims.of_int (22)))))
                                                                     (Obj.magic
                                                                     (Pulse_Checker_Prover_Substs.ss_to_nt_substs
@@ -2017,13 +2080,13 @@ let (try_frame_pre_uvs :
                     (FStar_Sealed.seal
                        (Obj.magic
                           (FStar_Range.mk_range "Pulse.Checker.Prover.fst"
-                             (Prims.of_int (287)) (Prims.of_int (10))
-                             (Prims.of_int (287)) (Prims.of_int (48)))))
+                             (Prims.of_int (288)) (Prims.of_int (10))
+                             (Prims.of_int (288)) (Prims.of_int (48)))))
                     (FStar_Sealed.seal
                        (Obj.magic
                           (FStar_Range.mk_range "Pulse.Checker.Prover.fst"
-                             (Prims.of_int (287)) (Prims.of_int (51))
-                             (Prims.of_int (343)) (Prims.of_int (65)))))
+                             (Prims.of_int (288)) (Prims.of_int (51))
+                             (Prims.of_int (344)) (Prims.of_int (65)))))
                     (FStar_Tactics_Effect.lift_div_tac
                        (fun uu___ ->
                           Pulse_Typing_Env.push_context g "try_frame_pre"
@@ -2036,17 +2099,17 @@ let (try_frame_pre_uvs :
                                   (Obj.magic
                                      (FStar_Range.mk_range
                                         "Pulse.Checker.Prover.fst"
-                                        (Prims.of_int (290))
+                                        (Prims.of_int (291))
                                         (Prims.of_int (4))
-                                        (Prims.of_int (290))
+                                        (Prims.of_int (291))
                                         (Prims.of_int (56)))))
                                (FStar_Sealed.seal
                                   (Obj.magic
                                      (FStar_Range.mk_range
                                         "Pulse.Checker.Prover.fst"
-                                        (Prims.of_int (287))
+                                        (Prims.of_int (288))
                                         (Prims.of_int (51))
-                                        (Prims.of_int (343))
+                                        (Prims.of_int (344))
                                         (Prims.of_int (65)))))
                                (Obj.magic
                                   (prove g1 ctxt () uvs
@@ -2063,17 +2126,17 @@ let (try_frame_pre_uvs :
                                                  (Obj.magic
                                                     (FStar_Range.mk_range
                                                        "Pulse.Checker.Prover.fst"
-                                                       (Prims.of_int (294))
+                                                       (Prims.of_int (295))
                                                        (Prims.of_int (4))
-                                                       (Prims.of_int (294))
+                                                       (Prims.of_int (295))
                                                        (Prims.of_int (49)))))
                                               (FStar_Sealed.seal
                                                  (Obj.magic
                                                     (FStar_Range.mk_range
                                                        "Pulse.Checker.Prover.fst"
-                                                       (Prims.of_int (296))
+                                                       (Prims.of_int (297))
                                                        (Prims.of_int (82))
-                                                       (Prims.of_int (343))
+                                                       (Prims.of_int (344))
                                                        (Prims.of_int (65)))))
                                               (FStar_Tactics_Effect.lift_div_tac
                                                  (fun uu___1 ->
@@ -2087,17 +2150,17 @@ let (try_frame_pre_uvs :
                                                             (Obj.magic
                                                                (FStar_Range.mk_range
                                                                   "Pulse.Checker.Prover.fst"
-                                                                  (Prims.of_int (297))
+                                                                  (Prims.of_int (298))
                                                                   (Prims.of_int (10))
-                                                                  (Prims.of_int (297))
+                                                                  (Prims.of_int (298))
                                                                   (Prims.of_int (35)))))
                                                          (FStar_Sealed.seal
                                                             (Obj.magic
                                                                (FStar_Range.mk_range
                                                                   "Pulse.Checker.Prover.fst"
-                                                                  (Prims.of_int (297))
+                                                                  (Prims.of_int (298))
                                                                   (Prims.of_int (38))
-                                                                  (Prims.of_int (343))
+                                                                  (Prims.of_int (344))
                                                                   (Prims.of_int (65)))))
                                                          (FStar_Tactics_Effect.lift_div_tac
                                                             (fun uu___1 ->
@@ -2112,18 +2175,18 @@ let (try_frame_pre_uvs :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (298))
+                                                                    (Prims.of_int (299))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (298))
+                                                                    (Prims.of_int (299))
                                                                     (Prims.of_int (32)))))
                                                                     (
                                                                     FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (298))
+                                                                    (Prims.of_int (299))
                                                                     (Prims.of_int (35))
-                                                                    (Prims.of_int (343))
+                                                                    (Prims.of_int (344))
                                                                     (Prims.of_int (65)))))
                                                                     (
                                                                     FStar_Tactics_Effect.lift_div_tac
@@ -2142,17 +2205,17 @@ let (try_frame_pre_uvs :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (301))
+                                                                    (Prims.of_int (302))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (301))
+                                                                    (Prims.of_int (302))
                                                                     (Prims.of_int (47)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (301))
+                                                                    (Prims.of_int (302))
                                                                     (Prims.of_int (50))
-                                                                    (Prims.of_int (343))
+                                                                    (Prims.of_int (344))
                                                                     (Prims.of_int (65)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -2170,17 +2233,17 @@ let (try_frame_pre_uvs :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (303))
+                                                                    (Prims.of_int (304))
                                                                     (Prims.of_int (82))
-                                                                    (Prims.of_int (303))
+                                                                    (Prims.of_int (304))
                                                                     (Prims.of_int (102)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (303))
+                                                                    (Prims.of_int (304))
                                                                     (Prims.of_int (105))
-                                                                    (Prims.of_int (343))
+                                                                    (Prims.of_int (344))
                                                                     (Prims.of_int (65)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -2199,17 +2262,17 @@ let (try_frame_pre_uvs :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (305))
+                                                                    (Prims.of_int (306))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (305))
+                                                                    (Prims.of_int (306))
                                                                     (Prims.of_int (18)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (305))
+                                                                    (Prims.of_int (306))
                                                                     (Prims.of_int (21))
-                                                                    (Prims.of_int (343))
+                                                                    (Prims.of_int (344))
                                                                     (Prims.of_int (65)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -2225,17 +2288,17 @@ let (try_frame_pre_uvs :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (306))
+                                                                    (Prims.of_int (307))
                                                                     (Prims.of_int (11))
-                                                                    (Prims.of_int (306))
+                                                                    (Prims.of_int (307))
                                                                     (Prims.of_int (21)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (306))
+                                                                    (Prims.of_int (307))
                                                                     (Prims.of_int (24))
-                                                                    (Prims.of_int (343))
+                                                                    (Prims.of_int (344))
                                                                     (Prims.of_int (65)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -2252,17 +2315,17 @@ let (try_frame_pre_uvs :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (307))
+                                                                    (Prims.of_int (308))
                                                                     (Prims.of_int (11))
-                                                                    (Prims.of_int (307))
+                                                                    (Prims.of_int (308))
                                                                     (Prims.of_int (42)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (308))
+                                                                    (Prims.of_int (309))
                                                                     (Prims.of_int (31))
-                                                                    (Prims.of_int (343))
+                                                                    (Prims.of_int (344))
                                                                     (Prims.of_int (65)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -2281,17 +2344,17 @@ let (try_frame_pre_uvs :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (309))
+                                                                    (Prims.of_int (310))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (309))
+                                                                    (Prims.of_int (310))
                                                                     (Prims.of_int (75)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (309))
+                                                                    (Prims.of_int (310))
                                                                     (Prims.of_int (78))
-                                                                    (Prims.of_int (343))
+                                                                    (Prims.of_int (344))
                                                                     (Prims.of_int (65)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -2313,17 +2376,17 @@ let (try_frame_pre_uvs :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (311))
+                                                                    (Prims.of_int (312))
                                                                     (Prims.of_int (29))
-                                                                    (Prims.of_int (311))
+                                                                    (Prims.of_int (312))
                                                                     (Prims.of_int (73)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (311))
+                                                                    (Prims.of_int (312))
                                                                     (Prims.of_int (76))
-                                                                    (Prims.of_int (343))
+                                                                    (Prims.of_int (344))
                                                                     (Prims.of_int (65)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -2341,17 +2404,17 @@ let (try_frame_pre_uvs :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (316))
+                                                                    (Prims.of_int (317))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (316))
+                                                                    (Prims.of_int (317))
                                                                     (Prims.of_int (81)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (323))
+                                                                    (Prims.of_int (324))
                                                                     (Prims.of_int (35))
-                                                                    (Prims.of_int (343))
+                                                                    (Prims.of_int (344))
                                                                     (Prims.of_int (65)))))
                                                                     (Obj.magic
                                                                     (Pulse_Checker_Base.continuation_elaborator_with_bind
@@ -2443,13 +2506,13 @@ let (try_frame_pre :
                   (FStar_Sealed.seal
                      (Obj.magic
                         (FStar_Range.mk_range "Pulse.Checker.Prover.fst"
-                           (Prims.of_int (351)) (Prims.of_int (12))
-                           (Prims.of_int (351)) (Prims.of_int (32)))))
+                           (Prims.of_int (352)) (Prims.of_int (12))
+                           (Prims.of_int (352)) (Prims.of_int (32)))))
                   (FStar_Sealed.seal
                      (Obj.magic
                         (FStar_Range.mk_range "Pulse.Checker.Prover.fst"
-                           (Prims.of_int (353)) (Prims.of_int (2))
-                           (Prims.of_int (353)) (Prims.of_int (48)))))
+                           (Prims.of_int (354)) (Prims.of_int (2))
+                           (Prims.of_int (354)) (Prims.of_int (48)))))
                   (FStar_Tactics_Effect.lift_div_tac
                      (fun uu___ ->
                         Pulse_Typing_Env.mk_env
@@ -2477,13 +2540,13 @@ let (prove_post_hint :
               (FStar_Sealed.seal
                  (Obj.magic
                     (FStar_Range.mk_range "Pulse.Checker.Prover.fst"
-                       (Prims.of_int (362)) (Prims.of_int (10))
-                       (Prims.of_int (362)) (Prims.of_int (46)))))
+                       (Prims.of_int (363)) (Prims.of_int (10))
+                       (Prims.of_int (363)) (Prims.of_int (46)))))
               (FStar_Sealed.seal
                  (Obj.magic
                     (FStar_Range.mk_range "Pulse.Checker.Prover.fst"
-                       (Prims.of_int (364)) (Prims.of_int (2))
-                       (Prims.of_int (414)) (Prims.of_int (102)))))
+                       (Prims.of_int (365)) (Prims.of_int (2))
+                       (Prims.of_int (418)) (Prims.of_int (102)))))
               (FStar_Tactics_Effect.lift_div_tac
                  (fun uu___ ->
                     Pulse_Typing_Env.push_context g "prove_post_hint" rng))
@@ -2503,17 +2566,17 @@ let (prove_post_hint :
                                    (Obj.magic
                                       (FStar_Range.mk_range
                                          "Pulse.Checker.Prover.fst"
-                                         (Prims.of_int (367))
+                                         (Prims.of_int (368))
                                          (Prims.of_int (79))
-                                         (Prims.of_int (367))
+                                         (Prims.of_int (368))
                                          (Prims.of_int (80)))))
                                 (FStar_Sealed.seal
                                    (Obj.magic
                                       (FStar_Range.mk_range
                                          "Pulse.Checker.Prover.fst"
-                                         (Prims.of_int (366))
+                                         (Prims.of_int (367))
                                          (Prims.of_int (21))
-                                         (Prims.of_int (414))
+                                         (Prims.of_int (418))
                                          (Prims.of_int (102)))))
                                 (FStar_Tactics_Effect.lift_div_tac
                                    (fun uu___ -> r))
@@ -2532,17 +2595,17 @@ let (prove_post_hint :
                                                   (Obj.magic
                                                      (FStar_Range.mk_range
                                                         "Pulse.Checker.Prover.fst"
-                                                        (Prims.of_int (369))
+                                                        (Prims.of_int (370))
                                                         (Prims.of_int (17))
-                                                        (Prims.of_int (369))
+                                                        (Prims.of_int (370))
                                                         (Prims.of_int (44)))))
                                                (FStar_Sealed.seal
                                                   (Obj.magic
                                                      (FStar_Range.mk_range
                                                         "Pulse.Checker.Prover.fst"
-                                                        (Prims.of_int (369))
+                                                        (Prims.of_int (370))
                                                         (Prims.of_int (47))
-                                                        (Prims.of_int (414))
+                                                        (Prims.of_int (418))
                                                         (Prims.of_int (102)))))
                                                (FStar_Tactics_Effect.lift_div_tac
                                                   (fun uu___1 ->
@@ -2556,17 +2619,17 @@ let (prove_post_hint :
                                                              (Obj.magic
                                                                 (FStar_Range.mk_range
                                                                    "Pulse.Checker.Prover.fst"
-                                                                   (Prims.of_int (370))
+                                                                   (Prims.of_int (371))
                                                                    (Prims.of_int (27))
-                                                                   (Prims.of_int (370))
+                                                                   (Prims.of_int (371))
                                                                    (Prims.of_int (66)))))
                                                           (FStar_Sealed.seal
                                                              (Obj.magic
                                                                 (FStar_Range.mk_range
                                                                    "Pulse.Checker.Prover.fst"
-                                                                   (Prims.of_int (373))
+                                                                   (Prims.of_int (374))
                                                                    (Prims.of_int (4))
-                                                                   (Prims.of_int (414))
+                                                                   (Prims.of_int (418))
                                                                    (Prims.of_int (102)))))
                                                           (FStar_Tactics_Effect.lift_div_tac
                                                              (fun uu___1 ->
@@ -2592,17 +2655,17 @@ let (prove_post_hint :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (376))
+                                                                    (Prims.of_int (377))
                                                                     (Prims.of_int (28))
-                                                                    (Prims.of_int (382))
+                                                                    (Prims.of_int (383))
                                                                     (Prims.of_int (7)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (376))
+                                                                    (Prims.of_int (377))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (382))
+                                                                    (Prims.of_int (383))
                                                                     (Prims.of_int (7)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -2610,17 +2673,17 @@ let (prove_post_hint :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (376))
+                                                                    (Prims.of_int (377))
                                                                     (Prims.of_int (28))
-                                                                    (Prims.of_int (382))
+                                                                    (Prims.of_int (383))
                                                                     (Prims.of_int (7)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (376))
+                                                                    (Prims.of_int (377))
                                                                     (Prims.of_int (28))
-                                                                    (Prims.of_int (382))
+                                                                    (Prims.of_int (383))
                                                                     (Prims.of_int (7)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -2628,17 +2691,17 @@ let (prove_post_hint :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (378))
+                                                                    (Prims.of_int (379))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (381))
+                                                                    (Prims.of_int (382))
                                                                     (Prims.of_int (38)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (376))
+                                                                    (Prims.of_int (377))
                                                                     (Prims.of_int (28))
-                                                                    (Prims.of_int (382))
+                                                                    (Prims.of_int (383))
                                                                     (Prims.of_int (7)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -2646,17 +2709,17 @@ let (prove_post_hint :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (379))
+                                                                    (Prims.of_int (380))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (381))
+                                                                    (Prims.of_int (382))
                                                                     (Prims.of_int (38)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (378))
+                                                                    (Prims.of_int (379))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (381))
+                                                                    (Prims.of_int (382))
                                                                     (Prims.of_int (38)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -2664,17 +2727,17 @@ let (prove_post_hint :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (379))
+                                                                    (Prims.of_int (380))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (379))
+                                                                    (Prims.of_int (380))
                                                                     (Prims.of_int (24)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (379))
+                                                                    (Prims.of_int (380))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (381))
+                                                                    (Prims.of_int (382))
                                                                     (Prims.of_int (38)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -2682,17 +2745,17 @@ let (prove_post_hint :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (379))
+                                                                    (Prims.of_int (380))
                                                                     (Prims.of_int (17))
-                                                                    (Prims.of_int (379))
+                                                                    (Prims.of_int (380))
                                                                     (Prims.of_int (24)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (379))
+                                                                    (Prims.of_int (380))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (379))
+                                                                    (Prims.of_int (380))
                                                                     (Prims.of_int (24)))))
                                                                     (Obj.magic
                                                                     (Pulse_PP.pp
@@ -2715,17 +2778,17 @@ let (prove_post_hint :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (380))
-                                                                    (Prims.of_int (8))
                                                                     (Prims.of_int (381))
+                                                                    (Prims.of_int (8))
+                                                                    (Prims.of_int (382))
                                                                     (Prims.of_int (38)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (379))
+                                                                    (Prims.of_int (380))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (381))
+                                                                    (Prims.of_int (382))
                                                                     (Prims.of_int (38)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -2733,17 +2796,17 @@ let (prove_post_hint :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (381))
+                                                                    (Prims.of_int (382))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (381))
+                                                                    (Prims.of_int (382))
                                                                     (Prims.of_int (38)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (380))
-                                                                    (Prims.of_int (8))
                                                                     (Prims.of_int (381))
+                                                                    (Prims.of_int (8))
+                                                                    (Prims.of_int (382))
                                                                     (Prims.of_int (38)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -2751,17 +2814,17 @@ let (prove_post_hint :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (381))
+                                                                    (Prims.of_int (382))
                                                                     (Prims.of_int (17))
-                                                                    (Prims.of_int (381))
+                                                                    (Prims.of_int (382))
                                                                     (Prims.of_int (38)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (381))
+                                                                    (Prims.of_int (382))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (381))
+                                                                    (Prims.of_int (382))
                                                                     (Prims.of_int (38)))))
                                                                     (Obj.magic
                                                                     (Pulse_PP.pp
@@ -2854,17 +2917,17 @@ let (prove_post_hint :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (387))
+                                                                    (Prims.of_int (388))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (387))
+                                                                    (Prims.of_int (388))
                                                                     (Prims.of_int (90)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (385))
+                                                                    (Prims.of_int (386))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (414))
+                                                                    (Prims.of_int (418))
                                                                     (Prims.of_int (102)))))
                                                                     (Obj.magic
                                                                     (prove g2
@@ -2892,17 +2955,17 @@ let (prove_post_hint :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (392))
+                                                                    (Prims.of_int (393))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (392))
+                                                                    (Prims.of_int (393))
                                                                     (Prims.of_int (27)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (394))
+                                                                    (Prims.of_int (395))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (414))
+                                                                    (Prims.of_int (418))
                                                                     (Prims.of_int (102)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -2929,17 +2992,17 @@ let (prove_post_hint :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (397))
+                                                                    (Prims.of_int (398))
                                                                     (Prims.of_int (30))
-                                                                    (Prims.of_int (401))
+                                                                    (Prims.of_int (405))
                                                                     (Prims.of_int (9)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (397))
+                                                                    (Prims.of_int (398))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (401))
+                                                                    (Prims.of_int (405))
                                                                     (Prims.of_int (9)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -2947,17 +3010,17 @@ let (prove_post_hint :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (397))
+                                                                    (Prims.of_int (398))
                                                                     (Prims.of_int (30))
-                                                                    (Prims.of_int (401))
+                                                                    (Prims.of_int (405))
                                                                     (Prims.of_int (9)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (397))
+                                                                    (Prims.of_int (398))
                                                                     (Prims.of_int (30))
-                                                                    (Prims.of_int (401))
+                                                                    (Prims.of_int (405))
                                                                     (Prims.of_int (9)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -2965,17 +3028,17 @@ let (prove_post_hint :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (399))
-                                                                    (Prims.of_int (10))
                                                                     (Prims.of_int (400))
+                                                                    (Prims.of_int (10))
+                                                                    (Prims.of_int (401))
                                                                     (Prims.of_int (38)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (397))
+                                                                    (Prims.of_int (398))
                                                                     (Prims.of_int (30))
-                                                                    (Prims.of_int (401))
+                                                                    (Prims.of_int (405))
                                                                     (Prims.of_int (9)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -2983,17 +3046,17 @@ let (prove_post_hint :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (400))
+                                                                    (Prims.of_int (401))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (400))
+                                                                    (Prims.of_int (401))
                                                                     (Prims.of_int (38)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (399))
-                                                                    (Prims.of_int (10))
                                                                     (Prims.of_int (400))
+                                                                    (Prims.of_int (10))
+                                                                    (Prims.of_int (401))
                                                                     (Prims.of_int (38)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -3001,17 +3064,17 @@ let (prove_post_hint :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (400))
+                                                                    (Prims.of_int (401))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (400))
+                                                                    (Prims.of_int (401))
                                                                     (Prims.of_int (38)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (400))
+                                                                    (Prims.of_int (401))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (400))
+                                                                    (Prims.of_int (401))
                                                                     (Prims.of_int (38)))))
                                                                     (Obj.magic
                                                                     (Pulse_PP.pp
@@ -3038,7 +3101,16 @@ let (prove_post_hint :
                                                                     FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
                                                                     uu___5 ->
-                                                                    [uu___4]))))
+                                                                    [uu___4;
+                                                                    if
+                                                                    Pulse_Syntax_Base.uu___is_Tm_Star
+                                                                    remaining_ctxt.Pulse_Syntax_Base.t
+                                                                    then
+                                                                    Pulse_PP.text
+                                                                    "Did you forget to free these resources?"
+                                                                    else
+                                                                    Pulse_PP.text
+                                                                    "Did you forget to free this resource?"]))))
                                                                     (fun
                                                                     uu___4 ->
                                                                     FStar_Tactics_Effect.lift_div_tac

--- a/src/ocaml/plugin/generated/Pulse_Checker_Prover.ml
+++ b/src/ocaml/plugin/generated/Pulse_Checker_Prover.ml
@@ -171,17 +171,17 @@ let rec (match_q :
                                              (Obj.magic
                                                 (FStar_Range.mk_range
                                                    "Pulse.Checker.Prover.fst"
-                                                   (Prims.of_int (77))
+                                                   (Prims.of_int (78))
                                                    (Prims.of_int (12))
-                                                   (Prims.of_int (77))
+                                                   (Prims.of_int (78))
                                                    (Prims.of_int (35)))))
                                           (FStar_Sealed.seal
                                              (Obj.magic
                                                 (FStar_Range.mk_range
                                                    "Pulse.Checker.Prover.fst"
-                                                   (Prims.of_int (77))
+                                                   (Prims.of_int (78))
                                                    (Prims.of_int (38))
-                                                   (Prims.of_int (86))
+                                                   (Prims.of_int (87))
                                                    (Prims.of_int (38)))))
                                           (FStar_Tactics_Effect.lift_div_tac
                                              (fun uu___3 ->
@@ -195,17 +195,17 @@ let rec (match_q :
                                                         (Obj.magic
                                                            (FStar_Range.mk_range
                                                               "Pulse.Checker.Prover.fst"
-                                                              (Prims.of_int (79))
+                                                              (Prims.of_int (80))
                                                               (Prims.of_int (6))
-                                                              (Prims.of_int (79))
+                                                              (Prims.of_int (80))
                                                               (Prims.of_int (69)))))
                                                      (FStar_Sealed.seal
                                                         (Obj.magic
                                                            (FStar_Range.mk_range
                                                               "Pulse.Checker.Prover.fst"
-                                                              (Prims.of_int (80))
+                                                              (Prims.of_int (81))
                                                               (Prims.of_int (4))
-                                                              (Prims.of_int (86))
+                                                              (Prims.of_int (87))
                                                               (Prims.of_int (38)))))
                                                      (Obj.magic
                                                         (Pulse_Checker_Prover_Match.match_step
@@ -236,17 +236,17 @@ let rec (match_q :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (84))
-                                                                    (Prims.of_int (8))
                                                                     (Prims.of_int (85))
+                                                                    (Prims.of_int (8))
+                                                                    (Prims.of_int (86))
                                                                     (Prims.of_int (49)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (86))
+                                                                    (Prims.of_int (87))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (86))
+                                                                    (Prims.of_int (87))
                                                                     (Prims.of_int (38)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -299,13 +299,13 @@ let rec (prove_pures :
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Checker.Prover.fst"
-                                (Prims.of_int (95)) (Prims.of_int (18))
-                                (Prims.of_int (95)) (Prims.of_int (57)))))
+                                (Prims.of_int (96)) (Prims.of_int (18))
+                                (Prims.of_int (96)) (Prims.of_int (57)))))
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Checker.Prover.fst"
-                                (Prims.of_int (96)) (Prims.of_int (4))
-                                (Prims.of_int (104)) (Prims.of_int (12)))))
+                                (Prims.of_int (97)) (Prims.of_int (4))
+                                (Prims.of_int (105)) (Prims.of_int (12)))))
                        (Obj.magic
                           (Pulse_Checker_Prover_IntroPure.intro_pure preamble
                              pst p unsolved' ()))
@@ -319,17 +319,17 @@ let rec (prove_pures :
                                          (Obj.magic
                                             (FStar_Range.mk_range
                                                "Pulse.Checker.Prover.fst"
-                                               (Prims.of_int (98))
+                                               (Prims.of_int (99))
                                                (Prims.of_int (24))
-                                               (Prims.of_int (98))
+                                               (Prims.of_int (99))
                                                (Prims.of_int (100)))))
                                       (FStar_Sealed.seal
                                          (Obj.magic
                                             (FStar_Range.mk_range
                                                "Pulse.Checker.Prover.fst"
-                                               (Prims.of_int (98))
+                                               (Prims.of_int (99))
                                                (Prims.of_int (7))
-                                               (Prims.of_int (98))
+                                               (Prims.of_int (99))
                                                (Prims.of_int (100)))))
                                       (Obj.magic
                                          (FStar_Tactics_Effect.tac_bind
@@ -337,9 +337,9 @@ let rec (prove_pures :
                                                (Obj.magic
                                                   (FStar_Range.mk_range
                                                      "Pulse.Checker.Prover.fst"
-                                                     (Prims.of_int (98))
+                                                     (Prims.of_int (99))
                                                      (Prims.of_int (79))
-                                                     (Prims.of_int (98))
+                                                     (Prims.of_int (99))
                                                      (Prims.of_int (99)))))
                                             (FStar_Sealed.seal
                                                (Obj.magic
@@ -373,17 +373,17 @@ let rec (prove_pures :
                                          (Obj.magic
                                             (FStar_Range.mk_range
                                                "Pulse.Checker.Prover.fst"
-                                               (Prims.of_int (100))
+                                               (Prims.of_int (101))
                                                (Prims.of_int (18))
-                                               (Prims.of_int (100))
+                                               (Prims.of_int (101))
                                                (Prims.of_int (34)))))
                                       (FStar_Sealed.seal
                                          (Obj.magic
                                             (FStar_Range.mk_range
                                                "Pulse.Checker.Prover.fst"
-                                               (Prims.of_int (100))
+                                               (Prims.of_int (101))
                                                (Prims.of_int (11))
-                                               (Prims.of_int (100))
+                                               (Prims.of_int (101))
                                                (Prims.of_int (15)))))
                                       (Obj.magic (prove_pures preamble pst1))
                                       (fun pst2 ->
@@ -396,21 +396,21 @@ let rec (prove_pures :
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Checker.Prover.fst"
-                                (Prims.of_int (107)) (Prims.of_int (6))
-                                (Prims.of_int (108)) (Prims.of_int (48)))))
+                                (Prims.of_int (108)) (Prims.of_int (6))
+                                (Prims.of_int (109)) (Prims.of_int (48)))))
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Checker.Prover.fst"
-                                (Prims.of_int (106)) (Prims.of_int (4))
-                                (Prims.of_int (108)) (Prims.of_int (48)))))
+                                (Prims.of_int (107)) (Prims.of_int (4))
+                                (Prims.of_int (109)) (Prims.of_int (48)))))
                        (Obj.magic
                           (FStar_Tactics_Effect.tac_bind
                              (FStar_Sealed.seal
                                 (Obj.magic
                                    (FStar_Range.mk_range
                                       "Pulse.Checker.Prover.fst"
-                                      (Prims.of_int (108)) (Prims.of_int (9))
-                                      (Prims.of_int (108))
+                                      (Prims.of_int (109)) (Prims.of_int (9))
+                                      (Prims.of_int (109))
                                       (Prims.of_int (47)))))
                              (FStar_Sealed.seal
                                 (Obj.magic
@@ -449,12 +449,12 @@ let rec (prover :
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.Prover.fst"
-                 (Prims.of_int (117)) (Prims.of_int (2)) (Prims.of_int (120))
+                 (Prims.of_int (118)) (Prims.of_int (2)) (Prims.of_int (121))
                  (Prims.of_int (55)))))
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.Prover.fst"
-                 (Prims.of_int (122)) (Prims.of_int (2)) (Prims.of_int (168))
+                 (Prims.of_int (123)) (Prims.of_int (2)) (Prims.of_int (178))
                  (Prims.of_int (32)))))
         (Obj.magic
            (Pulse_Checker_Prover_Util.debug_prover
@@ -464,13 +464,13 @@ let rec (prover :
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Checker.Prover.fst"
-                            (Prims.of_int (120)) (Prims.of_int (6))
-                            (Prims.of_int (120)) (Prims.of_int (54)))))
+                            (Prims.of_int (121)) (Prims.of_int (6))
+                            (Prims.of_int (121)) (Prims.of_int (54)))))
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Checker.Prover.fst"
-                            (Prims.of_int (118)) (Prims.of_int (4))
-                            (Prims.of_int (120)) (Prims.of_int (54)))))
+                            (Prims.of_int (119)) (Prims.of_int (4))
+                            (Prims.of_int (121)) (Prims.of_int (54)))))
                    (Obj.magic
                       (Pulse_Syntax_Printer.term_to_string
                          (Pulse_Typing_Combinators.list_as_vprop
@@ -483,17 +483,17 @@ let rec (prover :
                                  (Obj.magic
                                     (FStar_Range.mk_range
                                        "Pulse.Checker.Prover.fst"
-                                       (Prims.of_int (118))
+                                       (Prims.of_int (119))
                                        (Prims.of_int (4))
-                                       (Prims.of_int (120))
+                                       (Prims.of_int (121))
                                        (Prims.of_int (54)))))
                               (FStar_Sealed.seal
                                  (Obj.magic
                                     (FStar_Range.mk_range
                                        "Pulse.Checker.Prover.fst"
-                                       (Prims.of_int (118))
+                                       (Prims.of_int (119))
                                        (Prims.of_int (4))
-                                       (Prims.of_int (120))
+                                       (Prims.of_int (121))
                                        (Prims.of_int (54)))))
                               (Obj.magic
                                  (FStar_Tactics_Effect.tac_bind
@@ -501,9 +501,9 @@ let rec (prover :
                                        (Obj.magic
                                           (FStar_Range.mk_range
                                              "Pulse.Checker.Prover.fst"
-                                             (Prims.of_int (119))
+                                             (Prims.of_int (120))
                                              (Prims.of_int (6))
-                                             (Prims.of_int (119))
+                                             (Prims.of_int (120))
                                              (Prims.of_int (60)))))
                                     (FStar_Sealed.seal
                                        (Obj.magic
@@ -546,14 +546,14 @@ let rec (prover :
                              (Obj.magic
                                 (FStar_Range.mk_range
                                    "Pulse.Checker.Prover.fst"
-                                   (Prims.of_int (125)) (Prims.of_int (14))
-                                   (Prims.of_int (125)) (Prims.of_int (45)))))
+                                   (Prims.of_int (126)) (Prims.of_int (14))
+                                   (Prims.of_int (126)) (Prims.of_int (45)))))
                           (FStar_Sealed.seal
                              (Obj.magic
                                 (FStar_Range.mk_range
                                    "Pulse.Checker.Prover.fst"
-                                   (Prims.of_int (127)) (Prims.of_int (4))
-                                   (Prims.of_int (168)) (Prims.of_int (32)))))
+                                   (Prims.of_int (128)) (Prims.of_int (4))
+                                   (Prims.of_int (178)) (Prims.of_int (32)))))
                           (Obj.magic
                              (Pulse_Checker_Prover_ElimExists.elim_exists_pst
                                 preamble pst0))
@@ -565,17 +565,17 @@ let rec (prover :
                                         (Obj.magic
                                            (FStar_Range.mk_range
                                               "Pulse.Checker.Prover.fst"
-                                              (Prims.of_int (127))
+                                              (Prims.of_int (128))
                                               (Prims.of_int (4))
-                                              (Prims.of_int (129))
+                                              (Prims.of_int (130))
                                               (Prims.of_int (62)))))
                                      (FStar_Sealed.seal
                                         (Obj.magic
                                            (FStar_Range.mk_range
                                               "Pulse.Checker.Prover.fst"
-                                              (Prims.of_int (129))
+                                              (Prims.of_int (130))
                                               (Prims.of_int (63))
-                                              (Prims.of_int (168))
+                                              (Prims.of_int (178))
                                               (Prims.of_int (32)))))
                                      (Obj.magic
                                         (Pulse_Checker_Prover_Util.debug_prover
@@ -586,9 +586,9 @@ let rec (prover :
                                                    (Obj.magic
                                                       (FStar_Range.mk_range
                                                          "Pulse.Checker.Prover.fst"
-                                                         (Prims.of_int (129))
+                                                         (Prims.of_int (130))
                                                          (Prims.of_int (8))
-                                                         (Prims.of_int (129))
+                                                         (Prims.of_int (130))
                                                          (Prims.of_int (61)))))
                                                 (FStar_Sealed.seal
                                                    (Obj.magic
@@ -617,17 +617,17 @@ let rec (prover :
                                                    (Obj.magic
                                                       (FStar_Range.mk_range
                                                          "Pulse.Checker.Prover.fst"
-                                                         (Prims.of_int (131))
+                                                         (Prims.of_int (132))
                                                          (Prims.of_int (14))
-                                                         (Prims.of_int (131))
+                                                         (Prims.of_int (132))
                                                          (Prims.of_int (40)))))
                                                 (FStar_Sealed.seal
                                                    (Obj.magic
                                                       (FStar_Range.mk_range
                                                          "Pulse.Checker.Prover.fst"
-                                                         (Prims.of_int (133))
+                                                         (Prims.of_int (134))
                                                          (Prims.of_int (4))
-                                                         (Prims.of_int (168))
+                                                         (Prims.of_int (178))
                                                          (Prims.of_int (32)))))
                                                 (Obj.magic
                                                    (Pulse_Checker_Prover_ElimPure.elim_pure_pst
@@ -640,17 +640,17 @@ let rec (prover :
                                                               (Obj.magic
                                                                  (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (133))
+                                                                    (Prims.of_int (134))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (135))
+                                                                    (Prims.of_int (136))
                                                                     (Prims.of_int (62)))))
                                                            (FStar_Sealed.seal
                                                               (Obj.magic
                                                                  (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (135))
+                                                                    (Prims.of_int (136))
                                                                     (Prims.of_int (63))
-                                                                    (Prims.of_int (168))
+                                                                    (Prims.of_int (178))
                                                                     (Prims.of_int (32)))))
                                                            (Obj.magic
                                                               (Pulse_Checker_Prover_Util.debug_prover
@@ -662,9 +662,9 @@ let rec (prover :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (135))
+                                                                    (Prims.of_int (136))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (135))
+                                                                    (Prims.of_int (136))
                                                                     (Prims.of_int (61)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -696,17 +696,17 @@ let rec (prover :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (137))
+                                                                    (Prims.of_int (138))
                                                                     (Prims.of_int (29))
-                                                                    (Prims.of_int (137))
+                                                                    (Prims.of_int (138))
                                                                     (Prims.of_int (82)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (135))
+                                                                    (Prims.of_int (136))
                                                                     (Prims.of_int (63))
-                                                                    (Prims.of_int (168))
+                                                                    (Prims.of_int (178))
                                                                     (Prims.of_int (32)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -733,17 +733,17 @@ let rec (prover :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (139))
+                                                                    (Prims.of_int (140))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (141))
+                                                                    (Prims.of_int (142))
                                                                     (Prims.of_int (87)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (141))
+                                                                    (Prims.of_int (142))
                                                                     (Prims.of_int (88))
-                                                                    (Prims.of_int (168))
+                                                                    (Prims.of_int (178))
                                                                     (Prims.of_int (32)))))
                                                                     (Obj.magic
                                                                     (Pulse_Checker_Prover_Util.debug_prover
@@ -755,17 +755,17 @@ let rec (prover :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (141))
+                                                                    (Prims.of_int (142))
                                                                     (Prims.of_int (47))
-                                                                    (Prims.of_int (141))
+                                                                    (Prims.of_int (142))
                                                                     (Prims.of_int (86)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (140))
-                                                                    (Prims.of_int (6))
                                                                     (Prims.of_int (141))
+                                                                    (Prims.of_int (6))
+                                                                    (Prims.of_int (142))
                                                                     (Prims.of_int (86)))))
                                                                     (Obj.magic
                                                                     (Pulse_Syntax_Printer.term_to_string
@@ -781,17 +781,17 @@ let rec (prover :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (140))
-                                                                    (Prims.of_int (6))
                                                                     (Prims.of_int (141))
+                                                                    (Prims.of_int (6))
+                                                                    (Prims.of_int (142))
                                                                     (Prims.of_int (86)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (140))
-                                                                    (Prims.of_int (6))
                                                                     (Prims.of_int (141))
+                                                                    (Prims.of_int (6))
+                                                                    (Prims.of_int (142))
                                                                     (Prims.of_int (86)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -799,9 +799,9 @@ let rec (prover :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (141))
+                                                                    (Prims.of_int (142))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (141))
+                                                                    (Prims.of_int (142))
                                                                     (Prims.of_int (46)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -847,17 +847,17 @@ let rec (prover :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (143))
+                                                                    (Prims.of_int (144))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (143))
+                                                                    (Prims.of_int (144))
                                                                     (Prims.of_int (49)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (145))
+                                                                    (Prims.of_int (146))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (168))
+                                                                    (Prims.of_int (178))
                                                                     (Prims.of_int (32)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -878,17 +878,17 @@ let rec (prover :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (145))
+                                                                    (Prims.of_int (146))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (147))
+                                                                    (Prims.of_int (148))
                                                                     (Prims.of_int (56)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (149))
+                                                                    (Prims.of_int (150))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (168))
+                                                                    (Prims.of_int (178))
                                                                     (Prims.of_int (32)))))
                                                                     (Obj.magic
                                                                     (Pulse_Checker_Prover_Util.debug_prover
@@ -900,9 +900,9 @@ let rec (prover :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (147))
+                                                                    (Prims.of_int (148))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (147))
+                                                                    (Prims.of_int (148))
                                                                     (Prims.of_int (55)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -958,17 +958,17 @@ let rec (prover :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (153))
+                                                                    (Prims.of_int (154))
                                                                     (Prims.of_int (33))
-                                                                    (Prims.of_int (153))
+                                                                    (Prims.of_int (154))
                                                                     (Prims.of_int (85)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (152))
+                                                                    (Prims.of_int (153))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (168))
+                                                                    (Prims.of_int (178))
                                                                     (Prims.of_int (32)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -995,17 +995,17 @@ let rec (prover :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (154))
+                                                                    (Prims.of_int (155))
                                                                     (Prims.of_int (16))
-                                                                    (Prims.of_int (154))
+                                                                    (Prims.of_int (155))
                                                                     (Prims.of_int (53)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (155))
+                                                                    (Prims.of_int (156))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (168))
+                                                                    (Prims.of_int (178))
                                                                     (Prims.of_int (32)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -1044,17 +1044,17 @@ let rec (prover :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (158))
+                                                                    (Prims.of_int (159))
                                                                     (Prims.of_int (22))
-                                                                    (Prims.of_int (158))
+                                                                    (Prims.of_int (159))
                                                                     (Prims.of_int (43)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (159))
+                                                                    (Prims.of_int (160))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (168))
+                                                                    (Prims.of_int (178))
                                                                     (Prims.of_int (32)))))
                                                                     (Obj.magic
                                                                     (match_q
@@ -1078,17 +1078,53 @@ let rec (prover :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (161))
+                                                                    (Prims.of_int (164))
                                                                     (Prims.of_int (20))
-                                                                    (Prims.of_int (166))
-                                                                    (Prims.of_int (44)))))
+                                                                    (Prims.of_int (173))
+                                                                    (Prims.of_int (11)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (167))
+                                                                    (Prims.of_int (177))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (167))
+                                                                    (Prims.of_int (177))
+                                                                    (Prims.of_int (34)))))
+                                                                    (Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Prover.fst"
+                                                                    (Prims.of_int (165))
+                                                                    (Prims.of_int (12))
+                                                                    (Prims.of_int (166))
+                                                                    (Prims.of_int (30)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Prover.fst"
+                                                                    (Prims.of_int (164))
+                                                                    (Prims.of_int (20))
+                                                                    (Prims.of_int (173))
+                                                                    (Prims.of_int (11)))))
+                                                                    (Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Prover.fst"
+                                                                    (Prims.of_int (166))
+                                                                    (Prims.of_int (16))
+                                                                    (Prims.of_int (166))
+                                                                    (Prims.of_int (30)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Prover.fst"
+                                                                    (Prims.of_int (165))
+                                                                    (Prims.of_int (12))
+                                                                    (Prims.of_int (166))
                                                                     (Prims.of_int (30)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1097,20 +1133,39 @@ let rec (prover :
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
                                                                     (Prims.of_int (166))
-                                                                    (Prims.of_int (12))
+                                                                    (Prims.of_int (24))
                                                                     (Prims.of_int (166))
-                                                                    (Prims.of_int (44)))))
+                                                                    (Prims.of_int (30)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (161))
-                                                                    (Prims.of_int (20))
                                                                     (Prims.of_int (166))
-                                                                    (Prims.of_int (44)))))
+                                                                    (Prims.of_int (16))
+                                                                    (Prims.of_int (166))
+                                                                    (Prims.of_int (30)))))
                                                                     (Obj.magic
-                                                                    (Pulse_Syntax_Printer.term_to_string
-                                                                    preamble.Pulse_Checker_Prover_Base.ctxt))
+                                                                    (Pulse_PP.pp
+                                                                    Pulse_PP.uu___42
+                                                                    q))
+                                                                    (fun
+                                                                    uu___9 ->
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___10
+                                                                    ->
+                                                                    FStar_Pprint.bquotes
+                                                                    uu___9))))
+                                                                    (fun
+                                                                    uu___9 ->
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___10
+                                                                    ->
+                                                                    FStar_Pprint.op_Hat_Slash_Hat
+                                                                    (FStar_Pprint.doc_of_string
+                                                                    "Cannot prove vprop")
+                                                                    uu___9))))
                                                                     (fun
                                                                     uu___9 ->
                                                                     (fun
@@ -1121,86 +1176,200 @@ let rec (prover :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (161))
+                                                                    (Prims.of_int (164))
                                                                     (Prims.of_int (20))
-                                                                    (Prims.of_int (166))
-                                                                    (Prims.of_int (44)))))
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (161))
-                                                                    (Prims.of_int (20))
-                                                                    (Prims.of_int (166))
-                                                                    (Prims.of_int (44)))))
-                                                                    (Obj.magic
-                                                                    (FStar_Tactics_Effect.tac_bind
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (165))
-                                                                    (Prims.of_int (12))
-                                                                    (Prims.of_int (165))
-                                                                    (Prims.of_int (45)))))
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (161))
-                                                                    (Prims.of_int (20))
-                                                                    (Prims.of_int (166))
-                                                                    (Prims.of_int (44)))))
-                                                                    (Obj.magic
-                                                                    (Pulse_Syntax_Printer.term_to_string
-                                                                    preamble.Pulse_Checker_Prover_Base.goals))
-                                                                    (fun
-                                                                    uu___10
-                                                                    ->
-                                                                    (fun
-                                                                    uu___10
-                                                                    ->
-                                                                    Obj.magic
-                                                                    (FStar_Tactics_Effect.tac_bind
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (161))
-                                                                    (Prims.of_int (20))
-                                                                    (Prims.of_int (166))
-                                                                    (Prims.of_int (44)))))
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (161))
-                                                                    (Prims.of_int (20))
-                                                                    (Prims.of_int (166))
-                                                                    (Prims.of_int (44)))))
-                                                                    (Obj.magic
-                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (Prims.of_int (173))
+                                                                    (Prims.of_int (11)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
                                                                     (Prims.of_int (164))
-                                                                    (Prims.of_int (12))
-                                                                    (Prims.of_int (164))
-                                                                    (Prims.of_int (65)))))
+                                                                    (Prims.of_int (20))
+                                                                    (Prims.of_int (173))
+                                                                    (Prims.of_int (11)))))
+                                                                    (Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (161))
-                                                                    (Prims.of_int (20))
-                                                                    (Prims.of_int (166))
-                                                                    (Prims.of_int (44)))))
+                                                                    (Prims.of_int (167))
+                                                                    (Prims.of_int (12))
+                                                                    (Prims.of_int (168))
+                                                                    (Prims.of_int (63)))))
+                                                                    (FStar_Sealed.seal
                                                                     (Obj.magic
-                                                                    (Pulse_Syntax_Printer.term_to_string
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Prover.fst"
+                                                                    (Prims.of_int (164))
+                                                                    (Prims.of_int (20))
+                                                                    (Prims.of_int (173))
+                                                                    (Prims.of_int (11)))))
+                                                                    (Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Prover.fst"
+                                                                    (Prims.of_int (168))
+                                                                    (Prims.of_int (16))
+                                                                    (Prims.of_int (168))
+                                                                    (Prims.of_int (63)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Prover.fst"
+                                                                    (Prims.of_int (167))
+                                                                    (Prims.of_int (12))
+                                                                    (Prims.of_int (168))
+                                                                    (Prims.of_int (63)))))
+                                                                    (Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Prover.fst"
+                                                                    (Prims.of_int (168))
+                                                                    (Prims.of_int (24))
+                                                                    (Prims.of_int (168))
+                                                                    (Prims.of_int (63)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Prover.fst"
+                                                                    (Prims.of_int (168))
+                                                                    (Prims.of_int (16))
+                                                                    (Prims.of_int (168))
+                                                                    (Prims.of_int (63)))))
+                                                                    (Obj.magic
+                                                                    (Pulse_PP.pp
+                                                                    Pulse_PP.uu___42
                                                                     (Pulse_Typing_Combinators.list_as_vprop
                                                                     pst3.Pulse_Checker_Prover_Base.remaining_ctxt)))
                                                                     (fun
+                                                                    uu___10
+                                                                    ->
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___11
+                                                                    ->
+                                                                    FStar_Pprint.bquotes
+                                                                    uu___10))))
+                                                                    (fun
+                                                                    uu___10
+                                                                    ->
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___11
+                                                                    ->
+                                                                    FStar_Pprint.op_Hat_Slash_Hat
+                                                                    (FStar_Pprint.doc_of_string
+                                                                    "In the context")
+                                                                    uu___10))))
+                                                                    (fun
+                                                                    uu___10
+                                                                    ->
+                                                                    (fun
+                                                                    uu___10
+                                                                    ->
+                                                                    Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Prover.fst"
+                                                                    (Prims.of_int (164))
+                                                                    (Prims.of_int (20))
+                                                                    (Prims.of_int (173))
+                                                                    (Prims.of_int (11)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Prover.fst"
+                                                                    (Prims.of_int (164))
+                                                                    (Prims.of_int (20))
+                                                                    (Prims.of_int (173))
+                                                                    (Prims.of_int (11)))))
+                                                                    (Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Prover.fst"
+                                                                    (Prims.of_int (169))
+                                                                    (Prims.of_int (12))
+                                                                    (Prims.of_int (170))
+                                                                    (Prims.of_int (43)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Prover.fst"
+                                                                    (Prims.of_int (164))
+                                                                    (Prims.of_int (20))
+                                                                    (Prims.of_int (173))
+                                                                    (Prims.of_int (11)))))
+                                                                    (Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Prover.fst"
+                                                                    (Prims.of_int (170))
+                                                                    (Prims.of_int (16))
+                                                                    (Prims.of_int (170))
+                                                                    (Prims.of_int (43)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Prover.fst"
+                                                                    (Prims.of_int (169))
+                                                                    (Prims.of_int (12))
+                                                                    (Prims.of_int (170))
+                                                                    (Prims.of_int (43)))))
+                                                                    (Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Prover.fst"
+                                                                    (Prims.of_int (170))
+                                                                    (Prims.of_int (24))
+                                                                    (Prims.of_int (170))
+                                                                    (Prims.of_int (43)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Prover.fst"
+                                                                    (Prims.of_int (170))
+                                                                    (Prims.of_int (16))
+                                                                    (Prims.of_int (170))
+                                                                    (Prims.of_int (43)))))
+                                                                    (Obj.magic
+                                                                    (Pulse_PP.pp
+                                                                    Pulse_PP.uu___42
+                                                                    preamble.Pulse_Checker_Prover_Base.goals))
+                                                                    (fun
+                                                                    uu___11
+                                                                    ->
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___12
+                                                                    ->
+                                                                    FStar_Pprint.bquotes
+                                                                    uu___11))))
+                                                                    (fun
+                                                                    uu___11
+                                                                    ->
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___12
+                                                                    ->
+                                                                    FStar_Pprint.op_Hat_Slash_Hat
+                                                                    (FStar_Pprint.doc_of_string
+                                                                    "The prover was started with goal")
+                                                                    uu___11))))
+                                                                    (fun
                                                                     uu___11
                                                                     ->
                                                                     (fun
@@ -1212,39 +1381,76 @@ let rec (prover :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (161))
+                                                                    (Prims.of_int (164))
                                                                     (Prims.of_int (20))
-                                                                    (Prims.of_int (166))
-                                                                    (Prims.of_int (44)))))
+                                                                    (Prims.of_int (173))
+                                                                    (Prims.of_int (11)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (161))
+                                                                    (Prims.of_int (164))
                                                                     (Prims.of_int (20))
-                                                                    (Prims.of_int (166))
-                                                                    (Prims.of_int (44)))))
+                                                                    (Prims.of_int (173))
+                                                                    (Prims.of_int (11)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (163))
+                                                                    (Prims.of_int (171))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (163))
-                                                                    (Prims.of_int (32)))))
+                                                                    (Prims.of_int (172))
+                                                                    (Prims.of_int (42)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
-                                                                    "FStar.Printf.fst"
-                                                                    (Prims.of_int (121))
-                                                                    (Prims.of_int (8))
-                                                                    (Prims.of_int (123))
-                                                                    (Prims.of_int (44)))))
+                                                                    "Pulse.Checker.Prover.fst"
+                                                                    (Prims.of_int (164))
+                                                                    (Prims.of_int (20))
+                                                                    (Prims.of_int (173))
+                                                                    (Prims.of_int (11)))))
                                                                     (Obj.magic
-                                                                    (Pulse_Syntax_Printer.term_to_string
-                                                                    q))
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Prover.fst"
+                                                                    (Prims.of_int (172))
+                                                                    (Prims.of_int (16))
+                                                                    (Prims.of_int (172))
+                                                                    (Prims.of_int (42)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Prover.fst"
+                                                                    (Prims.of_int (171))
+                                                                    (Prims.of_int (12))
+                                                                    (Prims.of_int (172))
+                                                                    (Prims.of_int (42)))))
+                                                                    (Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Prover.fst"
+                                                                    (Prims.of_int (172))
+                                                                    (Prims.of_int (24))
+                                                                    (Prims.of_int (172))
+                                                                    (Prims.of_int (42)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Prover.fst"
+                                                                    (Prims.of_int (172))
+                                                                    (Prims.of_int (16))
+                                                                    (Prims.of_int (172))
+                                                                    (Prims.of_int (42)))))
+                                                                    (Obj.magic
+                                                                    (Pulse_PP.pp
+                                                                    Pulse_PP.uu___42
+                                                                    preamble.Pulse_Checker_Prover_Base.ctxt))
                                                                     (fun
                                                                     uu___12
                                                                     ->
@@ -1252,25 +1458,8 @@ let rec (prover :
                                                                     (fun
                                                                     uu___13
                                                                     ->
-                                                                    fun x ->
-                                                                    fun x1 ->
-                                                                    fun x2 ->
-                                                                    Prims.strcat
-                                                                    (Prims.strcat
-                                                                    (Prims.strcat
-                                                                    (Prims.strcat
-                                                                    "cannot prove vprop "
-                                                                    (Prims.strcat
-                                                                    uu___12
-                                                                    " in the context: "))
-                                                                    (Prims.strcat
-                                                                    x
-                                                                    "\n(the prover was started with goal "))
-                                                                    (Prims.strcat
-                                                                    x1
-                                                                    " and initial context "))
-                                                                    (Prims.strcat
-                                                                    x2 ")")))))
+                                                                    FStar_Pprint.bquotes
+                                                                    uu___12))))
                                                                     (fun
                                                                     uu___12
                                                                     ->
@@ -1278,8 +1467,28 @@ let rec (prover :
                                                                     (fun
                                                                     uu___13
                                                                     ->
+                                                                    FStar_Pprint.op_Hat_Slash_Hat
+                                                                    (FStar_Pprint.doc_of_string
+                                                                    "and initial context")
+                                                                    uu___12))))
+                                                                    (fun
                                                                     uu___12
-                                                                    uu___11))))
+                                                                    ->
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___13
+                                                                    ->
+                                                                    [uu___12]))))
+                                                                    (fun
+                                                                    uu___12
+                                                                    ->
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___13
+                                                                    ->
+                                                                    uu___11
+                                                                    ::
+                                                                    uu___12))))
                                                                     uu___11)))
                                                                     (fun
                                                                     uu___11
@@ -1288,8 +1497,9 @@ let rec (prover :
                                                                     (fun
                                                                     uu___12
                                                                     ->
-                                                                    uu___11
-                                                                    uu___10))))
+                                                                    uu___10
+                                                                    ::
+                                                                    uu___11))))
                                                                     uu___10)))
                                                                     (fun
                                                                     uu___10
@@ -1297,16 +1507,16 @@ let rec (prover :
                                                                     FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
                                                                     uu___11
-                                                                    ->
-                                                                    uu___10
-                                                                    uu___9))))
+                                                                    -> uu___9
+                                                                    ::
+                                                                    uu___10))))
                                                                     uu___9)))
                                                                     (fun
                                                                     uu___9 ->
                                                                     (fun msg
                                                                     ->
                                                                     Obj.magic
-                                                                    (Pulse_Typing_Env.fail
+                                                                    (Pulse_Typing_Env.fail_doc
                                                                     pst3.Pulse_Checker_Prover_Base.pg
                                                                     FStar_Pervasives_Native.None
                                                                     msg))
@@ -1370,13 +1580,13 @@ let (prove :
                 (FStar_Sealed.seal
                    (Obj.magic
                       (FStar_Range.mk_range "Pulse.Checker.Prover.fst"
-                         (Prims.of_int (192)) (Prims.of_int (2))
-                         (Prims.of_int (194)) (Prims.of_int (55)))))
+                         (Prims.of_int (202)) (Prims.of_int (2))
+                         (Prims.of_int (204)) (Prims.of_int (55)))))
                 (FStar_Sealed.seal
                    (Obj.magic
                       (FStar_Range.mk_range "Pulse.Checker.Prover.fst"
-                         (Prims.of_int (194)) (Prims.of_int (56))
-                         (Prims.of_int (261)) (Prims.of_int (97)))))
+                         (Prims.of_int (204)) (Prims.of_int (56))
+                         (Prims.of_int (271)) (Prims.of_int (97)))))
                 (Obj.magic
                    (Pulse_Checker_Prover_Util.debug_prover g
                       (fun uu___ ->
@@ -1385,14 +1595,14 @@ let (prove :
                               (Obj.magic
                                  (FStar_Range.mk_range
                                     "Pulse.Checker.Prover.fst"
-                                    (Prims.of_int (194)) (Prims.of_int (30))
-                                    (Prims.of_int (194)) (Prims.of_int (54)))))
+                                    (Prims.of_int (204)) (Prims.of_int (30))
+                                    (Prims.of_int (204)) (Prims.of_int (54)))))
                            (FStar_Sealed.seal
                               (Obj.magic
                                  (FStar_Range.mk_range
                                     "Pulse.Checker.Prover.fst"
-                                    (Prims.of_int (193)) (Prims.of_int (4))
-                                    (Prims.of_int (194)) (Prims.of_int (54)))))
+                                    (Prims.of_int (203)) (Prims.of_int (4))
+                                    (Prims.of_int (204)) (Prims.of_int (54)))))
                            (Obj.magic
                               (Pulse_Syntax_Printer.term_to_string goals))
                            (fun uu___1 ->
@@ -1403,17 +1613,17 @@ let (prove :
                                          (Obj.magic
                                             (FStar_Range.mk_range
                                                "Pulse.Checker.Prover.fst"
-                                               (Prims.of_int (193))
+                                               (Prims.of_int (203))
                                                (Prims.of_int (4))
-                                               (Prims.of_int (194))
+                                               (Prims.of_int (204))
                                                (Prims.of_int (54)))))
                                       (FStar_Sealed.seal
                                          (Obj.magic
                                             (FStar_Range.mk_range
                                                "Pulse.Checker.Prover.fst"
-                                               (Prims.of_int (193))
+                                               (Prims.of_int (203))
                                                (Prims.of_int (4))
-                                               (Prims.of_int (194))
+                                               (Prims.of_int (204))
                                                (Prims.of_int (54)))))
                                       (Obj.magic
                                          (FStar_Tactics_Effect.tac_bind
@@ -1421,9 +1631,9 @@ let (prove :
                                                (Obj.magic
                                                   (FStar_Range.mk_range
                                                      "Pulse.Checker.Prover.fst"
-                                                     (Prims.of_int (194))
+                                                     (Prims.of_int (204))
                                                      (Prims.of_int (6))
-                                                     (Prims.of_int (194))
+                                                     (Prims.of_int (204))
                                                      (Prims.of_int (29)))))
                                             (FStar_Sealed.seal
                                                (Obj.magic
@@ -1459,14 +1669,14 @@ let (prove :
                               (Obj.magic
                                  (FStar_Range.mk_range
                                     "Pulse.Checker.Prover.fst"
-                                    (Prims.of_int (196)) (Prims.of_int (15))
-                                    (Prims.of_int (196)) (Prims.of_int (33)))))
+                                    (Prims.of_int (206)) (Prims.of_int (15))
+                                    (Prims.of_int (206)) (Prims.of_int (33)))))
                            (FStar_Sealed.seal
                               (Obj.magic
                                  (FStar_Range.mk_range
                                     "Pulse.Checker.Prover.fst"
-                                    (Prims.of_int (210)) (Prims.of_int (6))
-                                    (Prims.of_int (261)) (Prims.of_int (97)))))
+                                    (Prims.of_int (220)) (Prims.of_int (6))
+                                    (Prims.of_int (271)) (Prims.of_int (97)))))
                            (FStar_Tactics_Effect.lift_div_tac
                               (fun uu___1 ->
                                  Pulse_Typing_Combinators.vprop_as_list ctxt))
@@ -1478,17 +1688,17 @@ let (prove :
                                          (Obj.magic
                                             (FStar_Range.mk_range
                                                "Pulse.Checker.Prover.fst"
-                                               (Prims.of_int (211))
+                                               (Prims.of_int (221))
                                                (Prims.of_int (61))
-                                               (Prims.of_int (211))
+                                               (Prims.of_int (221))
                                                (Prims.of_int (69)))))
                                       (FStar_Sealed.seal
                                          (Obj.magic
                                             (FStar_Range.mk_range
                                                "Pulse.Checker.Prover.fst"
-                                               (Prims.of_int (211))
+                                               (Prims.of_int (221))
                                                (Prims.of_int (72))
-                                               (Prims.of_int (261))
+                                               (Prims.of_int (271))
                                                (Prims.of_int (97)))))
                                       (FStar_Tactics_Effect.lift_div_tac
                                          (fun uu___1 -> ()))
@@ -1500,17 +1710,17 @@ let (prove :
                                                     (Obj.magic
                                                        (FStar_Range.mk_range
                                                           "Pulse.Checker.Prover.fst"
-                                                          (Prims.of_int (213))
+                                                          (Prims.of_int (223))
                                                           (Prims.of_int (6))
-                                                          (Prims.of_int (217))
+                                                          (Prims.of_int (227))
                                                           (Prims.of_int (12)))))
                                                  (FStar_Sealed.seal
                                                     (Obj.magic
                                                        (FStar_Range.mk_range
                                                           "Pulse.Checker.Prover.fst"
-                                                          (Prims.of_int (220))
+                                                          (Prims.of_int (230))
                                                           (Prims.of_int (43))
-                                                          (Prims.of_int (261))
+                                                          (Prims.of_int (271))
                                                           (Prims.of_int (97)))))
                                                  (FStar_Tactics_Effect.lift_div_tac
                                                     (fun uu___1 ->
@@ -1535,17 +1745,17 @@ let (prove :
                                                                (Obj.magic
                                                                   (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (222))
+                                                                    (Prims.of_int (232))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (231))
+                                                                    (Prims.of_int (241))
                                                                     (Prims.of_int (21)))))
                                                             (FStar_Sealed.seal
                                                                (Obj.magic
                                                                   (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (232))
+                                                                    (Prims.of_int (242))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (261))
+                                                                    (Prims.of_int (271))
                                                                     (Prims.of_int (97)))))
                                                             (FStar_Tactics_Effect.lift_div_tac
                                                                (fun uu___1 ->
@@ -1604,17 +1814,17 @@ let (prove :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (234))
+                                                                    (Prims.of_int (244))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (234))
+                                                                    (Prims.of_int (244))
                                                                     (Prims.of_int (25)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (234))
+                                                                    (Prims.of_int (244))
                                                                     (Prims.of_int (28))
-                                                                    (Prims.of_int (261))
+                                                                    (Prims.of_int (271))
                                                                     (Prims.of_int (97)))))
                                                                     (Obj.magic
                                                                     (prover
@@ -1630,17 +1840,17 @@ let (prove :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (237))
+                                                                    (Prims.of_int (247))
                                                                     (Prims.of_int (65))
-                                                                    (Prims.of_int (243))
+                                                                    (Prims.of_int (253))
                                                                     (Prims.of_int (22)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (261))
+                                                                    (Prims.of_int (271))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (261))
+                                                                    (Prims.of_int (271))
                                                                     (Prims.of_int (97)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1648,17 +1858,17 @@ let (prove :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (238))
+                                                                    (Prims.of_int (248))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (238))
+                                                                    (Prims.of_int (248))
                                                                     (Prims.of_int (54)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (239))
+                                                                    (Prims.of_int (249))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (243))
+                                                                    (Prims.of_int (253))
                                                                     (Prims.of_int (22)))))
                                                                     (Obj.magic
                                                                     (Pulse_Checker_Prover_Substs.ss_to_nt_substs
@@ -1759,13 +1969,13 @@ let (try_frame_pre_uvs :
                     (FStar_Sealed.seal
                        (Obj.magic
                           (FStar_Range.mk_range "Pulse.Checker.Prover.fst"
-                             (Prims.of_int (272)) (Prims.of_int (10))
-                             (Prims.of_int (272)) (Prims.of_int (48)))))
+                             (Prims.of_int (282)) (Prims.of_int (10))
+                             (Prims.of_int (282)) (Prims.of_int (48)))))
                     (FStar_Sealed.seal
                        (Obj.magic
                           (FStar_Range.mk_range "Pulse.Checker.Prover.fst"
-                             (Prims.of_int (272)) (Prims.of_int (51))
-                             (Prims.of_int (328)) (Prims.of_int (65)))))
+                             (Prims.of_int (282)) (Prims.of_int (51))
+                             (Prims.of_int (338)) (Prims.of_int (65)))))
                     (FStar_Tactics_Effect.lift_div_tac
                        (fun uu___ ->
                           Pulse_Typing_Env.push_context g "try_frame_pre"
@@ -1778,17 +1988,17 @@ let (try_frame_pre_uvs :
                                   (Obj.magic
                                      (FStar_Range.mk_range
                                         "Pulse.Checker.Prover.fst"
-                                        (Prims.of_int (275))
+                                        (Prims.of_int (285))
                                         (Prims.of_int (4))
-                                        (Prims.of_int (275))
+                                        (Prims.of_int (285))
                                         (Prims.of_int (56)))))
                                (FStar_Sealed.seal
                                   (Obj.magic
                                      (FStar_Range.mk_range
                                         "Pulse.Checker.Prover.fst"
-                                        (Prims.of_int (272))
+                                        (Prims.of_int (282))
                                         (Prims.of_int (51))
-                                        (Prims.of_int (328))
+                                        (Prims.of_int (338))
                                         (Prims.of_int (65)))))
                                (Obj.magic
                                   (prove g1 ctxt () uvs
@@ -1805,17 +2015,17 @@ let (try_frame_pre_uvs :
                                                  (Obj.magic
                                                     (FStar_Range.mk_range
                                                        "Pulse.Checker.Prover.fst"
-                                                       (Prims.of_int (279))
+                                                       (Prims.of_int (289))
                                                        (Prims.of_int (4))
-                                                       (Prims.of_int (279))
+                                                       (Prims.of_int (289))
                                                        (Prims.of_int (49)))))
                                               (FStar_Sealed.seal
                                                  (Obj.magic
                                                     (FStar_Range.mk_range
                                                        "Pulse.Checker.Prover.fst"
-                                                       (Prims.of_int (281))
+                                                       (Prims.of_int (291))
                                                        (Prims.of_int (82))
-                                                       (Prims.of_int (328))
+                                                       (Prims.of_int (338))
                                                        (Prims.of_int (65)))))
                                               (FStar_Tactics_Effect.lift_div_tac
                                                  (fun uu___1 ->
@@ -1829,17 +2039,17 @@ let (try_frame_pre_uvs :
                                                             (Obj.magic
                                                                (FStar_Range.mk_range
                                                                   "Pulse.Checker.Prover.fst"
-                                                                  (Prims.of_int (282))
+                                                                  (Prims.of_int (292))
                                                                   (Prims.of_int (10))
-                                                                  (Prims.of_int (282))
+                                                                  (Prims.of_int (292))
                                                                   (Prims.of_int (35)))))
                                                          (FStar_Sealed.seal
                                                             (Obj.magic
                                                                (FStar_Range.mk_range
                                                                   "Pulse.Checker.Prover.fst"
-                                                                  (Prims.of_int (282))
+                                                                  (Prims.of_int (292))
                                                                   (Prims.of_int (38))
-                                                                  (Prims.of_int (328))
+                                                                  (Prims.of_int (338))
                                                                   (Prims.of_int (65)))))
                                                          (FStar_Tactics_Effect.lift_div_tac
                                                             (fun uu___1 ->
@@ -1854,18 +2064,18 @@ let (try_frame_pre_uvs :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (283))
+                                                                    (Prims.of_int (293))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (283))
+                                                                    (Prims.of_int (293))
                                                                     (Prims.of_int (32)))))
                                                                     (
                                                                     FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (283))
+                                                                    (Prims.of_int (293))
                                                                     (Prims.of_int (35))
-                                                                    (Prims.of_int (328))
+                                                                    (Prims.of_int (338))
                                                                     (Prims.of_int (65)))))
                                                                     (
                                                                     FStar_Tactics_Effect.lift_div_tac
@@ -1884,17 +2094,17 @@ let (try_frame_pre_uvs :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (286))
+                                                                    (Prims.of_int (296))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (286))
+                                                                    (Prims.of_int (296))
                                                                     (Prims.of_int (47)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (286))
+                                                                    (Prims.of_int (296))
                                                                     (Prims.of_int (50))
-                                                                    (Prims.of_int (328))
+                                                                    (Prims.of_int (338))
                                                                     (Prims.of_int (65)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -1912,17 +2122,17 @@ let (try_frame_pre_uvs :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (288))
+                                                                    (Prims.of_int (298))
                                                                     (Prims.of_int (82))
-                                                                    (Prims.of_int (288))
+                                                                    (Prims.of_int (298))
                                                                     (Prims.of_int (102)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (288))
+                                                                    (Prims.of_int (298))
                                                                     (Prims.of_int (105))
-                                                                    (Prims.of_int (328))
+                                                                    (Prims.of_int (338))
                                                                     (Prims.of_int (65)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -1941,17 +2151,17 @@ let (try_frame_pre_uvs :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (290))
+                                                                    (Prims.of_int (300))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (290))
+                                                                    (Prims.of_int (300))
                                                                     (Prims.of_int (18)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (290))
+                                                                    (Prims.of_int (300))
                                                                     (Prims.of_int (21))
-                                                                    (Prims.of_int (328))
+                                                                    (Prims.of_int (338))
                                                                     (Prims.of_int (65)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -1967,17 +2177,17 @@ let (try_frame_pre_uvs :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (291))
+                                                                    (Prims.of_int (301))
                                                                     (Prims.of_int (11))
-                                                                    (Prims.of_int (291))
+                                                                    (Prims.of_int (301))
                                                                     (Prims.of_int (21)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (291))
+                                                                    (Prims.of_int (301))
                                                                     (Prims.of_int (24))
-                                                                    (Prims.of_int (328))
+                                                                    (Prims.of_int (338))
                                                                     (Prims.of_int (65)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -1994,17 +2204,17 @@ let (try_frame_pre_uvs :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (292))
+                                                                    (Prims.of_int (302))
                                                                     (Prims.of_int (11))
-                                                                    (Prims.of_int (292))
+                                                                    (Prims.of_int (302))
                                                                     (Prims.of_int (42)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (293))
+                                                                    (Prims.of_int (303))
                                                                     (Prims.of_int (31))
-                                                                    (Prims.of_int (328))
+                                                                    (Prims.of_int (338))
                                                                     (Prims.of_int (65)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -2023,17 +2233,17 @@ let (try_frame_pre_uvs :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (294))
+                                                                    (Prims.of_int (304))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (294))
+                                                                    (Prims.of_int (304))
                                                                     (Prims.of_int (75)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (294))
+                                                                    (Prims.of_int (304))
                                                                     (Prims.of_int (78))
-                                                                    (Prims.of_int (328))
+                                                                    (Prims.of_int (338))
                                                                     (Prims.of_int (65)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -2055,17 +2265,17 @@ let (try_frame_pre_uvs :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (296))
+                                                                    (Prims.of_int (306))
                                                                     (Prims.of_int (29))
-                                                                    (Prims.of_int (296))
+                                                                    (Prims.of_int (306))
                                                                     (Prims.of_int (73)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (296))
+                                                                    (Prims.of_int (306))
                                                                     (Prims.of_int (76))
-                                                                    (Prims.of_int (328))
+                                                                    (Prims.of_int (338))
                                                                     (Prims.of_int (65)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -2083,17 +2293,17 @@ let (try_frame_pre_uvs :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (301))
+                                                                    (Prims.of_int (311))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (301))
+                                                                    (Prims.of_int (311))
                                                                     (Prims.of_int (81)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (308))
+                                                                    (Prims.of_int (318))
                                                                     (Prims.of_int (35))
-                                                                    (Prims.of_int (328))
+                                                                    (Prims.of_int (338))
                                                                     (Prims.of_int (65)))))
                                                                     (Obj.magic
                                                                     (Pulse_Checker_Base.continuation_elaborator_with_bind
@@ -2185,13 +2395,13 @@ let (try_frame_pre :
                   (FStar_Sealed.seal
                      (Obj.magic
                         (FStar_Range.mk_range "Pulse.Checker.Prover.fst"
-                           (Prims.of_int (336)) (Prims.of_int (12))
-                           (Prims.of_int (336)) (Prims.of_int (32)))))
+                           (Prims.of_int (346)) (Prims.of_int (12))
+                           (Prims.of_int (346)) (Prims.of_int (32)))))
                   (FStar_Sealed.seal
                      (Obj.magic
                         (FStar_Range.mk_range "Pulse.Checker.Prover.fst"
-                           (Prims.of_int (338)) (Prims.of_int (2))
-                           (Prims.of_int (338)) (Prims.of_int (48)))))
+                           (Prims.of_int (348)) (Prims.of_int (2))
+                           (Prims.of_int (348)) (Prims.of_int (48)))))
                   (FStar_Tactics_Effect.lift_div_tac
                      (fun uu___ ->
                         Pulse_Typing_Env.mk_env
@@ -2219,13 +2429,13 @@ let (prove_post_hint :
               (FStar_Sealed.seal
                  (Obj.magic
                     (FStar_Range.mk_range "Pulse.Checker.Prover.fst"
-                       (Prims.of_int (347)) (Prims.of_int (10))
-                       (Prims.of_int (347)) (Prims.of_int (46)))))
+                       (Prims.of_int (357)) (Prims.of_int (10))
+                       (Prims.of_int (357)) (Prims.of_int (46)))))
               (FStar_Sealed.seal
                  (Obj.magic
                     (FStar_Range.mk_range "Pulse.Checker.Prover.fst"
-                       (Prims.of_int (349)) (Prims.of_int (2))
-                       (Prims.of_int (393)) (Prims.of_int (102)))))
+                       (Prims.of_int (359)) (Prims.of_int (2))
+                       (Prims.of_int (405)) (Prims.of_int (102)))))
               (FStar_Tactics_Effect.lift_div_tac
                  (fun uu___ ->
                     Pulse_Typing_Env.push_context g "prove_post_hint" rng))
@@ -2245,17 +2455,17 @@ let (prove_post_hint :
                                    (Obj.magic
                                       (FStar_Range.mk_range
                                          "Pulse.Checker.Prover.fst"
-                                         (Prims.of_int (352))
+                                         (Prims.of_int (362))
                                          (Prims.of_int (79))
-                                         (Prims.of_int (352))
+                                         (Prims.of_int (362))
                                          (Prims.of_int (80)))))
                                 (FStar_Sealed.seal
                                    (Obj.magic
                                       (FStar_Range.mk_range
                                          "Pulse.Checker.Prover.fst"
-                                         (Prims.of_int (351))
+                                         (Prims.of_int (361))
                                          (Prims.of_int (21))
-                                         (Prims.of_int (393))
+                                         (Prims.of_int (405))
                                          (Prims.of_int (102)))))
                                 (FStar_Tactics_Effect.lift_div_tac
                                    (fun uu___ -> r))
@@ -2274,17 +2484,17 @@ let (prove_post_hint :
                                                   (Obj.magic
                                                      (FStar_Range.mk_range
                                                         "Pulse.Checker.Prover.fst"
-                                                        (Prims.of_int (354))
+                                                        (Prims.of_int (364))
                                                         (Prims.of_int (17))
-                                                        (Prims.of_int (354))
+                                                        (Prims.of_int (364))
                                                         (Prims.of_int (44)))))
                                                (FStar_Sealed.seal
                                                   (Obj.magic
                                                      (FStar_Range.mk_range
                                                         "Pulse.Checker.Prover.fst"
-                                                        (Prims.of_int (354))
+                                                        (Prims.of_int (364))
                                                         (Prims.of_int (47))
-                                                        (Prims.of_int (393))
+                                                        (Prims.of_int (405))
                                                         (Prims.of_int (102)))))
                                                (FStar_Tactics_Effect.lift_div_tac
                                                   (fun uu___1 ->
@@ -2298,17 +2508,17 @@ let (prove_post_hint :
                                                              (Obj.magic
                                                                 (FStar_Range.mk_range
                                                                    "Pulse.Checker.Prover.fst"
-                                                                   (Prims.of_int (355))
+                                                                   (Prims.of_int (365))
                                                                    (Prims.of_int (27))
-                                                                   (Prims.of_int (355))
+                                                                   (Prims.of_int (365))
                                                                    (Prims.of_int (66)))))
                                                           (FStar_Sealed.seal
                                                              (Obj.magic
                                                                 (FStar_Range.mk_range
                                                                    "Pulse.Checker.Prover.fst"
-                                                                   (Prims.of_int (358))
+                                                                   (Prims.of_int (368))
                                                                    (Prims.of_int (4))
-                                                                   (Prims.of_int (393))
+                                                                   (Prims.of_int (405))
                                                                    (Prims.of_int (102)))))
                                                           (FStar_Tactics_Effect.lift_div_tac
                                                              (fun uu___1 ->
@@ -2334,17 +2544,17 @@ let (prove_post_hint :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (360))
+                                                                    (Prims.of_int (370))
                                                                     (Prims.of_int (11))
-                                                                    (Prims.of_int (363))
+                                                                    (Prims.of_int (373))
                                                                     (Prims.of_int (50)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (359))
+                                                                    (Prims.of_int (369))
                                                                     (Prims.of_int (9))
-                                                                    (Prims.of_int (363))
+                                                                    (Prims.of_int (373))
                                                                     (Prims.of_int (50)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -2352,17 +2562,17 @@ let (prove_post_hint :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (363))
+                                                                    (Prims.of_int (373))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (363))
+                                                                    (Prims.of_int (373))
                                                                     (Prims.of_int (49)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (360))
+                                                                    (Prims.of_int (370))
                                                                     (Prims.of_int (11))
-                                                                    (Prims.of_int (363))
+                                                                    (Prims.of_int (373))
                                                                     (Prims.of_int (50)))))
                                                                     (Obj.magic
                                                                     (Pulse_Syntax_Printer.term_to_string
@@ -2377,17 +2587,17 @@ let (prove_post_hint :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (360))
+                                                                    (Prims.of_int (370))
                                                                     (Prims.of_int (11))
-                                                                    (Prims.of_int (363))
+                                                                    (Prims.of_int (373))
                                                                     (Prims.of_int (50)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (360))
+                                                                    (Prims.of_int (370))
                                                                     (Prims.of_int (11))
-                                                                    (Prims.of_int (363))
+                                                                    (Prims.of_int (373))
                                                                     (Prims.of_int (50)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -2395,9 +2605,9 @@ let (prove_post_hint :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (362))
+                                                                    (Prims.of_int (372))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (362))
+                                                                    (Prims.of_int (372))
                                                                     (Prims.of_int (35)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -2471,17 +2681,17 @@ let (prove_post_hint :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (368))
+                                                                    (Prims.of_int (378))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (368))
+                                                                    (Prims.of_int (378))
                                                                     (Prims.of_int (90)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (366))
+                                                                    (Prims.of_int (376))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (393))
+                                                                    (Prims.of_int (405))
                                                                     (Prims.of_int (102)))))
                                                                     (Obj.magic
                                                                     (prove g2
@@ -2509,17 +2719,17 @@ let (prove_post_hint :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (373))
+                                                                    (Prims.of_int (383))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (373))
+                                                                    (Prims.of_int (383))
                                                                     (Prims.of_int (27)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (375))
+                                                                    (Prims.of_int (385))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (393))
+                                                                    (Prims.of_int (405))
                                                                     (Prims.of_int (102)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -2546,55 +2756,105 @@ let (prove_post_hint :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (378))
-                                                                    (Prims.of_int (10))
-                                                                    (Prims.of_int (380))
-                                                                    (Prims.of_int (47)))))
+                                                                    (Prims.of_int (388))
+                                                                    (Prims.of_int (30))
+                                                                    (Prims.of_int (392))
+                                                                    (Prims.of_int (9)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (377))
+                                                                    (Prims.of_int (388))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (380))
-                                                                    (Prims.of_int (47)))))
+                                                                    (Prims.of_int (392))
+                                                                    (Prims.of_int (9)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (380))
-                                                                    (Prims.of_int (13))
-                                                                    (Prims.of_int (380))
-                                                                    (Prims.of_int (46)))))
+                                                                    (Prims.of_int (388))
+                                                                    (Prims.of_int (30))
+                                                                    (Prims.of_int (392))
+                                                                    (Prims.of_int (9)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
-                                                                    "prims.fst"
-                                                                    (Prims.of_int (590))
-                                                                    (Prims.of_int (19))
-                                                                    (Prims.of_int (590))
-                                                                    (Prims.of_int (31)))))
+                                                                    "Pulse.Checker.Prover.fst"
+                                                                    (Prims.of_int (388))
+                                                                    (Prims.of_int (30))
+                                                                    (Prims.of_int (392))
+                                                                    (Prims.of_int (9)))))
                                                                     (Obj.magic
-                                                                    (Pulse_Syntax_Printer.term_to_string
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Prover.fst"
+                                                                    (Prims.of_int (390))
+                                                                    (Prims.of_int (10))
+                                                                    (Prims.of_int (391))
+                                                                    (Prims.of_int (33)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Prover.fst"
+                                                                    (Prims.of_int (388))
+                                                                    (Prims.of_int (30))
+                                                                    (Prims.of_int (392))
+                                                                    (Prims.of_int (9)))))
+                                                                    (Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Prover.fst"
+                                                                    (Prims.of_int (391))
+                                                                    (Prims.of_int (16))
+                                                                    (Prims.of_int (391))
+                                                                    (Prims.of_int (33)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Prover.fst"
+                                                                    (Prims.of_int (390))
+                                                                    (Prims.of_int (10))
+                                                                    (Prims.of_int (391))
+                                                                    (Prims.of_int (33)))))
+                                                                    (Obj.magic
+                                                                    (Pulse_PP.pp
+                                                                    Pulse_PP.uu___42
                                                                     remaining_ctxt))
                                                                     (fun
                                                                     uu___4 ->
                                                                     FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
                                                                     uu___5 ->
-                                                                    Prims.strcat
-                                                                    "error in proving post hint:comp post contains extra vprops not matched in the post hint: "
-                                                                    (Prims.strcat
-                                                                    uu___4
-                                                                    "\n")))))
+                                                                    FStar_Pprint.op_Hat_Slash_Hat
+                                                                    (Pulse_PP.text
+                                                                    "Postcondition contains extra vprops not matched in the post hint")
+                                                                    uu___4))))
+                                                                    (fun
+                                                                    uu___4 ->
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___5 ->
+                                                                    [uu___4]))))
+                                                                    (fun
+                                                                    uu___4 ->
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___5 ->
+                                                                    (Pulse_PP.text
+                                                                    "Error in proving post hint")
+                                                                    :: uu___4))))
                                                                     (fun
                                                                     uu___4 ->
                                                                     (fun
                                                                     uu___4 ->
                                                                     Obj.magic
-                                                                    (Pulse_Typing_Env.fail
+                                                                    (Pulse_Typing_Env.fail_doc
                                                                     g1
                                                                     (FStar_Pervasives_Native.Some
                                                                     rng)

--- a/src/ocaml/plugin/generated/Pulse_Config.ml
+++ b/src/ocaml/plugin/generated/Pulse_Config.ml
@@ -1,2 +1,19 @@
 open Prims
 let (join_goals : Prims.bool) = false
+let (debug_flag :
+  Prims.string -> (Prims.bool, unit) FStar_Tactics_Effect.tac_repr) =
+  fun s ->
+    FStar_Tactics_Effect.tac_bind
+      (FStar_Sealed.seal
+         (Obj.magic
+            (FStar_Range.mk_range "Pulse.Config.fst" (Prims.of_int (9))
+               (Prims.of_int (10)) (Prims.of_int (9)) (Prims.of_int (33)))))
+      (FStar_Sealed.seal
+         (Obj.magic
+            (FStar_Range.mk_range "Pulse.Config.fst" (Prims.of_int (10))
+               (Prims.of_int (2)) (Prims.of_int (10)) (Prims.of_int (37)))))
+      (Obj.magic
+         (FStar_Tactics_V2_Builtins.ext_getv (Prims.strcat "pulse:" s)))
+      (fun v ->
+         FStar_Tactics_Effect.lift_div_tac
+           (fun uu___ -> ((v <> "") && (v <> "0")) && (v <> "false")))

--- a/src/ocaml/plugin/generated/Pulse_PP.ml
+++ b/src/ocaml/plugin/generated/Pulse_PP.ml
@@ -3,6 +3,10 @@ let (text : Prims.string -> FStar_Pprint.document) =
   fun s ->
     FStar_Pprint.flow (FStar_Pprint.break_ Prims.int_one)
       (FStar_Pprint.words s)
+let (indent : FStar_Pprint.document -> FStar_Pprint.document) =
+  fun d ->
+    FStar_Pprint.nest (Prims.of_int (2))
+      (FStar_Pprint.op_Hat_Hat FStar_Pprint.hardline (FStar_Pprint.align d))
 type 'a printable =
   {
   pp: 'a -> (FStar_Pprint.document, unit) FStar_Tactics_Effect.tac_repr }
@@ -24,24 +28,24 @@ let from_show : 'a . 'a Pulse_Show.tac_showable -> 'a printable =
            FStar_Tactics_Effect.tac_bind
              (FStar_Sealed.seal
                 (Obj.magic
-                   (FStar_Range.mk_range "Pulse.PP.fst" (Prims.of_int (25))
-                      (Prims.of_int (34)) (Prims.of_int (25))
+                   (FStar_Range.mk_range "Pulse.PP.fst" (Prims.of_int (38))
+                      (Prims.of_int (34)) (Prims.of_int (38))
                       (Prims.of_int (42)))))
              (FStar_Sealed.seal
                 (Obj.magic
-                   (FStar_Range.mk_range "Pulse.PP.fst" (Prims.of_int (25))
-                      (Prims.of_int (17)) (Prims.of_int (25))
+                   (FStar_Range.mk_range "Pulse.PP.fst" (Prims.of_int (38))
+                      (Prims.of_int (17)) (Prims.of_int (38))
                       (Prims.of_int (42)))))
              (Obj.magic (Pulse_Show.show d x))
              (fun uu___ ->
                 FStar_Tactics_Effect.lift_div_tac
                   (fun uu___1 -> FStar_Pprint.arbitrary_string uu___)))
     }
-let (uu___17 : Prims.string printable) = from_show Pulse_Show.uu___12
-let (uu___18 : unit printable) = from_show Pulse_Show.uu___14
-let (uu___19 : Prims.bool printable) = from_show Pulse_Show.uu___16
-let (uu___20 : Prims.int printable) = from_show Pulse_Show.uu___18
-let (uu___21 : Pulse_Syntax_Base.ctag printable) =
+let (uu___19 : Prims.string printable) = from_show Pulse_Show.uu___12
+let (uu___20 : unit printable) = from_show Pulse_Show.uu___14
+let (uu___21 : Prims.bool printable) = from_show Pulse_Show.uu___16
+let (uu___22 : Prims.int printable) = from_show Pulse_Show.uu___18
+let (uu___23 : Pulse_Syntax_Base.ctag printable) =
   from_show Pulse_Show.uu___28
 let showable_option :
   'a . 'a printable -> 'a FStar_Pervasives_Native.option printable =
@@ -63,13 +67,13 @@ let showable_option :
                           (FStar_Sealed.seal
                              (Obj.magic
                                 (FStar_Range.mk_range "Pulse.PP.fst"
-                                   (Prims.of_int (37)) (Prims.of_int (54))
-                                   (Prims.of_int (37)) (Prims.of_int (58)))))
+                                   (Prims.of_int (50)) (Prims.of_int (54))
+                                   (Prims.of_int (50)) (Prims.of_int (58)))))
                           (FStar_Sealed.seal
                              (Obj.magic
                                 (FStar_Range.mk_range "Pulse.PP.fst"
-                                   (Prims.of_int (37)) (Prims.of_int (29))
-                                   (Prims.of_int (37)) (Prims.of_int (58)))))
+                                   (Prims.of_int (50)) (Prims.of_int (29))
+                                   (Prims.of_int (50)) (Prims.of_int (58)))))
                           (Obj.magic (pp uu___ v))
                           (fun uu___2 ->
                              FStar_Tactics_Effect.lift_div_tac
@@ -105,13 +109,13 @@ let rec separate_map :
                            (FStar_Sealed.seal
                               (Obj.magic
                                  (FStar_Range.mk_range "Pulse.PP.fst"
-                                    (Prims.of_int (46)) (Prims.of_int (13))
-                                    (Prims.of_int (46)) (Prims.of_int (16)))))
+                                    (Prims.of_int (59)) (Prims.of_int (13))
+                                    (Prims.of_int (59)) (Prims.of_int (16)))))
                            (FStar_Sealed.seal
                               (Obj.magic
                                  (FStar_Range.mk_range "Pulse.PP.fst"
-                                    (Prims.of_int (46)) (Prims.of_int (13))
-                                    (Prims.of_int (46)) (Prims.of_int (49)))))
+                                    (Prims.of_int (59)) (Prims.of_int (13))
+                                    (Prims.of_int (59)) (Prims.of_int (49)))))
                            (Obj.magic (f x))
                            (fun uu___ ->
                               (fun uu___ ->
@@ -121,17 +125,17 @@ let rec separate_map :
                                          (Obj.magic
                                             (FStar_Range.mk_range
                                                "Pulse.PP.fst"
-                                               (Prims.of_int (46))
+                                               (Prims.of_int (59))
                                                (Prims.of_int (20))
-                                               (Prims.of_int (46))
+                                               (Prims.of_int (59))
                                                (Prims.of_int (49)))))
                                       (FStar_Sealed.seal
                                          (Obj.magic
                                             (FStar_Range.mk_range
                                                "Pulse.PP.fst"
-                                               (Prims.of_int (46))
+                                               (Prims.of_int (59))
                                                (Prims.of_int (13))
-                                               (Prims.of_int (46))
+                                               (Prims.of_int (59))
                                                (Prims.of_int (49)))))
                                       (Obj.magic
                                          (FStar_Tactics_Effect.tac_bind
@@ -139,17 +143,17 @@ let rec separate_map :
                                                (Obj.magic
                                                   (FStar_Range.mk_range
                                                      "Pulse.PP.fst"
-                                                     (Prims.of_int (46))
+                                                     (Prims.of_int (59))
                                                      (Prims.of_int (28))
-                                                     (Prims.of_int (46))
+                                                     (Prims.of_int (59))
                                                      (Prims.of_int (49)))))
                                             (FStar_Sealed.seal
                                                (Obj.magic
                                                   (FStar_Range.mk_range
                                                      "Pulse.PP.fst"
-                                                     (Prims.of_int (46))
+                                                     (Prims.of_int (59))
                                                      (Prims.of_int (20))
-                                                     (Prims.of_int (46))
+                                                     (Prims.of_int (59))
                                                      (Prims.of_int (49)))))
                                             (Obj.magic
                                                (separate_map sep f xs))
@@ -172,26 +176,26 @@ let showable_list : 'a . 'a printable -> 'a Prims.list printable =
            FStar_Tactics_Effect.tac_bind
              (FStar_Sealed.seal
                 (Obj.magic
-                   (FStar_Range.mk_range "Pulse.PP.fst" (Prims.of_int (49))
-                      (Prims.of_int (26)) (Prims.of_int (49))
+                   (FStar_Range.mk_range "Pulse.PP.fst" (Prims.of_int (62))
+                      (Prims.of_int (26)) (Prims.of_int (62))
                       (Prims.of_int (51)))))
              (FStar_Sealed.seal
                 (Obj.magic
-                   (FStar_Range.mk_range "Pulse.PP.fst" (Prims.of_int (49))
-                      (Prims.of_int (17)) (Prims.of_int (49))
+                   (FStar_Range.mk_range "Pulse.PP.fst" (Prims.of_int (62))
+                      (Prims.of_int (17)) (Prims.of_int (62))
                       (Prims.of_int (51)))))
              (Obj.magic (separate_map FStar_Pprint.comma (pp uu___) l))
              (fun uu___1 ->
                 FStar_Tactics_Effect.lift_div_tac
                   (fun uu___2 -> FStar_Pprint.brackets uu___1)))
     }
-let (uu___42 : Pulse_Syntax_Base.term printable) =
+let (uu___44 : Pulse_Syntax_Base.term printable) =
   from_show Pulse_Show.uu___30
-let (uu___43 : Pulse_Syntax_Base.universe printable) =
+let (uu___45 : Pulse_Syntax_Base.universe printable) =
   from_show Pulse_Show.uu___31
-let (uu___44 : Pulse_Syntax_Base.comp printable) =
+let (uu___46 : Pulse_Syntax_Base.comp printable) =
   from_show Pulse_Show.uu___33
-let (uu___45 : Pulse_Typing_Env.env printable) =
+let (uu___47 : Pulse_Typing_Env.env printable) =
   { pp = Pulse_Typing_Env.env_to_doc }
 let (pp_record :
   (Prims.string * FStar_Pprint.document) Prims.list ->
@@ -201,12 +205,12 @@ let (pp_record :
     FStar_Tactics_Effect.tac_bind
       (FStar_Sealed.seal
          (Obj.magic
-            (FStar_Range.mk_range "Pulse.PP.fst" (Prims.of_int (61))
-               (Prims.of_int (9)) (Prims.of_int (62)) (Prims.of_int (91)))))
+            (FStar_Range.mk_range "Pulse.PP.fst" (Prims.of_int (74))
+               (Prims.of_int (9)) (Prims.of_int (75)) (Prims.of_int (91)))))
       (FStar_Sealed.seal
          (Obj.magic
-            (FStar_Range.mk_range "Pulse.PP.fst" (Prims.of_int (61))
-               (Prims.of_int (2)) (Prims.of_int (62)) (Prims.of_int (91)))))
+            (FStar_Range.mk_range "Pulse.PP.fst" (Prims.of_int (74))
+               (Prims.of_int (2)) (Prims.of_int (75)) (Prims.of_int (91)))))
       (Obj.magic
          (separate_map (FStar_Pprint.doc_of_string ";")
             (fun uu___ ->
@@ -223,46 +227,46 @@ let (pp_record :
       (fun uu___ ->
          FStar_Tactics_Effect.lift_div_tac
            (fun uu___1 -> FStar_Pprint.braces uu___))
-let (uu___50 : Pulse_Typing.post_hint_t printable) =
+let (uu___52 : Pulse_Typing.post_hint_t printable) =
   {
     pp =
       (fun h ->
          FStar_Tactics_Effect.tac_bind
            (FStar_Sealed.seal
               (Obj.magic
-                 (FStar_Range.mk_range "Pulse.PP.fst" (Prims.of_int (66))
-                    (Prims.of_int (20)) (Prims.of_int (70))
+                 (FStar_Range.mk_range "Pulse.PP.fst" (Prims.of_int (79))
+                    (Prims.of_int (20)) (Prims.of_int (83))
                     (Prims.of_int (41)))))
            (FStar_Sealed.seal
               (Obj.magic
-                 (FStar_Range.mk_range "Pulse.PP.fst" (Prims.of_int (66))
-                    (Prims.of_int (10)) (Prims.of_int (70))
+                 (FStar_Range.mk_range "Pulse.PP.fst" (Prims.of_int (79))
+                    (Prims.of_int (10)) (Prims.of_int (83))
                     (Prims.of_int (41)))))
            (Obj.magic
               (FStar_Tactics_Effect.tac_bind
                  (FStar_Sealed.seal
                     (Obj.magic
                        (FStar_Range.mk_range "Pulse.PP.fst"
-                          (Prims.of_int (66)) (Prims.of_int (22))
-                          (Prims.of_int (66)) (Prims.of_int (33)))))
+                          (Prims.of_int (79)) (Prims.of_int (22))
+                          (Prims.of_int (79)) (Prims.of_int (33)))))
                  (FStar_Sealed.seal
                     (Obj.magic
                        (FStar_Range.mk_range "Pulse.PP.fst"
-                          (Prims.of_int (66)) (Prims.of_int (20))
-                          (Prims.of_int (70)) (Prims.of_int (41)))))
+                          (Prims.of_int (79)) (Prims.of_int (20))
+                          (Prims.of_int (83)) (Prims.of_int (41)))))
                  (Obj.magic
                     (FStar_Tactics_Effect.tac_bind
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.PP.fst"
-                                (Prims.of_int (66)) (Prims.of_int (27))
-                                (Prims.of_int (66)) (Prims.of_int (33)))))
+                                (Prims.of_int (79)) (Prims.of_int (27))
+                                (Prims.of_int (79)) (Prims.of_int (33)))))
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.PP.fst"
-                                (Prims.of_int (66)) (Prims.of_int (22))
-                                (Prims.of_int (66)) (Prims.of_int (33)))))
-                       (Obj.magic (pp uu___45 h.Pulse_Typing.g))
+                                (Prims.of_int (79)) (Prims.of_int (22))
+                                (Prims.of_int (79)) (Prims.of_int (33)))))
+                       (Obj.magic (pp uu___47 h.Pulse_Typing.g))
                        (fun uu___ ->
                           FStar_Tactics_Effect.lift_div_tac
                             (fun uu___1 -> ("g", uu___)))))
@@ -273,28 +277,28 @@ let (uu___50 : Pulse_Typing.post_hint_t printable) =
                             (FStar_Sealed.seal
                                (Obj.magic
                                   (FStar_Range.mk_range "Pulse.PP.fst"
-                                     (Prims.of_int (66)) (Prims.of_int (20))
-                                     (Prims.of_int (70)) (Prims.of_int (41)))))
+                                     (Prims.of_int (79)) (Prims.of_int (20))
+                                     (Prims.of_int (83)) (Prims.of_int (41)))))
                             (FStar_Sealed.seal
                                (Obj.magic
                                   (FStar_Range.mk_range "Pulse.PP.fst"
-                                     (Prims.of_int (66)) (Prims.of_int (20))
-                                     (Prims.of_int (70)) (Prims.of_int (41)))))
+                                     (Prims.of_int (79)) (Prims.of_int (20))
+                                     (Prims.of_int (83)) (Prims.of_int (41)))))
                             (Obj.magic
                                (FStar_Tactics_Effect.tac_bind
                                   (FStar_Sealed.seal
                                      (Obj.magic
                                         (FStar_Range.mk_range "Pulse.PP.fst"
-                                           (Prims.of_int (67))
+                                           (Prims.of_int (80))
                                            (Prims.of_int (22))
-                                           (Prims.of_int (67))
+                                           (Prims.of_int (80))
                                            (Prims.of_int (49)))))
                                   (FStar_Sealed.seal
                                      (Obj.magic
                                         (FStar_Range.mk_range "Pulse.PP.fst"
-                                           (Prims.of_int (66))
+                                           (Prims.of_int (79))
                                            (Prims.of_int (20))
-                                           (Prims.of_int (70))
+                                           (Prims.of_int (83))
                                            (Prims.of_int (41)))))
                                   (Obj.magic
                                      (FStar_Tactics_Effect.tac_bind
@@ -302,20 +306,20 @@ let (uu___50 : Pulse_Typing.post_hint_t printable) =
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.PP.fst"
-                                                 (Prims.of_int (67))
+                                                 (Prims.of_int (80))
                                                  (Prims.of_int (35))
-                                                 (Prims.of_int (67))
+                                                 (Prims.of_int (80))
                                                  (Prims.of_int (49)))))
                                         (FStar_Sealed.seal
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.PP.fst"
-                                                 (Prims.of_int (67))
+                                                 (Prims.of_int (80))
                                                  (Prims.of_int (22))
-                                                 (Prims.of_int (67))
+                                                 (Prims.of_int (80))
                                                  (Prims.of_int (49)))))
                                         (Obj.magic
-                                           (pp (showable_option uu___21)
+                                           (pp (showable_option uu___23)
                                               h.Pulse_Typing.ctag_hint))
                                         (fun uu___1 ->
                                            FStar_Tactics_Effect.lift_div_tac
@@ -329,17 +333,17 @@ let (uu___50 : Pulse_Typing.post_hint_t printable) =
                                                 (Obj.magic
                                                    (FStar_Range.mk_range
                                                       "Pulse.PP.fst"
-                                                      (Prims.of_int (66))
+                                                      (Prims.of_int (79))
                                                       (Prims.of_int (20))
-                                                      (Prims.of_int (70))
+                                                      (Prims.of_int (83))
                                                       (Prims.of_int (41)))))
                                              (FStar_Sealed.seal
                                                 (Obj.magic
                                                    (FStar_Range.mk_range
                                                       "Pulse.PP.fst"
-                                                      (Prims.of_int (66))
+                                                      (Prims.of_int (79))
                                                       (Prims.of_int (20))
-                                                      (Prims.of_int (70))
+                                                      (Prims.of_int (83))
                                                       (Prims.of_int (41)))))
                                              (Obj.magic
                                                 (FStar_Tactics_Effect.tac_bind
@@ -347,17 +351,17 @@ let (uu___50 : Pulse_Typing.post_hint_t printable) =
                                                       (Obj.magic
                                                          (FStar_Range.mk_range
                                                             "Pulse.PP.fst"
-                                                            (Prims.of_int (68))
+                                                            (Prims.of_int (81))
                                                             (Prims.of_int (22))
-                                                            (Prims.of_int (68))
+                                                            (Prims.of_int (81))
                                                             (Prims.of_int (43)))))
                                                    (FStar_Sealed.seal
                                                       (Obj.magic
                                                          (FStar_Range.mk_range
                                                             "Pulse.PP.fst"
-                                                            (Prims.of_int (66))
+                                                            (Prims.of_int (79))
                                                             (Prims.of_int (20))
-                                                            (Prims.of_int (70))
+                                                            (Prims.of_int (83))
                                                             (Prims.of_int (41)))))
                                                    (Obj.magic
                                                       (FStar_Tactics_Effect.tac_bind
@@ -365,20 +369,20 @@ let (uu___50 : Pulse_Typing.post_hint_t printable) =
                                                             (Obj.magic
                                                                (FStar_Range.mk_range
                                                                   "Pulse.PP.fst"
-                                                                  (Prims.of_int (68))
+                                                                  (Prims.of_int (81))
                                                                   (Prims.of_int (32))
-                                                                  (Prims.of_int (68))
+                                                                  (Prims.of_int (81))
                                                                   (Prims.of_int (43)))))
                                                          (FStar_Sealed.seal
                                                             (Obj.magic
                                                                (FStar_Range.mk_range
                                                                   "Pulse.PP.fst"
-                                                                  (Prims.of_int (68))
+                                                                  (Prims.of_int (81))
                                                                   (Prims.of_int (22))
-                                                                  (Prims.of_int (68))
+                                                                  (Prims.of_int (81))
                                                                   (Prims.of_int (43)))))
                                                          (Obj.magic
-                                                            (pp uu___42
+                                                            (pp uu___44
                                                                h.Pulse_Typing.ret_ty))
                                                          (fun uu___2 ->
                                                             FStar_Tactics_Effect.lift_div_tac
@@ -394,18 +398,18 @@ let (uu___50 : Pulse_Typing.post_hint_t printable) =
                                                                     (
                                                                     FStar_Range.mk_range
                                                                     "Pulse.PP.fst"
-                                                                    (Prims.of_int (66))
+                                                                    (Prims.of_int (79))
                                                                     (Prims.of_int (20))
-                                                                    (Prims.of_int (70))
+                                                                    (Prims.of_int (83))
                                                                     (Prims.of_int (41)))))
                                                               (FStar_Sealed.seal
                                                                  (Obj.magic
                                                                     (
                                                                     FStar_Range.mk_range
                                                                     "Pulse.PP.fst"
-                                                                    (Prims.of_int (66))
+                                                                    (Prims.of_int (79))
                                                                     (Prims.of_int (20))
-                                                                    (Prims.of_int (70))
+                                                                    (Prims.of_int (83))
                                                                     (Prims.of_int (41)))))
                                                               (Obj.magic
                                                                  (FStar_Tactics_Effect.tac_bind
@@ -414,18 +418,18 @@ let (uu___50 : Pulse_Typing.post_hint_t printable) =
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.PP.fst"
-                                                                    (Prims.of_int (69))
+                                                                    (Prims.of_int (82))
                                                                     (Prims.of_int (22))
-                                                                    (Prims.of_int (69))
+                                                                    (Prims.of_int (82))
                                                                     (Prims.of_int (33)))))
                                                                     (
                                                                     FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.PP.fst"
-                                                                    (Prims.of_int (66))
+                                                                    (Prims.of_int (79))
                                                                     (Prims.of_int (20))
-                                                                    (Prims.of_int (70))
+                                                                    (Prims.of_int (83))
                                                                     (Prims.of_int (41)))))
                                                                     (
                                                                     Obj.magic
@@ -434,21 +438,21 @@ let (uu___50 : Pulse_Typing.post_hint_t printable) =
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.PP.fst"
-                                                                    (Prims.of_int (69))
+                                                                    (Prims.of_int (82))
                                                                     (Prims.of_int (27))
-                                                                    (Prims.of_int (69))
+                                                                    (Prims.of_int (82))
                                                                     (Prims.of_int (33)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.PP.fst"
-                                                                    (Prims.of_int (69))
+                                                                    (Prims.of_int (82))
                                                                     (Prims.of_int (22))
-                                                                    (Prims.of_int (69))
+                                                                    (Prims.of_int (82))
                                                                     (Prims.of_int (33)))))
                                                                     (Obj.magic
                                                                     (pp
-                                                                    uu___43
+                                                                    uu___45
                                                                     h.Pulse_Typing.u))
                                                                     (fun
                                                                     uu___3 ->
@@ -468,17 +472,17 @@ let (uu___50 : Pulse_Typing.post_hint_t printable) =
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.PP.fst"
-                                                                    (Prims.of_int (66))
+                                                                    (Prims.of_int (79))
                                                                     (Prims.of_int (20))
-                                                                    (Prims.of_int (70))
+                                                                    (Prims.of_int (83))
                                                                     (Prims.of_int (41)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.PP.fst"
-                                                                    (Prims.of_int (66))
+                                                                    (Prims.of_int (79))
                                                                     (Prims.of_int (20))
-                                                                    (Prims.of_int (70))
+                                                                    (Prims.of_int (83))
                                                                     (Prims.of_int (41)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -486,17 +490,17 @@ let (uu___50 : Pulse_Typing.post_hint_t printable) =
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.PP.fst"
-                                                                    (Prims.of_int (70))
+                                                                    (Prims.of_int (83))
                                                                     (Prims.of_int (22))
-                                                                    (Prims.of_int (70))
+                                                                    (Prims.of_int (83))
                                                                     (Prims.of_int (39)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.PP.fst"
-                                                                    (Prims.of_int (66))
+                                                                    (Prims.of_int (79))
                                                                     (Prims.of_int (20))
-                                                                    (Prims.of_int (70))
+                                                                    (Prims.of_int (83))
                                                                     (Prims.of_int (41)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -504,21 +508,21 @@ let (uu___50 : Pulse_Typing.post_hint_t printable) =
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.PP.fst"
-                                                                    (Prims.of_int (70))
+                                                                    (Prims.of_int (83))
                                                                     (Prims.of_int (30))
-                                                                    (Prims.of_int (70))
+                                                                    (Prims.of_int (83))
                                                                     (Prims.of_int (39)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.PP.fst"
-                                                                    (Prims.of_int (70))
+                                                                    (Prims.of_int (83))
                                                                     (Prims.of_int (22))
-                                                                    (Prims.of_int (70))
+                                                                    (Prims.of_int (83))
                                                                     (Prims.of_int (39)))))
                                                                     (Obj.magic
                                                                     (pp
-                                                                    uu___42
+                                                                    uu___44
                                                                     h.Pulse_Typing.post))
                                                                     (fun
                                                                     uu___4 ->

--- a/src/ocaml/plugin/generated/Pulse_PP.ml
+++ b/src/ocaml/plugin/generated/Pulse_PP.ml
@@ -1,0 +1,559 @@
+open Prims
+let (text : Prims.string -> FStar_Pprint.document) =
+  fun s ->
+    FStar_Pprint.flow (FStar_Pprint.break_ Prims.int_one)
+      (FStar_Pprint.words s)
+type 'a printable =
+  {
+  pp: 'a -> (FStar_Pprint.document, unit) FStar_Tactics_Effect.tac_repr }
+let __proj__Mkprintable__item__pp :
+  'a .
+    'a printable ->
+      'a -> (FStar_Pprint.document, unit) FStar_Tactics_Effect.tac_repr
+  = fun projectee -> match projectee with | { pp;_} -> pp
+let pp :
+  'a .
+    'a printable ->
+      'a -> (FStar_Pprint.document, unit) FStar_Tactics_Effect.tac_repr
+  = fun projectee -> match projectee with | { pp = pp1;_} -> pp1
+let from_show : 'a . 'a Pulse_Show.tac_showable -> 'a printable =
+  fun d ->
+    {
+      pp =
+        (fun x ->
+           FStar_Tactics_Effect.tac_bind
+             (FStar_Sealed.seal
+                (Obj.magic
+                   (FStar_Range.mk_range "Pulse.PP.fst" (Prims.of_int (25))
+                      (Prims.of_int (34)) (Prims.of_int (25))
+                      (Prims.of_int (42)))))
+             (FStar_Sealed.seal
+                (Obj.magic
+                   (FStar_Range.mk_range "Pulse.PP.fst" (Prims.of_int (25))
+                      (Prims.of_int (17)) (Prims.of_int (25))
+                      (Prims.of_int (42)))))
+             (Obj.magic (Pulse_Show.show d x))
+             (fun uu___ ->
+                FStar_Tactics_Effect.lift_div_tac
+                  (fun uu___1 -> FStar_Pprint.arbitrary_string uu___)))
+    }
+let (uu___17 : Prims.string printable) = from_show Pulse_Show.uu___12
+let (uu___18 : unit printable) = from_show Pulse_Show.uu___14
+let (uu___19 : Prims.bool printable) = from_show Pulse_Show.uu___16
+let (uu___20 : Prims.int printable) = from_show Pulse_Show.uu___18
+let (uu___21 : Pulse_Syntax_Base.ctag printable) =
+  from_show Pulse_Show.uu___28
+let showable_option :
+  'a . 'a printable -> 'a FStar_Pervasives_Native.option printable =
+  fun uu___ ->
+    {
+      pp =
+        (fun uu___1 ->
+           (fun uu___1 ->
+              match uu___1 with
+              | FStar_Pervasives_Native.None ->
+                  Obj.magic
+                    (Obj.repr
+                       (FStar_Tactics_Effect.lift_div_tac
+                          (fun uu___2 -> FStar_Pprint.doc_of_string "None")))
+              | FStar_Pervasives_Native.Some v ->
+                  Obj.magic
+                    (Obj.repr
+                       (FStar_Tactics_Effect.tac_bind
+                          (FStar_Sealed.seal
+                             (Obj.magic
+                                (FStar_Range.mk_range "Pulse.PP.fst"
+                                   (Prims.of_int (37)) (Prims.of_int (54))
+                                   (Prims.of_int (37)) (Prims.of_int (58)))))
+                          (FStar_Sealed.seal
+                             (Obj.magic
+                                (FStar_Range.mk_range "Pulse.PP.fst"
+                                   (Prims.of_int (37)) (Prims.of_int (29))
+                                   (Prims.of_int (37)) (Prims.of_int (58)))))
+                          (Obj.magic (pp uu___ v))
+                          (fun uu___2 ->
+                             FStar_Tactics_Effect.lift_div_tac
+                               (fun uu___3 ->
+                                  FStar_Pprint.op_Hat_Slash_Hat
+                                    (FStar_Pprint.doc_of_string "Some")
+                                    uu___2))))) uu___1)
+    }
+let rec separate_map :
+  'a .
+    FStar_Pprint.document ->
+      ('a -> (FStar_Pprint.document, unit) FStar_Tactics_Effect.tac_repr) ->
+        'a Prims.list ->
+          (FStar_Pprint.document, unit) FStar_Tactics_Effect.tac_repr
+  =
+  fun uu___2 ->
+    fun uu___1 ->
+      fun uu___ ->
+        (fun sep ->
+           fun f ->
+             fun l ->
+               match l with
+               | [] ->
+                   Obj.magic
+                     (Obj.repr
+                        (FStar_Tactics_Effect.lift_div_tac
+                           (fun uu___ -> FStar_Pprint.empty)))
+               | x::[] -> Obj.magic (Obj.repr (f x))
+               | x::xs ->
+                   Obj.magic
+                     (Obj.repr
+                        (FStar_Tactics_Effect.tac_bind
+                           (FStar_Sealed.seal
+                              (Obj.magic
+                                 (FStar_Range.mk_range "Pulse.PP.fst"
+                                    (Prims.of_int (46)) (Prims.of_int (13))
+                                    (Prims.of_int (46)) (Prims.of_int (16)))))
+                           (FStar_Sealed.seal
+                              (Obj.magic
+                                 (FStar_Range.mk_range "Pulse.PP.fst"
+                                    (Prims.of_int (46)) (Prims.of_int (13))
+                                    (Prims.of_int (46)) (Prims.of_int (49)))))
+                           (Obj.magic (f x))
+                           (fun uu___ ->
+                              (fun uu___ ->
+                                 Obj.magic
+                                   (FStar_Tactics_Effect.tac_bind
+                                      (FStar_Sealed.seal
+                                         (Obj.magic
+                                            (FStar_Range.mk_range
+                                               "Pulse.PP.fst"
+                                               (Prims.of_int (46))
+                                               (Prims.of_int (20))
+                                               (Prims.of_int (46))
+                                               (Prims.of_int (49)))))
+                                      (FStar_Sealed.seal
+                                         (Obj.magic
+                                            (FStar_Range.mk_range
+                                               "Pulse.PP.fst"
+                                               (Prims.of_int (46))
+                                               (Prims.of_int (13))
+                                               (Prims.of_int (46))
+                                               (Prims.of_int (49)))))
+                                      (Obj.magic
+                                         (FStar_Tactics_Effect.tac_bind
+                                            (FStar_Sealed.seal
+                                               (Obj.magic
+                                                  (FStar_Range.mk_range
+                                                     "Pulse.PP.fst"
+                                                     (Prims.of_int (46))
+                                                     (Prims.of_int (28))
+                                                     (Prims.of_int (46))
+                                                     (Prims.of_int (49)))))
+                                            (FStar_Sealed.seal
+                                               (Obj.magic
+                                                  (FStar_Range.mk_range
+                                                     "Pulse.PP.fst"
+                                                     (Prims.of_int (46))
+                                                     (Prims.of_int (20))
+                                                     (Prims.of_int (46))
+                                                     (Prims.of_int (49)))))
+                                            (Obj.magic
+                                               (separate_map sep f xs))
+                                            (fun uu___1 ->
+                                               FStar_Tactics_Effect.lift_div_tac
+                                                 (fun uu___2 ->
+                                                    FStar_Pprint.op_Hat_Slash_Hat
+                                                      sep uu___1))))
+                                      (fun uu___1 ->
+                                         FStar_Tactics_Effect.lift_div_tac
+                                           (fun uu___2 ->
+                                              FStar_Pprint.op_Hat_Hat uu___
+                                                uu___1)))) uu___)))) uu___2
+          uu___1 uu___
+let showable_list : 'a . 'a printable -> 'a Prims.list printable =
+  fun uu___ ->
+    {
+      pp =
+        (fun l ->
+           FStar_Tactics_Effect.tac_bind
+             (FStar_Sealed.seal
+                (Obj.magic
+                   (FStar_Range.mk_range "Pulse.PP.fst" (Prims.of_int (49))
+                      (Prims.of_int (26)) (Prims.of_int (49))
+                      (Prims.of_int (51)))))
+             (FStar_Sealed.seal
+                (Obj.magic
+                   (FStar_Range.mk_range "Pulse.PP.fst" (Prims.of_int (49))
+                      (Prims.of_int (17)) (Prims.of_int (49))
+                      (Prims.of_int (51)))))
+             (Obj.magic (separate_map FStar_Pprint.comma (pp uu___) l))
+             (fun uu___1 ->
+                FStar_Tactics_Effect.lift_div_tac
+                  (fun uu___2 -> FStar_Pprint.brackets uu___1)))
+    }
+let (uu___42 : Pulse_Syntax_Base.term printable) =
+  from_show Pulse_Show.uu___30
+let (uu___43 : Pulse_Syntax_Base.universe printable) =
+  from_show Pulse_Show.uu___31
+let (uu___44 : Pulse_Syntax_Base.comp printable) =
+  from_show Pulse_Show.uu___33
+let (uu___45 : Pulse_Typing_Env.env printable) =
+  { pp = Pulse_Typing_Env.env_to_doc }
+let (pp_record :
+  (Prims.string * FStar_Pprint.document) Prims.list ->
+    (FStar_Pprint.document, unit) FStar_Tactics_Effect.tac_repr)
+  =
+  fun flds ->
+    FStar_Tactics_Effect.tac_bind
+      (FStar_Sealed.seal
+         (Obj.magic
+            (FStar_Range.mk_range "Pulse.PP.fst" (Prims.of_int (61))
+               (Prims.of_int (9)) (Prims.of_int (62)) (Prims.of_int (91)))))
+      (FStar_Sealed.seal
+         (Obj.magic
+            (FStar_Range.mk_range "Pulse.PP.fst" (Prims.of_int (61))
+               (Prims.of_int (2)) (Prims.of_int (62)) (Prims.of_int (91)))))
+      (Obj.magic
+         (separate_map (FStar_Pprint.doc_of_string ";")
+            (fun uu___ ->
+               (fun uu___ ->
+                  Obj.magic
+                    (FStar_Tactics_Effect.lift_div_tac
+                       (fun uu___1 ->
+                          match uu___ with
+                          | (s, d) ->
+                              FStar_Pprint.op_Hat_Slash_Hat
+                                (FStar_Pprint.doc_of_string s)
+                                (FStar_Pprint.op_Hat_Slash_Hat
+                                   FStar_Pprint.equals d)))) uu___) flds))
+      (fun uu___ ->
+         FStar_Tactics_Effect.lift_div_tac
+           (fun uu___1 -> FStar_Pprint.braces uu___))
+let (uu___50 : Pulse_Typing.post_hint_t printable) =
+  {
+    pp =
+      (fun h ->
+         FStar_Tactics_Effect.tac_bind
+           (FStar_Sealed.seal
+              (Obj.magic
+                 (FStar_Range.mk_range "Pulse.PP.fst" (Prims.of_int (66))
+                    (Prims.of_int (20)) (Prims.of_int (70))
+                    (Prims.of_int (41)))))
+           (FStar_Sealed.seal
+              (Obj.magic
+                 (FStar_Range.mk_range "Pulse.PP.fst" (Prims.of_int (66))
+                    (Prims.of_int (10)) (Prims.of_int (70))
+                    (Prims.of_int (41)))))
+           (Obj.magic
+              (FStar_Tactics_Effect.tac_bind
+                 (FStar_Sealed.seal
+                    (Obj.magic
+                       (FStar_Range.mk_range "Pulse.PP.fst"
+                          (Prims.of_int (66)) (Prims.of_int (22))
+                          (Prims.of_int (66)) (Prims.of_int (33)))))
+                 (FStar_Sealed.seal
+                    (Obj.magic
+                       (FStar_Range.mk_range "Pulse.PP.fst"
+                          (Prims.of_int (66)) (Prims.of_int (20))
+                          (Prims.of_int (70)) (Prims.of_int (41)))))
+                 (Obj.magic
+                    (FStar_Tactics_Effect.tac_bind
+                       (FStar_Sealed.seal
+                          (Obj.magic
+                             (FStar_Range.mk_range "Pulse.PP.fst"
+                                (Prims.of_int (66)) (Prims.of_int (27))
+                                (Prims.of_int (66)) (Prims.of_int (33)))))
+                       (FStar_Sealed.seal
+                          (Obj.magic
+                             (FStar_Range.mk_range "Pulse.PP.fst"
+                                (Prims.of_int (66)) (Prims.of_int (22))
+                                (Prims.of_int (66)) (Prims.of_int (33)))))
+                       (Obj.magic (pp uu___45 h.Pulse_Typing.g))
+                       (fun uu___ ->
+                          FStar_Tactics_Effect.lift_div_tac
+                            (fun uu___1 -> ("g", uu___)))))
+                 (fun uu___ ->
+                    (fun uu___ ->
+                       Obj.magic
+                         (FStar_Tactics_Effect.tac_bind
+                            (FStar_Sealed.seal
+                               (Obj.magic
+                                  (FStar_Range.mk_range "Pulse.PP.fst"
+                                     (Prims.of_int (66)) (Prims.of_int (20))
+                                     (Prims.of_int (70)) (Prims.of_int (41)))))
+                            (FStar_Sealed.seal
+                               (Obj.magic
+                                  (FStar_Range.mk_range "Pulse.PP.fst"
+                                     (Prims.of_int (66)) (Prims.of_int (20))
+                                     (Prims.of_int (70)) (Prims.of_int (41)))))
+                            (Obj.magic
+                               (FStar_Tactics_Effect.tac_bind
+                                  (FStar_Sealed.seal
+                                     (Obj.magic
+                                        (FStar_Range.mk_range "Pulse.PP.fst"
+                                           (Prims.of_int (67))
+                                           (Prims.of_int (22))
+                                           (Prims.of_int (67))
+                                           (Prims.of_int (49)))))
+                                  (FStar_Sealed.seal
+                                     (Obj.magic
+                                        (FStar_Range.mk_range "Pulse.PP.fst"
+                                           (Prims.of_int (66))
+                                           (Prims.of_int (20))
+                                           (Prims.of_int (70))
+                                           (Prims.of_int (41)))))
+                                  (Obj.magic
+                                     (FStar_Tactics_Effect.tac_bind
+                                        (FStar_Sealed.seal
+                                           (Obj.magic
+                                              (FStar_Range.mk_range
+                                                 "Pulse.PP.fst"
+                                                 (Prims.of_int (67))
+                                                 (Prims.of_int (35))
+                                                 (Prims.of_int (67))
+                                                 (Prims.of_int (49)))))
+                                        (FStar_Sealed.seal
+                                           (Obj.magic
+                                              (FStar_Range.mk_range
+                                                 "Pulse.PP.fst"
+                                                 (Prims.of_int (67))
+                                                 (Prims.of_int (22))
+                                                 (Prims.of_int (67))
+                                                 (Prims.of_int (49)))))
+                                        (Obj.magic
+                                           (pp (showable_option uu___21)
+                                              h.Pulse_Typing.ctag_hint))
+                                        (fun uu___1 ->
+                                           FStar_Tactics_Effect.lift_div_tac
+                                             (fun uu___2 ->
+                                                ("ctag_hint", uu___1)))))
+                                  (fun uu___1 ->
+                                     (fun uu___1 ->
+                                        Obj.magic
+                                          (FStar_Tactics_Effect.tac_bind
+                                             (FStar_Sealed.seal
+                                                (Obj.magic
+                                                   (FStar_Range.mk_range
+                                                      "Pulse.PP.fst"
+                                                      (Prims.of_int (66))
+                                                      (Prims.of_int (20))
+                                                      (Prims.of_int (70))
+                                                      (Prims.of_int (41)))))
+                                             (FStar_Sealed.seal
+                                                (Obj.magic
+                                                   (FStar_Range.mk_range
+                                                      "Pulse.PP.fst"
+                                                      (Prims.of_int (66))
+                                                      (Prims.of_int (20))
+                                                      (Prims.of_int (70))
+                                                      (Prims.of_int (41)))))
+                                             (Obj.magic
+                                                (FStar_Tactics_Effect.tac_bind
+                                                   (FStar_Sealed.seal
+                                                      (Obj.magic
+                                                         (FStar_Range.mk_range
+                                                            "Pulse.PP.fst"
+                                                            (Prims.of_int (68))
+                                                            (Prims.of_int (22))
+                                                            (Prims.of_int (68))
+                                                            (Prims.of_int (43)))))
+                                                   (FStar_Sealed.seal
+                                                      (Obj.magic
+                                                         (FStar_Range.mk_range
+                                                            "Pulse.PP.fst"
+                                                            (Prims.of_int (66))
+                                                            (Prims.of_int (20))
+                                                            (Prims.of_int (70))
+                                                            (Prims.of_int (41)))))
+                                                   (Obj.magic
+                                                      (FStar_Tactics_Effect.tac_bind
+                                                         (FStar_Sealed.seal
+                                                            (Obj.magic
+                                                               (FStar_Range.mk_range
+                                                                  "Pulse.PP.fst"
+                                                                  (Prims.of_int (68))
+                                                                  (Prims.of_int (32))
+                                                                  (Prims.of_int (68))
+                                                                  (Prims.of_int (43)))))
+                                                         (FStar_Sealed.seal
+                                                            (Obj.magic
+                                                               (FStar_Range.mk_range
+                                                                  "Pulse.PP.fst"
+                                                                  (Prims.of_int (68))
+                                                                  (Prims.of_int (22))
+                                                                  (Prims.of_int (68))
+                                                                  (Prims.of_int (43)))))
+                                                         (Obj.magic
+                                                            (pp uu___42
+                                                               h.Pulse_Typing.ret_ty))
+                                                         (fun uu___2 ->
+                                                            FStar_Tactics_Effect.lift_div_tac
+                                                              (fun uu___3 ->
+                                                                 ("ret_ty",
+                                                                   uu___2)))))
+                                                   (fun uu___2 ->
+                                                      (fun uu___2 ->
+                                                         Obj.magic
+                                                           (FStar_Tactics_Effect.tac_bind
+                                                              (FStar_Sealed.seal
+                                                                 (Obj.magic
+                                                                    (
+                                                                    FStar_Range.mk_range
+                                                                    "Pulse.PP.fst"
+                                                                    (Prims.of_int (66))
+                                                                    (Prims.of_int (20))
+                                                                    (Prims.of_int (70))
+                                                                    (Prims.of_int (41)))))
+                                                              (FStar_Sealed.seal
+                                                                 (Obj.magic
+                                                                    (
+                                                                    FStar_Range.mk_range
+                                                                    "Pulse.PP.fst"
+                                                                    (Prims.of_int (66))
+                                                                    (Prims.of_int (20))
+                                                                    (Prims.of_int (70))
+                                                                    (Prims.of_int (41)))))
+                                                              (Obj.magic
+                                                                 (FStar_Tactics_Effect.tac_bind
+                                                                    (
+                                                                    FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.PP.fst"
+                                                                    (Prims.of_int (69))
+                                                                    (Prims.of_int (22))
+                                                                    (Prims.of_int (69))
+                                                                    (Prims.of_int (33)))))
+                                                                    (
+                                                                    FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.PP.fst"
+                                                                    (Prims.of_int (66))
+                                                                    (Prims.of_int (20))
+                                                                    (Prims.of_int (70))
+                                                                    (Prims.of_int (41)))))
+                                                                    (
+                                                                    Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.PP.fst"
+                                                                    (Prims.of_int (69))
+                                                                    (Prims.of_int (27))
+                                                                    (Prims.of_int (69))
+                                                                    (Prims.of_int (33)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.PP.fst"
+                                                                    (Prims.of_int (69))
+                                                                    (Prims.of_int (22))
+                                                                    (Prims.of_int (69))
+                                                                    (Prims.of_int (33)))))
+                                                                    (Obj.magic
+                                                                    (pp
+                                                                    uu___43
+                                                                    h.Pulse_Typing.u))
+                                                                    (fun
+                                                                    uu___3 ->
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___4 ->
+                                                                    ("u",
+                                                                    uu___3)))))
+                                                                    (
+                                                                    fun
+                                                                    uu___3 ->
+                                                                    (fun
+                                                                    uu___3 ->
+                                                                    Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.PP.fst"
+                                                                    (Prims.of_int (66))
+                                                                    (Prims.of_int (20))
+                                                                    (Prims.of_int (70))
+                                                                    (Prims.of_int (41)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.PP.fst"
+                                                                    (Prims.of_int (66))
+                                                                    (Prims.of_int (20))
+                                                                    (Prims.of_int (70))
+                                                                    (Prims.of_int (41)))))
+                                                                    (Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.PP.fst"
+                                                                    (Prims.of_int (70))
+                                                                    (Prims.of_int (22))
+                                                                    (Prims.of_int (70))
+                                                                    (Prims.of_int (39)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.PP.fst"
+                                                                    (Prims.of_int (66))
+                                                                    (Prims.of_int (20))
+                                                                    (Prims.of_int (70))
+                                                                    (Prims.of_int (41)))))
+                                                                    (Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.PP.fst"
+                                                                    (Prims.of_int (70))
+                                                                    (Prims.of_int (30))
+                                                                    (Prims.of_int (70))
+                                                                    (Prims.of_int (39)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.PP.fst"
+                                                                    (Prims.of_int (70))
+                                                                    (Prims.of_int (22))
+                                                                    (Prims.of_int (70))
+                                                                    (Prims.of_int (39)))))
+                                                                    (Obj.magic
+                                                                    (pp
+                                                                    uu___42
+                                                                    h.Pulse_Typing.post))
+                                                                    (fun
+                                                                    uu___4 ->
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___5 ->
+                                                                    ("post",
+                                                                    uu___4)))))
+                                                                    (fun
+                                                                    uu___4 ->
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___5 ->
+                                                                    [uu___4]))))
+                                                                    (fun
+                                                                    uu___4 ->
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___5 ->
+                                                                    uu___3 ::
+                                                                    uu___4))))
+                                                                    uu___3)))
+                                                              (fun uu___3 ->
+                                                                 FStar_Tactics_Effect.lift_div_tac
+                                                                   (fun
+                                                                    uu___4 ->
+                                                                    uu___2 ::
+                                                                    uu___3))))
+                                                        uu___2)))
+                                             (fun uu___2 ->
+                                                FStar_Tactics_Effect.lift_div_tac
+                                                  (fun uu___3 -> uu___1 ::
+                                                     uu___2)))) uu___1)))
+                            (fun uu___1 ->
+                               FStar_Tactics_Effect.lift_div_tac
+                                 (fun uu___2 -> uu___ :: uu___1)))) uu___)))
+           (fun uu___ -> (fun uu___ -> Obj.magic (pp_record uu___)) uu___))
+  }

--- a/src/ocaml/plugin/generated/Pulse_Show.ml
+++ b/src/ocaml/plugin/generated/Pulse_Show.ml
@@ -25,8 +25,8 @@ let (uu___14 : unit tac_showable) =
     show =
       (fun uu___ ->
          (fun uu___ ->
-            Obj.magic (FStar_Tactics_Effect.lift_div_tac (fun uu___1 -> "")))
-           uu___)
+            Obj.magic
+              (FStar_Tactics_Effect.lift_div_tac (fun uu___1 -> "()"))) uu___)
   }
 let (uu___16 : Prims.bool tac_showable) =
   {

--- a/src/ocaml/plugin/generated/Pulse_Syntax_Printer.ml
+++ b/src/ocaml/plugin/generated/Pulse_Syntax_Printer.ml
@@ -503,6 +503,588 @@ let (term_to_string :
   Pulse_Syntax_Base.term ->
     (Prims.string, unit) FStar_Tactics_Effect.tac_repr)
   = fun t -> term_to_string' "" t
+let rec (term_to_doc :
+  Pulse_Syntax_Base.term ->
+    (FStar_Pprint.document, unit) FStar_Tactics_Effect.tac_repr)
+  =
+  fun uu___ ->
+    (fun t ->
+       match t.Pulse_Syntax_Base.t with
+       | Pulse_Syntax_Base.Tm_Emp ->
+           Obj.magic
+             (Obj.repr
+                (FStar_Tactics_Effect.lift_div_tac
+                   (fun uu___ -> FStar_Pprint.doc_of_string "emp")))
+       | Pulse_Syntax_Base.Tm_Pure p ->
+           Obj.magic
+             (Obj.repr
+                (FStar_Tactics_Effect.tac_bind
+                   (FStar_Sealed.seal
+                      (Obj.magic
+                         (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
+                            (Prims.of_int (90)) (Prims.of_int (44))
+                            (Prims.of_int (90)) (Prims.of_int (66)))))
+                   (FStar_Sealed.seal
+                      (Obj.magic
+                         (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
+                            (Prims.of_int (90)) (Prims.of_int (19))
+                            (Prims.of_int (90)) (Prims.of_int (66)))))
+                   (Obj.magic
+                      (FStar_Tactics_Effect.tac_bind
+                         (FStar_Sealed.seal
+                            (Obj.magic
+                               (FStar_Range.mk_range
+                                  "Pulse.Syntax.Printer.fst"
+                                  (Prims.of_int (90)) (Prims.of_int (51))
+                                  (Prims.of_int (90)) (Prims.of_int (66)))))
+                         (FStar_Sealed.seal
+                            (Obj.magic
+                               (FStar_Range.mk_range
+                                  "Pulse.Syntax.Printer.fst"
+                                  (Prims.of_int (90)) (Prims.of_int (44))
+                                  (Prims.of_int (90)) (Prims.of_int (66)))))
+                         (Obj.magic (term_to_doc p))
+                         (fun uu___ ->
+                            FStar_Tactics_Effect.lift_div_tac
+                              (fun uu___1 -> FStar_Pprint.parens uu___))))
+                   (fun uu___ ->
+                      FStar_Tactics_Effect.lift_div_tac
+                        (fun uu___1 ->
+                           FStar_Pprint.op_Hat_Slash_Hat
+                             (FStar_Pprint.doc_of_string "pure") uu___))))
+       | Pulse_Syntax_Base.Tm_Star (p1, p2) ->
+           Obj.magic
+             (Obj.repr
+                (FStar_Tactics_Effect.tac_bind
+                   (FStar_Sealed.seal
+                      (Obj.magic
+                         (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
+                            (Prims.of_int (93)) (Prims.of_int (16))
+                            (Prims.of_int (93)) (Prims.of_int (32)))))
+                   (FStar_Sealed.seal
+                      (Obj.magic
+                         (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
+                            (Prims.of_int (92)) (Prims.of_int (6))
+                            (Prims.of_int (94)) (Prims.of_int (32)))))
+                   (Obj.magic (term_to_doc p1))
+                   (fun uu___ ->
+                      (fun uu___ ->
+                         Obj.magic
+                           (FStar_Tactics_Effect.tac_bind
+                              (FStar_Sealed.seal
+                                 (Obj.magic
+                                    (FStar_Range.mk_range
+                                       "Pulse.Syntax.Printer.fst"
+                                       (Prims.of_int (94))
+                                       (Prims.of_int (16))
+                                       (Prims.of_int (94))
+                                       (Prims.of_int (32)))))
+                              (FStar_Sealed.seal
+                                 (Obj.magic
+                                    (FStar_Range.mk_range
+                                       "Pulse.Syntax.Printer.fst"
+                                       (Prims.of_int (92)) (Prims.of_int (6))
+                                       (Prims.of_int (94))
+                                       (Prims.of_int (32)))))
+                              (Obj.magic (term_to_doc p2))
+                              (fun uu___1 ->
+                                 FStar_Tactics_Effect.lift_div_tac
+                                   (fun uu___2 ->
+                                      FStar_Pprint.infix (Prims.of_int (2))
+                                        Prims.int_one
+                                        (FStar_Pprint.doc_of_string "**")
+                                        uu___ uu___1)))) uu___)))
+       | Pulse_Syntax_Base.Tm_ExistsSL (uu___, b, body) ->
+           Obj.magic
+             (Obj.repr
+                (FStar_Tactics_Effect.tac_bind
+                   (FStar_Sealed.seal
+                      (Obj.magic
+                         (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
+                            (Prims.of_int (97)) (Prims.of_int (13))
+                            (Prims.of_int (101)) (Prims.of_int (35)))))
+                   (FStar_Sealed.seal
+                      (Obj.magic
+                         (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
+                            (Prims.of_int (97)) (Prims.of_int (6))
+                            (Prims.of_int (101)) (Prims.of_int (35)))))
+                   (Obj.magic
+                      (FStar_Tactics_Effect.tac_bind
+                         (FStar_Sealed.seal
+                            (Obj.magic
+                               (FStar_Range.mk_range
+                                  "Pulse.Syntax.Printer.fst"
+                                  (Prims.of_int (97)) (Prims.of_int (41))
+                                  (Prims.of_int (101)) (Prims.of_int (34)))))
+                         (FStar_Sealed.seal
+                            (Obj.magic
+                               (FStar_Range.mk_range
+                                  "Pulse.Syntax.Printer.fst"
+                                  (Prims.of_int (97)) (Prims.of_int (13))
+                                  (Prims.of_int (101)) (Prims.of_int (35)))))
+                         (Obj.magic
+                            (FStar_Tactics_Effect.tac_bind
+                               (FStar_Sealed.seal
+                                  (Obj.magic
+                                     (FStar_Range.mk_range
+                                        "Pulse.Syntax.Printer.fst"
+                                        (Prims.of_int (97))
+                                        (Prims.of_int (41))
+                                        (Prims.of_int (99))
+                                        (Prims.of_int (77)))))
+                               (FStar_Sealed.seal
+                                  (Obj.magic
+                                     (FStar_Range.mk_range
+                                        "Pulse.Syntax.Printer.fst"
+                                        (Prims.of_int (97))
+                                        (Prims.of_int (41))
+                                        (Prims.of_int (101))
+                                        (Prims.of_int (34)))))
+                               (Obj.magic
+                                  (FStar_Tactics_Effect.tac_bind
+                                     (FStar_Sealed.seal
+                                        (Obj.magic
+                                           (FStar_Range.mk_range
+                                              "Pulse.Syntax.Printer.fst"
+                                              (Prims.of_int (97))
+                                              (Prims.of_int (48))
+                                              (Prims.of_int (99))
+                                              (Prims.of_int (77)))))
+                                     (FStar_Sealed.seal
+                                        (Obj.magic
+                                           (FStar_Range.mk_range
+                                              "Pulse.Syntax.Printer.fst"
+                                              (Prims.of_int (97))
+                                              (Prims.of_int (41))
+                                              (Prims.of_int (99))
+                                              (Prims.of_int (77)))))
+                                     (Obj.magic
+                                        (FStar_Tactics_Effect.tac_bind
+                                           (FStar_Sealed.seal
+                                              (Obj.magic
+                                                 (FStar_Range.mk_range
+                                                    "Pulse.Syntax.Printer.fst"
+                                                    (Prims.of_int (97))
+                                                    (Prims.of_int (49))
+                                                    (Prims.of_int (97))
+                                                    (Prims.of_int (94)))))
+                                           (FStar_Sealed.seal
+                                              (Obj.magic
+                                                 (FStar_Range.mk_range
+                                                    "Pulse.Syntax.Printer.fst"
+                                                    (Prims.of_int (97))
+                                                    (Prims.of_int (48))
+                                                    (Prims.of_int (99))
+                                                    (Prims.of_int (77)))))
+                                           (Obj.magic
+                                              (FStar_Tactics_Effect.tac_bind
+                                                 (FStar_Sealed.seal
+                                                    (Obj.magic
+                                                       (FStar_Range.mk_range
+                                                          "Pulse.Syntax.Printer.fst"
+                                                          (Prims.of_int (97))
+                                                          (Prims.of_int (63))
+                                                          (Prims.of_int (97))
+                                                          (Prims.of_int (94)))))
+                                                 (FStar_Sealed.seal
+                                                    (Obj.magic
+                                                       (FStar_Range.mk_range
+                                                          "Pulse.Syntax.Printer.fst"
+                                                          (Prims.of_int (97))
+                                                          (Prims.of_int (49))
+                                                          (Prims.of_int (97))
+                                                          (Prims.of_int (94)))))
+                                                 (Obj.magic
+                                                    (FStar_Tactics_Unseal.unseal
+                                                       (b.Pulse_Syntax_Base.binder_ppname).Pulse_Syntax_Base.name))
+                                                 (fun uu___1 ->
+                                                    FStar_Tactics_Effect.lift_div_tac
+                                                      (fun uu___2 ->
+                                                         FStar_Pprint.doc_of_string
+                                                           uu___1))))
+                                           (fun uu___1 ->
+                                              (fun uu___1 ->
+                                                 Obj.magic
+                                                   (FStar_Tactics_Effect.tac_bind
+                                                      (FStar_Sealed.seal
+                                                         (Obj.magic
+                                                            (FStar_Range.mk_range
+                                                               "Pulse.Syntax.Printer.fst"
+                                                               (Prims.of_int (98))
+                                                               (Prims.of_int (53))
+                                                               (Prims.of_int (99))
+                                                               (Prims.of_int (76)))))
+                                                      (FStar_Sealed.seal
+                                                         (Obj.magic
+                                                            (FStar_Range.mk_range
+                                                               "Pulse.Syntax.Printer.fst"
+                                                               (Prims.of_int (97))
+                                                               (Prims.of_int (48))
+                                                               (Prims.of_int (99))
+                                                               (Prims.of_int (77)))))
+                                                      (Obj.magic
+                                                         (FStar_Tactics_Effect.tac_bind
+                                                            (FStar_Sealed.seal
+                                                               (Obj.magic
+                                                                  (FStar_Range.mk_range
+                                                                    "Pulse.Syntax.Printer.fst"
+                                                                    (Prims.of_int (99))
+                                                                    (Prims.of_int (53))
+                                                                    (Prims.of_int (99))
+                                                                    (Prims.of_int (76)))))
+                                                            (FStar_Sealed.seal
+                                                               (Obj.magic
+                                                                  (FStar_Range.mk_range
+                                                                    "Pulse.Syntax.Printer.fst"
+                                                                    (Prims.of_int (98))
+                                                                    (Prims.of_int (53))
+                                                                    (Prims.of_int (99))
+                                                                    (Prims.of_int (76)))))
+                                                            (Obj.magic
+                                                               (term_to_doc
+                                                                  b.Pulse_Syntax_Base.binder_ty))
+                                                            (fun uu___2 ->
+                                                               FStar_Tactics_Effect.lift_div_tac
+                                                                 (fun uu___3
+                                                                    ->
+                                                                    FStar_Pprint.op_Hat_Hat
+                                                                    (FStar_Pprint.doc_of_string
+                                                                    ":")
+                                                                    uu___2))))
+                                                      (fun uu___2 ->
+                                                         FStar_Tactics_Effect.lift_div_tac
+                                                           (fun uu___3 ->
+                                                              FStar_Pprint.op_Hat_Hat
+                                                                uu___1 uu___2))))
+                                                uu___1)))
+                                     (fun uu___1 ->
+                                        FStar_Tactics_Effect.lift_div_tac
+                                          (fun uu___2 ->
+                                             FStar_Pprint.parens uu___1))))
+                               (fun uu___1 ->
+                                  (fun uu___1 ->
+                                     Obj.magic
+                                       (FStar_Tactics_Effect.tac_bind
+                                          (FStar_Sealed.seal
+                                             (Obj.magic
+                                                (FStar_Range.mk_range
+                                                   "Pulse.Syntax.Printer.fst"
+                                                   (Prims.of_int (100))
+                                                   (Prims.of_int (17))
+                                                   (Prims.of_int (101))
+                                                   (Prims.of_int (34)))))
+                                          (FStar_Sealed.seal
+                                             (Obj.magic
+                                                (FStar_Range.mk_range
+                                                   "Pulse.Syntax.Printer.fst"
+                                                   (Prims.of_int (97))
+                                                   (Prims.of_int (41))
+                                                   (Prims.of_int (101))
+                                                   (Prims.of_int (34)))))
+                                          (Obj.magic
+                                             (FStar_Tactics_Effect.tac_bind
+                                                (FStar_Sealed.seal
+                                                   (Obj.magic
+                                                      (FStar_Range.mk_range
+                                                         "Pulse.Syntax.Printer.fst"
+                                                         (Prims.of_int (101))
+                                                         (Prims.of_int (18))
+                                                         (Prims.of_int (101))
+                                                         (Prims.of_int (34)))))
+                                                (FStar_Sealed.seal
+                                                   (Obj.magic
+                                                      (FStar_Range.mk_range
+                                                         "Pulse.Syntax.Printer.fst"
+                                                         (Prims.of_int (100))
+                                                         (Prims.of_int (17))
+                                                         (Prims.of_int (101))
+                                                         (Prims.of_int (34)))))
+                                                (Obj.magic (term_to_doc body))
+                                                (fun uu___2 ->
+                                                   FStar_Tactics_Effect.lift_div_tac
+                                                     (fun uu___3 ->
+                                                        FStar_Pprint.op_Hat_Slash_Hat
+                                                          (FStar_Pprint.doc_of_string
+                                                             ".") uu___2))))
+                                          (fun uu___2 ->
+                                             FStar_Tactics_Effect.lift_div_tac
+                                               (fun uu___3 ->
+                                                  FStar_Pprint.op_Hat_Hat
+                                                    uu___1 uu___2)))) uu___1)))
+                         (fun uu___1 ->
+                            FStar_Tactics_Effect.lift_div_tac
+                              (fun uu___2 ->
+                                 FStar_Pprint.op_Hat_Slash_Hat
+                                   (FStar_Pprint.doc_of_string "exists")
+                                   uu___1))))
+                   (fun uu___1 ->
+                      FStar_Tactics_Effect.lift_div_tac
+                        (fun uu___2 -> FStar_Pprint.parens uu___1))))
+       | Pulse_Syntax_Base.Tm_ForallSL (u, b, body) ->
+           Obj.magic
+             (Obj.repr
+                (FStar_Tactics_Effect.tac_bind
+                   (FStar_Sealed.seal
+                      (Obj.magic
+                         (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
+                            (Prims.of_int (104)) (Prims.of_int (13))
+                            (Prims.of_int (108)) (Prims.of_int (35)))))
+                   (FStar_Sealed.seal
+                      (Obj.magic
+                         (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
+                            (Prims.of_int (104)) (Prims.of_int (6))
+                            (Prims.of_int (108)) (Prims.of_int (35)))))
+                   (Obj.magic
+                      (FStar_Tactics_Effect.tac_bind
+                         (FStar_Sealed.seal
+                            (Obj.magic
+                               (FStar_Range.mk_range
+                                  "Pulse.Syntax.Printer.fst"
+                                  (Prims.of_int (104)) (Prims.of_int (41))
+                                  (Prims.of_int (108)) (Prims.of_int (34)))))
+                         (FStar_Sealed.seal
+                            (Obj.magic
+                               (FStar_Range.mk_range
+                                  "Pulse.Syntax.Printer.fst"
+                                  (Prims.of_int (104)) (Prims.of_int (13))
+                                  (Prims.of_int (108)) (Prims.of_int (35)))))
+                         (Obj.magic
+                            (FStar_Tactics_Effect.tac_bind
+                               (FStar_Sealed.seal
+                                  (Obj.magic
+                                     (FStar_Range.mk_range
+                                        "Pulse.Syntax.Printer.fst"
+                                        (Prims.of_int (104))
+                                        (Prims.of_int (41))
+                                        (Prims.of_int (106))
+                                        (Prims.of_int (77)))))
+                               (FStar_Sealed.seal
+                                  (Obj.magic
+                                     (FStar_Range.mk_range
+                                        "Pulse.Syntax.Printer.fst"
+                                        (Prims.of_int (104))
+                                        (Prims.of_int (41))
+                                        (Prims.of_int (108))
+                                        (Prims.of_int (34)))))
+                               (Obj.magic
+                                  (FStar_Tactics_Effect.tac_bind
+                                     (FStar_Sealed.seal
+                                        (Obj.magic
+                                           (FStar_Range.mk_range
+                                              "Pulse.Syntax.Printer.fst"
+                                              (Prims.of_int (104))
+                                              (Prims.of_int (48))
+                                              (Prims.of_int (106))
+                                              (Prims.of_int (77)))))
+                                     (FStar_Sealed.seal
+                                        (Obj.magic
+                                           (FStar_Range.mk_range
+                                              "Pulse.Syntax.Printer.fst"
+                                              (Prims.of_int (104))
+                                              (Prims.of_int (41))
+                                              (Prims.of_int (106))
+                                              (Prims.of_int (77)))))
+                                     (Obj.magic
+                                        (FStar_Tactics_Effect.tac_bind
+                                           (FStar_Sealed.seal
+                                              (Obj.magic
+                                                 (FStar_Range.mk_range
+                                                    "Pulse.Syntax.Printer.fst"
+                                                    (Prims.of_int (104))
+                                                    (Prims.of_int (49))
+                                                    (Prims.of_int (104))
+                                                    (Prims.of_int (94)))))
+                                           (FStar_Sealed.seal
+                                              (Obj.magic
+                                                 (FStar_Range.mk_range
+                                                    "Pulse.Syntax.Printer.fst"
+                                                    (Prims.of_int (104))
+                                                    (Prims.of_int (48))
+                                                    (Prims.of_int (106))
+                                                    (Prims.of_int (77)))))
+                                           (Obj.magic
+                                              (FStar_Tactics_Effect.tac_bind
+                                                 (FStar_Sealed.seal
+                                                    (Obj.magic
+                                                       (FStar_Range.mk_range
+                                                          "Pulse.Syntax.Printer.fst"
+                                                          (Prims.of_int (104))
+                                                          (Prims.of_int (63))
+                                                          (Prims.of_int (104))
+                                                          (Prims.of_int (94)))))
+                                                 (FStar_Sealed.seal
+                                                    (Obj.magic
+                                                       (FStar_Range.mk_range
+                                                          "Pulse.Syntax.Printer.fst"
+                                                          (Prims.of_int (104))
+                                                          (Prims.of_int (49))
+                                                          (Prims.of_int (104))
+                                                          (Prims.of_int (94)))))
+                                                 (Obj.magic
+                                                    (FStar_Tactics_Unseal.unseal
+                                                       (b.Pulse_Syntax_Base.binder_ppname).Pulse_Syntax_Base.name))
+                                                 (fun uu___ ->
+                                                    FStar_Tactics_Effect.lift_div_tac
+                                                      (fun uu___1 ->
+                                                         FStar_Pprint.doc_of_string
+                                                           uu___))))
+                                           (fun uu___ ->
+                                              (fun uu___ ->
+                                                 Obj.magic
+                                                   (FStar_Tactics_Effect.tac_bind
+                                                      (FStar_Sealed.seal
+                                                         (Obj.magic
+                                                            (FStar_Range.mk_range
+                                                               "Pulse.Syntax.Printer.fst"
+                                                               (Prims.of_int (105))
+                                                               (Prims.of_int (53))
+                                                               (Prims.of_int (106))
+                                                               (Prims.of_int (76)))))
+                                                      (FStar_Sealed.seal
+                                                         (Obj.magic
+                                                            (FStar_Range.mk_range
+                                                               "Pulse.Syntax.Printer.fst"
+                                                               (Prims.of_int (104))
+                                                               (Prims.of_int (48))
+                                                               (Prims.of_int (106))
+                                                               (Prims.of_int (77)))))
+                                                      (Obj.magic
+                                                         (FStar_Tactics_Effect.tac_bind
+                                                            (FStar_Sealed.seal
+                                                               (Obj.magic
+                                                                  (FStar_Range.mk_range
+                                                                    "Pulse.Syntax.Printer.fst"
+                                                                    (Prims.of_int (106))
+                                                                    (Prims.of_int (53))
+                                                                    (Prims.of_int (106))
+                                                                    (Prims.of_int (76)))))
+                                                            (FStar_Sealed.seal
+                                                               (Obj.magic
+                                                                  (FStar_Range.mk_range
+                                                                    "Pulse.Syntax.Printer.fst"
+                                                                    (Prims.of_int (105))
+                                                                    (Prims.of_int (53))
+                                                                    (Prims.of_int (106))
+                                                                    (Prims.of_int (76)))))
+                                                            (Obj.magic
+                                                               (term_to_doc
+                                                                  b.Pulse_Syntax_Base.binder_ty))
+                                                            (fun uu___1 ->
+                                                               FStar_Tactics_Effect.lift_div_tac
+                                                                 (fun uu___2
+                                                                    ->
+                                                                    FStar_Pprint.op_Hat_Hat
+                                                                    (FStar_Pprint.doc_of_string
+                                                                    ":")
+                                                                    uu___1))))
+                                                      (fun uu___1 ->
+                                                         FStar_Tactics_Effect.lift_div_tac
+                                                           (fun uu___2 ->
+                                                              FStar_Pprint.op_Hat_Hat
+                                                                uu___ uu___1))))
+                                                uu___)))
+                                     (fun uu___ ->
+                                        FStar_Tactics_Effect.lift_div_tac
+                                          (fun uu___1 ->
+                                             FStar_Pprint.parens uu___))))
+                               (fun uu___ ->
+                                  (fun uu___ ->
+                                     Obj.magic
+                                       (FStar_Tactics_Effect.tac_bind
+                                          (FStar_Sealed.seal
+                                             (Obj.magic
+                                                (FStar_Range.mk_range
+                                                   "Pulse.Syntax.Printer.fst"
+                                                   (Prims.of_int (107))
+                                                   (Prims.of_int (17))
+                                                   (Prims.of_int (108))
+                                                   (Prims.of_int (34)))))
+                                          (FStar_Sealed.seal
+                                             (Obj.magic
+                                                (FStar_Range.mk_range
+                                                   "Pulse.Syntax.Printer.fst"
+                                                   (Prims.of_int (104))
+                                                   (Prims.of_int (41))
+                                                   (Prims.of_int (108))
+                                                   (Prims.of_int (34)))))
+                                          (Obj.magic
+                                             (FStar_Tactics_Effect.tac_bind
+                                                (FStar_Sealed.seal
+                                                   (Obj.magic
+                                                      (FStar_Range.mk_range
+                                                         "Pulse.Syntax.Printer.fst"
+                                                         (Prims.of_int (108))
+                                                         (Prims.of_int (18))
+                                                         (Prims.of_int (108))
+                                                         (Prims.of_int (34)))))
+                                                (FStar_Sealed.seal
+                                                   (Obj.magic
+                                                      (FStar_Range.mk_range
+                                                         "Pulse.Syntax.Printer.fst"
+                                                         (Prims.of_int (107))
+                                                         (Prims.of_int (17))
+                                                         (Prims.of_int (108))
+                                                         (Prims.of_int (34)))))
+                                                (Obj.magic (term_to_doc body))
+                                                (fun uu___1 ->
+                                                   FStar_Tactics_Effect.lift_div_tac
+                                                     (fun uu___2 ->
+                                                        FStar_Pprint.op_Hat_Slash_Hat
+                                                          (FStar_Pprint.doc_of_string
+                                                             ".") uu___1))))
+                                          (fun uu___1 ->
+                                             FStar_Tactics_Effect.lift_div_tac
+                                               (fun uu___2 ->
+                                                  FStar_Pprint.op_Hat_Hat
+                                                    uu___ uu___1)))) uu___)))
+                         (fun uu___ ->
+                            FStar_Tactics_Effect.lift_div_tac
+                              (fun uu___1 ->
+                                 FStar_Pprint.op_Hat_Slash_Hat
+                                   (FStar_Pprint.doc_of_string "forall")
+                                   uu___))))
+                   (fun uu___ ->
+                      FStar_Tactics_Effect.lift_div_tac
+                        (fun uu___1 -> FStar_Pprint.parens uu___))))
+       | Pulse_Syntax_Base.Tm_VProp ->
+           Obj.magic
+             (Obj.repr
+                (FStar_Tactics_Effect.lift_div_tac
+                   (fun uu___ -> FStar_Pprint.doc_of_string "vprop")))
+       | Pulse_Syntax_Base.Tm_Inames ->
+           Obj.magic
+             (Obj.repr
+                (FStar_Tactics_Effect.lift_div_tac
+                   (fun uu___ -> FStar_Pprint.doc_of_string "inames")))
+       | Pulse_Syntax_Base.Tm_EmpInames ->
+           Obj.magic
+             (Obj.repr
+                (FStar_Tactics_Effect.lift_div_tac
+                   (fun uu___ -> FStar_Pprint.doc_of_string "emp_inames")))
+       | Pulse_Syntax_Base.Tm_Unknown ->
+           Obj.magic
+             (Obj.repr
+                (FStar_Tactics_Effect.lift_div_tac
+                   (fun uu___ -> FStar_Pprint.doc_of_string "_")))
+       | Pulse_Syntax_Base.Tm_FStar t1 ->
+           Obj.magic
+             (Obj.repr
+                (FStar_Tactics_Effect.tac_bind
+                   (FStar_Sealed.seal
+                      (Obj.magic
+                         (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
+                            (Prims.of_int (116)) (Prims.of_int (20))
+                            (Prims.of_int (116)) (Prims.of_int (40)))))
+                   (FStar_Sealed.seal
+                      (Obj.magic
+                         (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
+                            (Prims.of_int (116)) (Prims.of_int (6))
+                            (Prims.of_int (116)) (Prims.of_int (40)))))
+                   (Obj.magic (FStar_Tactics_V2_Builtins.term_to_string t1))
+                   (fun uu___ ->
+                      FStar_Tactics_Effect.lift_div_tac
+                        (fun uu___1 -> FStar_Pprint.doc_of_string uu___)))))
+      uu___
 let (binder_to_string :
   Pulse_Syntax_Base.binder ->
     (Prims.string, unit) FStar_Tactics_Effect.tac_repr)
@@ -512,12 +1094,12 @@ let (binder_to_string :
       (FStar_Sealed.seal
          (Obj.magic
             (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-               (Prims.of_int (89)) (Prims.of_int (12)) (Prims.of_int (89))
+               (Prims.of_int (122)) (Prims.of_int (12)) (Prims.of_int (122))
                (Prims.of_int (40)))))
       (FStar_Sealed.seal
          (Obj.magic
             (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-               (Prims.of_int (87)) (Prims.of_int (4)) (Prims.of_int (89))
+               (Prims.of_int (120)) (Prims.of_int (4)) (Prims.of_int (122))
                (Prims.of_int (40)))))
       (Obj.magic (term_to_string b.Pulse_Syntax_Base.binder_ty))
       (fun uu___ ->
@@ -527,20 +1109,20 @@ let (binder_to_string :
                  (FStar_Sealed.seal
                     (Obj.magic
                        (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                          (Prims.of_int (87)) (Prims.of_int (4))
-                          (Prims.of_int (89)) (Prims.of_int (40)))))
+                          (Prims.of_int (120)) (Prims.of_int (4))
+                          (Prims.of_int (122)) (Prims.of_int (40)))))
                  (FStar_Sealed.seal
                     (Obj.magic
                        (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                          (Prims.of_int (87)) (Prims.of_int (4))
-                          (Prims.of_int (89)) (Prims.of_int (40)))))
+                          (Prims.of_int (120)) (Prims.of_int (4))
+                          (Prims.of_int (122)) (Prims.of_int (40)))))
                  (Obj.magic
                     (FStar_Tactics_Effect.tac_bind
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (88)) (Prims.of_int (12))
-                                (Prims.of_int (88)) (Prims.of_int (43)))))
+                                (Prims.of_int (121)) (Prims.of_int (12))
+                                (Prims.of_int (121)) (Prims.of_int (43)))))
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "FStar.Printf.fst"
@@ -576,8 +1158,8 @@ let (comp_to_string :
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                   (Prims.of_int (100)) (Prims.of_int (23))
-                   (Prims.of_int (100)) (Prims.of_int (41)))))
+                   (Prims.of_int (133)) (Prims.of_int (23))
+                   (Prims.of_int (133)) (Prims.of_int (41)))))
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "prims.fst" (Prims.of_int (590))
@@ -591,13 +1173,13 @@ let (comp_to_string :
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                   (Prims.of_int (106)) (Prims.of_int (14))
-                   (Prims.of_int (106)) (Prims.of_int (37)))))
+                   (Prims.of_int (139)) (Prims.of_int (14))
+                   (Prims.of_int (139)) (Prims.of_int (37)))))
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                   (Prims.of_int (103)) (Prims.of_int (6))
-                   (Prims.of_int (106)) (Prims.of_int (37)))))
+                   (Prims.of_int (136)) (Prims.of_int (6))
+                   (Prims.of_int (139)) (Prims.of_int (37)))))
           (Obj.magic (term_to_string s.Pulse_Syntax_Base.post))
           (fun uu___ ->
              (fun uu___ ->
@@ -606,27 +1188,27 @@ let (comp_to_string :
                      (FStar_Sealed.seal
                         (Obj.magic
                            (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                              (Prims.of_int (103)) (Prims.of_int (6))
-                              (Prims.of_int (106)) (Prims.of_int (37)))))
+                              (Prims.of_int (136)) (Prims.of_int (6))
+                              (Prims.of_int (139)) (Prims.of_int (37)))))
                      (FStar_Sealed.seal
                         (Obj.magic
                            (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                              (Prims.of_int (103)) (Prims.of_int (6))
-                              (Prims.of_int (106)) (Prims.of_int (37)))))
+                              (Prims.of_int (136)) (Prims.of_int (6))
+                              (Prims.of_int (139)) (Prims.of_int (37)))))
                      (Obj.magic
                         (FStar_Tactics_Effect.tac_bind
                            (FStar_Sealed.seal
                               (Obj.magic
                                  (FStar_Range.mk_range
                                     "Pulse.Syntax.Printer.fst"
-                                    (Prims.of_int (105)) (Prims.of_int (14))
-                                    (Prims.of_int (105)) (Prims.of_int (36)))))
+                                    (Prims.of_int (138)) (Prims.of_int (14))
+                                    (Prims.of_int (138)) (Prims.of_int (36)))))
                            (FStar_Sealed.seal
                               (Obj.magic
                                  (FStar_Range.mk_range
                                     "Pulse.Syntax.Printer.fst"
-                                    (Prims.of_int (103)) (Prims.of_int (6))
-                                    (Prims.of_int (106)) (Prims.of_int (37)))))
+                                    (Prims.of_int (136)) (Prims.of_int (6))
+                                    (Prims.of_int (139)) (Prims.of_int (37)))))
                            (Obj.magic
                               (term_to_string s.Pulse_Syntax_Base.pre))
                            (fun uu___1 ->
@@ -637,17 +1219,17 @@ let (comp_to_string :
                                          (Obj.magic
                                             (FStar_Range.mk_range
                                                "Pulse.Syntax.Printer.fst"
-                                               (Prims.of_int (103))
+                                               (Prims.of_int (136))
                                                (Prims.of_int (6))
-                                               (Prims.of_int (106))
+                                               (Prims.of_int (139))
                                                (Prims.of_int (37)))))
                                       (FStar_Sealed.seal
                                          (Obj.magic
                                             (FStar_Range.mk_range
                                                "Pulse.Syntax.Printer.fst"
-                                               (Prims.of_int (103))
+                                               (Prims.of_int (136))
                                                (Prims.of_int (6))
-                                               (Prims.of_int (106))
+                                               (Prims.of_int (139))
                                                (Prims.of_int (37)))))
                                       (Obj.magic
                                          (FStar_Tactics_Effect.tac_bind
@@ -655,9 +1237,9 @@ let (comp_to_string :
                                                (Obj.magic
                                                   (FStar_Range.mk_range
                                                      "Pulse.Syntax.Printer.fst"
-                                                     (Prims.of_int (104))
+                                                     (Prims.of_int (137))
                                                      (Prims.of_int (14))
-                                                     (Prims.of_int (104))
+                                                     (Prims.of_int (137))
                                                      (Prims.of_int (36)))))
                                             (FStar_Sealed.seal
                                                (Obj.magic
@@ -698,13 +1280,13 @@ let (comp_to_string :
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                   (Prims.of_int (113)) (Prims.of_int (14))
-                   (Prims.of_int (113)) (Prims.of_int (37)))))
+                   (Prims.of_int (146)) (Prims.of_int (14))
+                   (Prims.of_int (146)) (Prims.of_int (37)))))
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                   (Prims.of_int (109)) (Prims.of_int (6))
-                   (Prims.of_int (113)) (Prims.of_int (37)))))
+                   (Prims.of_int (142)) (Prims.of_int (6))
+                   (Prims.of_int (146)) (Prims.of_int (37)))))
           (Obj.magic (term_to_string s.Pulse_Syntax_Base.post))
           (fun uu___ ->
              (fun uu___ ->
@@ -713,27 +1295,27 @@ let (comp_to_string :
                      (FStar_Sealed.seal
                         (Obj.magic
                            (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                              (Prims.of_int (109)) (Prims.of_int (6))
-                              (Prims.of_int (113)) (Prims.of_int (37)))))
+                              (Prims.of_int (142)) (Prims.of_int (6))
+                              (Prims.of_int (146)) (Prims.of_int (37)))))
                      (FStar_Sealed.seal
                         (Obj.magic
                            (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                              (Prims.of_int (109)) (Prims.of_int (6))
-                              (Prims.of_int (113)) (Prims.of_int (37)))))
+                              (Prims.of_int (142)) (Prims.of_int (6))
+                              (Prims.of_int (146)) (Prims.of_int (37)))))
                      (Obj.magic
                         (FStar_Tactics_Effect.tac_bind
                            (FStar_Sealed.seal
                               (Obj.magic
                                  (FStar_Range.mk_range
                                     "Pulse.Syntax.Printer.fst"
-                                    (Prims.of_int (112)) (Prims.of_int (14))
-                                    (Prims.of_int (112)) (Prims.of_int (36)))))
+                                    (Prims.of_int (145)) (Prims.of_int (14))
+                                    (Prims.of_int (145)) (Prims.of_int (36)))))
                            (FStar_Sealed.seal
                               (Obj.magic
                                  (FStar_Range.mk_range
                                     "Pulse.Syntax.Printer.fst"
-                                    (Prims.of_int (109)) (Prims.of_int (6))
-                                    (Prims.of_int (113)) (Prims.of_int (37)))))
+                                    (Prims.of_int (142)) (Prims.of_int (6))
+                                    (Prims.of_int (146)) (Prims.of_int (37)))))
                            (Obj.magic
                               (term_to_string s.Pulse_Syntax_Base.pre))
                            (fun uu___1 ->
@@ -744,17 +1326,17 @@ let (comp_to_string :
                                          (Obj.magic
                                             (FStar_Range.mk_range
                                                "Pulse.Syntax.Printer.fst"
-                                               (Prims.of_int (109))
+                                               (Prims.of_int (142))
                                                (Prims.of_int (6))
-                                               (Prims.of_int (113))
+                                               (Prims.of_int (146))
                                                (Prims.of_int (37)))))
                                       (FStar_Sealed.seal
                                          (Obj.magic
                                             (FStar_Range.mk_range
                                                "Pulse.Syntax.Printer.fst"
-                                               (Prims.of_int (109))
+                                               (Prims.of_int (142))
                                                (Prims.of_int (6))
-                                               (Prims.of_int (113))
+                                               (Prims.of_int (146))
                                                (Prims.of_int (37)))))
                                       (Obj.magic
                                          (FStar_Tactics_Effect.tac_bind
@@ -762,17 +1344,17 @@ let (comp_to_string :
                                                (Obj.magic
                                                   (FStar_Range.mk_range
                                                      "Pulse.Syntax.Printer.fst"
-                                                     (Prims.of_int (111))
+                                                     (Prims.of_int (144))
                                                      (Prims.of_int (14))
-                                                     (Prims.of_int (111))
+                                                     (Prims.of_int (144))
                                                      (Prims.of_int (36)))))
                                             (FStar_Sealed.seal
                                                (Obj.magic
                                                   (FStar_Range.mk_range
                                                      "Pulse.Syntax.Printer.fst"
-                                                     (Prims.of_int (109))
+                                                     (Prims.of_int (142))
                                                      (Prims.of_int (6))
-                                                     (Prims.of_int (113))
+                                                     (Prims.of_int (146))
                                                      (Prims.of_int (37)))))
                                             (Obj.magic
                                                (term_to_string
@@ -785,17 +1367,17 @@ let (comp_to_string :
                                                           (Obj.magic
                                                              (FStar_Range.mk_range
                                                                 "Pulse.Syntax.Printer.fst"
-                                                                (Prims.of_int (109))
+                                                                (Prims.of_int (142))
                                                                 (Prims.of_int (6))
-                                                                (Prims.of_int (113))
+                                                                (Prims.of_int (146))
                                                                 (Prims.of_int (37)))))
                                                        (FStar_Sealed.seal
                                                           (Obj.magic
                                                              (FStar_Range.mk_range
                                                                 "Pulse.Syntax.Printer.fst"
-                                                                (Prims.of_int (109))
+                                                                (Prims.of_int (142))
                                                                 (Prims.of_int (6))
-                                                                (Prims.of_int (113))
+                                                                (Prims.of_int (146))
                                                                 (Prims.of_int (37)))))
                                                        (Obj.magic
                                                           (FStar_Tactics_Effect.tac_bind
@@ -803,9 +1385,9 @@ let (comp_to_string :
                                                                 (Obj.magic
                                                                    (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (110))
+                                                                    (Prims.of_int (143))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (110))
+                                                                    (Prims.of_int (143))
                                                                     (Prims.of_int (37)))))
                                                              (FStar_Sealed.seal
                                                                 (Obj.magic
@@ -858,13 +1440,13 @@ let (comp_to_string :
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                   (Prims.of_int (120)) (Prims.of_int (14))
-                   (Prims.of_int (120)) (Prims.of_int (37)))))
+                   (Prims.of_int (153)) (Prims.of_int (14))
+                   (Prims.of_int (153)) (Prims.of_int (37)))))
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                   (Prims.of_int (116)) (Prims.of_int (6))
-                   (Prims.of_int (120)) (Prims.of_int (37)))))
+                   (Prims.of_int (149)) (Prims.of_int (6))
+                   (Prims.of_int (153)) (Prims.of_int (37)))))
           (Obj.magic (term_to_string s.Pulse_Syntax_Base.post))
           (fun uu___ ->
              (fun uu___ ->
@@ -873,27 +1455,27 @@ let (comp_to_string :
                      (FStar_Sealed.seal
                         (Obj.magic
                            (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                              (Prims.of_int (116)) (Prims.of_int (6))
-                              (Prims.of_int (120)) (Prims.of_int (37)))))
+                              (Prims.of_int (149)) (Prims.of_int (6))
+                              (Prims.of_int (153)) (Prims.of_int (37)))))
                      (FStar_Sealed.seal
                         (Obj.magic
                            (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                              (Prims.of_int (116)) (Prims.of_int (6))
-                              (Prims.of_int (120)) (Prims.of_int (37)))))
+                              (Prims.of_int (149)) (Prims.of_int (6))
+                              (Prims.of_int (153)) (Prims.of_int (37)))))
                      (Obj.magic
                         (FStar_Tactics_Effect.tac_bind
                            (FStar_Sealed.seal
                               (Obj.magic
                                  (FStar_Range.mk_range
                                     "Pulse.Syntax.Printer.fst"
-                                    (Prims.of_int (119)) (Prims.of_int (14))
-                                    (Prims.of_int (119)) (Prims.of_int (36)))))
+                                    (Prims.of_int (152)) (Prims.of_int (14))
+                                    (Prims.of_int (152)) (Prims.of_int (36)))))
                            (FStar_Sealed.seal
                               (Obj.magic
                                  (FStar_Range.mk_range
                                     "Pulse.Syntax.Printer.fst"
-                                    (Prims.of_int (116)) (Prims.of_int (6))
-                                    (Prims.of_int (120)) (Prims.of_int (37)))))
+                                    (Prims.of_int (149)) (Prims.of_int (6))
+                                    (Prims.of_int (153)) (Prims.of_int (37)))))
                            (Obj.magic
                               (term_to_string s.Pulse_Syntax_Base.pre))
                            (fun uu___1 ->
@@ -904,17 +1486,17 @@ let (comp_to_string :
                                          (Obj.magic
                                             (FStar_Range.mk_range
                                                "Pulse.Syntax.Printer.fst"
-                                               (Prims.of_int (116))
+                                               (Prims.of_int (149))
                                                (Prims.of_int (6))
-                                               (Prims.of_int (120))
+                                               (Prims.of_int (153))
                                                (Prims.of_int (37)))))
                                       (FStar_Sealed.seal
                                          (Obj.magic
                                             (FStar_Range.mk_range
                                                "Pulse.Syntax.Printer.fst"
-                                               (Prims.of_int (116))
+                                               (Prims.of_int (149))
                                                (Prims.of_int (6))
-                                               (Prims.of_int (120))
+                                               (Prims.of_int (153))
                                                (Prims.of_int (37)))))
                                       (Obj.magic
                                          (FStar_Tactics_Effect.tac_bind
@@ -922,17 +1504,17 @@ let (comp_to_string :
                                                (Obj.magic
                                                   (FStar_Range.mk_range
                                                      "Pulse.Syntax.Printer.fst"
-                                                     (Prims.of_int (118))
+                                                     (Prims.of_int (151))
                                                      (Prims.of_int (14))
-                                                     (Prims.of_int (118))
+                                                     (Prims.of_int (151))
                                                      (Prims.of_int (36)))))
                                             (FStar_Sealed.seal
                                                (Obj.magic
                                                   (FStar_Range.mk_range
                                                      "Pulse.Syntax.Printer.fst"
-                                                     (Prims.of_int (116))
+                                                     (Prims.of_int (149))
                                                      (Prims.of_int (6))
-                                                     (Prims.of_int (120))
+                                                     (Prims.of_int (153))
                                                      (Prims.of_int (37)))))
                                             (Obj.magic
                                                (term_to_string
@@ -945,17 +1527,17 @@ let (comp_to_string :
                                                           (Obj.magic
                                                              (FStar_Range.mk_range
                                                                 "Pulse.Syntax.Printer.fst"
-                                                                (Prims.of_int (116))
+                                                                (Prims.of_int (149))
                                                                 (Prims.of_int (6))
-                                                                (Prims.of_int (120))
+                                                                (Prims.of_int (153))
                                                                 (Prims.of_int (37)))))
                                                        (FStar_Sealed.seal
                                                           (Obj.magic
                                                              (FStar_Range.mk_range
                                                                 "Pulse.Syntax.Printer.fst"
-                                                                (Prims.of_int (116))
+                                                                (Prims.of_int (149))
                                                                 (Prims.of_int (6))
-                                                                (Prims.of_int (120))
+                                                                (Prims.of_int (153))
                                                                 (Prims.of_int (37)))))
                                                        (Obj.magic
                                                           (FStar_Tactics_Effect.tac_bind
@@ -963,9 +1545,9 @@ let (comp_to_string :
                                                                 (Obj.magic
                                                                    (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (117))
+                                                                    (Prims.of_int (150))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (117))
+                                                                    (Prims.of_int (150))
                                                                     (Prims.of_int (37)))))
                                                              (FStar_Sealed.seal
                                                                 (Obj.magic
@@ -1036,12 +1618,12 @@ let (term_list_to_string :
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                 (Prims.of_int (130)) (Prims.of_int (22))
-                 (Prims.of_int (130)) (Prims.of_int (46)))))
+                 (Prims.of_int (163)) (Prims.of_int (22))
+                 (Prims.of_int (163)) (Prims.of_int (46)))))
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                 (Prims.of_int (130)) (Prims.of_int (4)) (Prims.of_int (130))
+                 (Prims.of_int (163)) (Prims.of_int (4)) (Prims.of_int (163))
                  (Prims.of_int (46)))))
         (Obj.magic (FStar_Tactics_Util.map term_to_string t))
         (fun uu___ ->
@@ -1064,8 +1646,8 @@ let rec (st_term_to_string' :
             (FStar_Sealed.seal
                (Obj.magic
                   (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                     (Prims.of_int (142)) (Prims.of_int (8))
-                     (Prims.of_int (142)) (Prims.of_int (29)))))
+                     (Prims.of_int (175)) (Prims.of_int (8))
+                     (Prims.of_int (175)) (Prims.of_int (29)))))
             (FStar_Sealed.seal
                (Obj.magic
                   (FStar_Range.mk_range "prims.fst" (Prims.of_int (590))
@@ -1095,13 +1677,13 @@ let rec (st_term_to_string' :
             (FStar_Sealed.seal
                (Obj.magic
                   (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                     (Prims.of_int (149)) (Prims.of_int (8))
-                     (Prims.of_int (149)) (Prims.of_int (28)))))
+                     (Prims.of_int (182)) (Prims.of_int (8))
+                     (Prims.of_int (182)) (Prims.of_int (28)))))
             (FStar_Sealed.seal
                (Obj.magic
                   (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                     (Prims.of_int (145)) (Prims.of_int (6))
-                     (Prims.of_int (149)) (Prims.of_int (28)))))
+                     (Prims.of_int (178)) (Prims.of_int (6))
+                     (Prims.of_int (182)) (Prims.of_int (28)))))
             (Obj.magic (term_to_string arg))
             (fun uu___ ->
                (fun uu___ ->
@@ -1110,28 +1692,28 @@ let rec (st_term_to_string' :
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (145)) (Prims.of_int (6))
-                                (Prims.of_int (149)) (Prims.of_int (28)))))
+                                (Prims.of_int (178)) (Prims.of_int (6))
+                                (Prims.of_int (182)) (Prims.of_int (28)))))
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (145)) (Prims.of_int (6))
-                                (Prims.of_int (149)) (Prims.of_int (28)))))
+                                (Prims.of_int (178)) (Prims.of_int (6))
+                                (Prims.of_int (182)) (Prims.of_int (28)))))
                        (Obj.magic
                           (FStar_Tactics_Effect.tac_bind
                              (FStar_Sealed.seal
                                 (Obj.magic
                                    (FStar_Range.mk_range
                                       "Pulse.Syntax.Printer.fst"
-                                      (Prims.of_int (145)) (Prims.of_int (6))
-                                      (Prims.of_int (149))
+                                      (Prims.of_int (178)) (Prims.of_int (6))
+                                      (Prims.of_int (182))
                                       (Prims.of_int (28)))))
                              (FStar_Sealed.seal
                                 (Obj.magic
                                    (FStar_Range.mk_range
                                       "Pulse.Syntax.Printer.fst"
-                                      (Prims.of_int (145)) (Prims.of_int (6))
-                                      (Prims.of_int (149))
+                                      (Prims.of_int (178)) (Prims.of_int (6))
+                                      (Prims.of_int (182))
                                       (Prims.of_int (28)))))
                              (Obj.magic
                                 (FStar_Tactics_Effect.tac_bind
@@ -1139,9 +1721,9 @@ let rec (st_term_to_string' :
                                       (Obj.magic
                                          (FStar_Range.mk_range
                                             "Pulse.Syntax.Printer.fst"
-                                            (Prims.of_int (147))
+                                            (Prims.of_int (180))
                                             (Prims.of_int (8))
-                                            (Prims.of_int (147))
+                                            (Prims.of_int (180))
                                             (Prims.of_int (29)))))
                                    (FStar_Sealed.seal
                                       (Obj.magic
@@ -1184,13 +1766,13 @@ let rec (st_term_to_string' :
             (FStar_Sealed.seal
                (Obj.magic
                   (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                     (Prims.of_int (162)) (Prims.of_int (10))
-                     (Prims.of_int (162)) (Prims.of_int (41)))))
+                     (Prims.of_int (195)) (Prims.of_int (10))
+                     (Prims.of_int (195)) (Prims.of_int (41)))))
             (FStar_Sealed.seal
                (Obj.magic
                   (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                     (Prims.of_int (158)) (Prims.of_int (8))
-                     (Prims.of_int (162)) (Prims.of_int (41)))))
+                     (Prims.of_int (191)) (Prims.of_int (8))
+                     (Prims.of_int (195)) (Prims.of_int (41)))))
             (Obj.magic (st_term_to_string' level body))
             (fun uu___ ->
                (fun uu___ ->
@@ -1199,28 +1781,28 @@ let rec (st_term_to_string' :
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (158)) (Prims.of_int (8))
-                                (Prims.of_int (162)) (Prims.of_int (41)))))
+                                (Prims.of_int (191)) (Prims.of_int (8))
+                                (Prims.of_int (195)) (Prims.of_int (41)))))
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (158)) (Prims.of_int (8))
-                                (Prims.of_int (162)) (Prims.of_int (41)))))
+                                (Prims.of_int (191)) (Prims.of_int (8))
+                                (Prims.of_int (195)) (Prims.of_int (41)))))
                        (Obj.magic
                           (FStar_Tactics_Effect.tac_bind
                              (FStar_Sealed.seal
                                 (Obj.magic
                                    (FStar_Range.mk_range
                                       "Pulse.Syntax.Printer.fst"
-                                      (Prims.of_int (158)) (Prims.of_int (8))
-                                      (Prims.of_int (162))
+                                      (Prims.of_int (191)) (Prims.of_int (8))
+                                      (Prims.of_int (195))
                                       (Prims.of_int (41)))))
                              (FStar_Sealed.seal
                                 (Obj.magic
                                    (FStar_Range.mk_range
                                       "Pulse.Syntax.Printer.fst"
-                                      (Prims.of_int (158)) (Prims.of_int (8))
-                                      (Prims.of_int (162))
+                                      (Prims.of_int (191)) (Prims.of_int (8))
+                                      (Prims.of_int (195))
                                       (Prims.of_int (41)))))
                              (Obj.magic
                                 (FStar_Tactics_Effect.tac_bind
@@ -1228,17 +1810,17 @@ let rec (st_term_to_string' :
                                       (Obj.magic
                                          (FStar_Range.mk_range
                                             "Pulse.Syntax.Printer.fst"
-                                            (Prims.of_int (160))
+                                            (Prims.of_int (193))
                                             (Prims.of_int (10))
-                                            (Prims.of_int (160))
+                                            (Prims.of_int (193))
                                             (Prims.of_int (41)))))
                                    (FStar_Sealed.seal
                                       (Obj.magic
                                          (FStar_Range.mk_range
                                             "Pulse.Syntax.Printer.fst"
-                                            (Prims.of_int (158))
+                                            (Prims.of_int (191))
                                             (Prims.of_int (8))
-                                            (Prims.of_int (162))
+                                            (Prims.of_int (195))
                                             (Prims.of_int (41)))))
                                    (Obj.magic (st_term_to_string' level head))
                                    (fun uu___1 ->
@@ -1249,17 +1831,17 @@ let rec (st_term_to_string' :
                                                  (Obj.magic
                                                     (FStar_Range.mk_range
                                                        "Pulse.Syntax.Printer.fst"
-                                                       (Prims.of_int (158))
+                                                       (Prims.of_int (191))
                                                        (Prims.of_int (8))
-                                                       (Prims.of_int (162))
+                                                       (Prims.of_int (195))
                                                        (Prims.of_int (41)))))
                                               (FStar_Sealed.seal
                                                  (Obj.magic
                                                     (FStar_Range.mk_range
                                                        "Pulse.Syntax.Printer.fst"
-                                                       (Prims.of_int (158))
+                                                       (Prims.of_int (191))
                                                        (Prims.of_int (8))
-                                                       (Prims.of_int (162))
+                                                       (Prims.of_int (195))
                                                        (Prims.of_int (41)))))
                                               (Obj.magic
                                                  (FStar_Tactics_Effect.tac_bind
@@ -1267,9 +1849,9 @@ let rec (st_term_to_string' :
                                                        (Obj.magic
                                                           (FStar_Range.mk_range
                                                              "Pulse.Syntax.Printer.fst"
-                                                             (Prims.of_int (159))
+                                                             (Prims.of_int (192))
                                                              (Prims.of_int (10))
-                                                             (Prims.of_int (159))
+                                                             (Prims.of_int (192))
                                                              (Prims.of_int (35)))))
                                                     (FStar_Sealed.seal
                                                        (Obj.magic
@@ -1323,13 +1905,13 @@ let rec (st_term_to_string' :
             (FStar_Sealed.seal
                (Obj.magic
                   (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                     (Prims.of_int (170)) (Prims.of_int (8))
-                     (Prims.of_int (170)) (Prims.of_int (39)))))
+                     (Prims.of_int (203)) (Prims.of_int (8))
+                     (Prims.of_int (203)) (Prims.of_int (39)))))
             (FStar_Sealed.seal
                (Obj.magic
                   (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                     (Prims.of_int (166)) (Prims.of_int (6))
-                     (Prims.of_int (170)) (Prims.of_int (39)))))
+                     (Prims.of_int (199)) (Prims.of_int (6))
+                     (Prims.of_int (203)) (Prims.of_int (39)))))
             (Obj.magic (st_term_to_string' level body))
             (fun uu___ ->
                (fun uu___ ->
@@ -1338,28 +1920,28 @@ let rec (st_term_to_string' :
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (166)) (Prims.of_int (6))
-                                (Prims.of_int (170)) (Prims.of_int (39)))))
+                                (Prims.of_int (199)) (Prims.of_int (6))
+                                (Prims.of_int (203)) (Prims.of_int (39)))))
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (166)) (Prims.of_int (6))
-                                (Prims.of_int (170)) (Prims.of_int (39)))))
+                                (Prims.of_int (199)) (Prims.of_int (6))
+                                (Prims.of_int (203)) (Prims.of_int (39)))))
                        (Obj.magic
                           (FStar_Tactics_Effect.tac_bind
                              (FStar_Sealed.seal
                                 (Obj.magic
                                    (FStar_Range.mk_range
                                       "Pulse.Syntax.Printer.fst"
-                                      (Prims.of_int (166)) (Prims.of_int (6))
-                                      (Prims.of_int (170))
+                                      (Prims.of_int (199)) (Prims.of_int (6))
+                                      (Prims.of_int (203))
                                       (Prims.of_int (39)))))
                              (FStar_Sealed.seal
                                 (Obj.magic
                                    (FStar_Range.mk_range
                                       "Pulse.Syntax.Printer.fst"
-                                      (Prims.of_int (166)) (Prims.of_int (6))
-                                      (Prims.of_int (170))
+                                      (Prims.of_int (199)) (Prims.of_int (6))
+                                      (Prims.of_int (203))
                                       (Prims.of_int (39)))))
                              (Obj.magic
                                 (FStar_Tactics_Effect.tac_bind
@@ -1367,17 +1949,17 @@ let rec (st_term_to_string' :
                                       (Obj.magic
                                          (FStar_Range.mk_range
                                             "Pulse.Syntax.Printer.fst"
-                                            (Prims.of_int (168))
+                                            (Prims.of_int (201))
                                             (Prims.of_int (8))
-                                            (Prims.of_int (168))
+                                            (Prims.of_int (201))
                                             (Prims.of_int (29)))))
                                    (FStar_Sealed.seal
                                       (Obj.magic
                                          (FStar_Range.mk_range
                                             "Pulse.Syntax.Printer.fst"
-                                            (Prims.of_int (166))
+                                            (Prims.of_int (199))
                                             (Prims.of_int (6))
-                                            (Prims.of_int (170))
+                                            (Prims.of_int (203))
                                             (Prims.of_int (39)))))
                                    (Obj.magic (term_to_string head))
                                    (fun uu___1 ->
@@ -1388,17 +1970,17 @@ let rec (st_term_to_string' :
                                                  (Obj.magic
                                                     (FStar_Range.mk_range
                                                        "Pulse.Syntax.Printer.fst"
-                                                       (Prims.of_int (166))
+                                                       (Prims.of_int (199))
                                                        (Prims.of_int (6))
-                                                       (Prims.of_int (170))
+                                                       (Prims.of_int (203))
                                                        (Prims.of_int (39)))))
                                               (FStar_Sealed.seal
                                                  (Obj.magic
                                                     (FStar_Range.mk_range
                                                        "Pulse.Syntax.Printer.fst"
-                                                       (Prims.of_int (166))
+                                                       (Prims.of_int (199))
                                                        (Prims.of_int (6))
-                                                       (Prims.of_int (170))
+                                                       (Prims.of_int (203))
                                                        (Prims.of_int (39)))))
                                               (Obj.magic
                                                  (FStar_Tactics_Effect.tac_bind
@@ -1406,9 +1988,9 @@ let rec (st_term_to_string' :
                                                        (Obj.magic
                                                           (FStar_Range.mk_range
                                                              "Pulse.Syntax.Printer.fst"
-                                                             (Prims.of_int (167))
+                                                             (Prims.of_int (200))
                                                              (Prims.of_int (8))
-                                                             (Prims.of_int (167))
+                                                             (Prims.of_int (200))
                                                              (Prims.of_int (33)))))
                                                     (FStar_Sealed.seal
                                                        (Obj.magic
@@ -1463,13 +2045,13 @@ let rec (st_term_to_string' :
             (FStar_Sealed.seal
                (Obj.magic
                   (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                     (Prims.of_int (178)) (Prims.of_int (14))
-                     (Prims.of_int (178)) (Prims.of_int (54)))))
+                     (Prims.of_int (211)) (Prims.of_int (14))
+                     (Prims.of_int (211)) (Prims.of_int (54)))))
             (FStar_Sealed.seal
                (Obj.magic
                   (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                     (Prims.of_int (173)) (Prims.of_int (6))
-                     (Prims.of_int (178)) (Prims.of_int (54)))))
+                     (Prims.of_int (206)) (Prims.of_int (6))
+                     (Prims.of_int (211)) (Prims.of_int (54)))))
             (Obj.magic (st_term_to_string' (indent level) body))
             (fun uu___ ->
                (fun uu___ ->
@@ -1478,28 +2060,28 @@ let rec (st_term_to_string' :
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (173)) (Prims.of_int (6))
-                                (Prims.of_int (178)) (Prims.of_int (54)))))
+                                (Prims.of_int (206)) (Prims.of_int (6))
+                                (Prims.of_int (211)) (Prims.of_int (54)))))
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (173)) (Prims.of_int (6))
-                                (Prims.of_int (178)) (Prims.of_int (54)))))
+                                (Prims.of_int (206)) (Prims.of_int (6))
+                                (Prims.of_int (211)) (Prims.of_int (54)))))
                        (Obj.magic
                           (FStar_Tactics_Effect.tac_bind
                              (FStar_Sealed.seal
                                 (Obj.magic
                                    (FStar_Range.mk_range
                                       "Pulse.Syntax.Printer.fst"
-                                      (Prims.of_int (173)) (Prims.of_int (6))
-                                      (Prims.of_int (178))
+                                      (Prims.of_int (206)) (Prims.of_int (6))
+                                      (Prims.of_int (211))
                                       (Prims.of_int (54)))))
                              (FStar_Sealed.seal
                                 (Obj.magic
                                    (FStar_Range.mk_range
                                       "Pulse.Syntax.Printer.fst"
-                                      (Prims.of_int (173)) (Prims.of_int (6))
-                                      (Prims.of_int (178))
+                                      (Prims.of_int (206)) (Prims.of_int (6))
+                                      (Prims.of_int (211))
                                       (Prims.of_int (54)))))
                              (Obj.magic
                                 (FStar_Tactics_Effect.tac_bind
@@ -1507,17 +2089,17 @@ let rec (st_term_to_string' :
                                       (Obj.magic
                                          (FStar_Range.mk_range
                                             "Pulse.Syntax.Printer.fst"
-                                            (Prims.of_int (176))
+                                            (Prims.of_int (209))
                                             (Prims.of_int (14))
-                                            (Prims.of_int (176))
+                                            (Prims.of_int (209))
                                             (Prims.of_int (32)))))
                                    (FStar_Sealed.seal
                                       (Obj.magic
                                          (FStar_Range.mk_range
                                             "Pulse.Syntax.Printer.fst"
-                                            (Prims.of_int (173))
+                                            (Prims.of_int (206))
                                             (Prims.of_int (6))
-                                            (Prims.of_int (178))
+                                            (Prims.of_int (211))
                                             (Prims.of_int (54)))))
                                    (Obj.magic (comp_to_string c))
                                    (fun uu___1 ->
@@ -1528,17 +2110,17 @@ let rec (st_term_to_string' :
                                                  (Obj.magic
                                                     (FStar_Range.mk_range
                                                        "Pulse.Syntax.Printer.fst"
-                                                       (Prims.of_int (173))
+                                                       (Prims.of_int (206))
                                                        (Prims.of_int (6))
-                                                       (Prims.of_int (178))
+                                                       (Prims.of_int (211))
                                                        (Prims.of_int (54)))))
                                               (FStar_Sealed.seal
                                                  (Obj.magic
                                                     (FStar_Range.mk_range
                                                        "Pulse.Syntax.Printer.fst"
-                                                       (Prims.of_int (173))
+                                                       (Prims.of_int (206))
                                                        (Prims.of_int (6))
-                                                       (Prims.of_int (178))
+                                                       (Prims.of_int (211))
                                                        (Prims.of_int (54)))))
                                               (Obj.magic
                                                  (FStar_Tactics_Effect.tac_bind
@@ -1546,9 +2128,9 @@ let rec (st_term_to_string' :
                                                        (Obj.magic
                                                           (FStar_Range.mk_range
                                                              "Pulse.Syntax.Printer.fst"
-                                                             (Prims.of_int (175))
+                                                             (Prims.of_int (208))
                                                              (Prims.of_int (14))
-                                                             (Prims.of_int (175))
+                                                             (Prims.of_int (208))
                                                              (Prims.of_int (34)))))
                                                     (FStar_Sealed.seal
                                                        (Obj.magic
@@ -1607,25 +2189,25 @@ let rec (st_term_to_string' :
             (FStar_Sealed.seal
                (Obj.magic
                   (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                     (Prims.of_int (181)) (Prims.of_int (6))
-                     (Prims.of_int (191)) (Prims.of_int (13)))))
+                     (Prims.of_int (214)) (Prims.of_int (6))
+                     (Prims.of_int (224)) (Prims.of_int (13)))))
             (FStar_Sealed.seal
                (Obj.magic
                   (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                     (Prims.of_int (181)) (Prims.of_int (6))
-                     (Prims.of_int (191)) (Prims.of_int (13)))))
+                     (Prims.of_int (214)) (Prims.of_int (6))
+                     (Prims.of_int (224)) (Prims.of_int (13)))))
             (Obj.magic
                (FStar_Tactics_Effect.tac_bind
                   (FStar_Sealed.seal
                      (Obj.magic
                         (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                           (Prims.of_int (190)) (Prims.of_int (8))
-                           (Prims.of_int (190)) (Prims.of_int (49)))))
+                           (Prims.of_int (223)) (Prims.of_int (8))
+                           (Prims.of_int (223)) (Prims.of_int (49)))))
                   (FStar_Sealed.seal
                      (Obj.magic
                         (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                           (Prims.of_int (181)) (Prims.of_int (6))
-                           (Prims.of_int (191)) (Prims.of_int (13)))))
+                           (Prims.of_int (214)) (Prims.of_int (6))
+                           (Prims.of_int (224)) (Prims.of_int (13)))))
                   (Obj.magic (st_term_to_string' (indent level) else_))
                   (fun uu___1 ->
                      (fun uu___1 ->
@@ -1635,15 +2217,15 @@ let rec (st_term_to_string' :
                                 (Obj.magic
                                    (FStar_Range.mk_range
                                       "Pulse.Syntax.Printer.fst"
-                                      (Prims.of_int (181)) (Prims.of_int (6))
-                                      (Prims.of_int (191))
+                                      (Prims.of_int (214)) (Prims.of_int (6))
+                                      (Prims.of_int (224))
                                       (Prims.of_int (13)))))
                              (FStar_Sealed.seal
                                 (Obj.magic
                                    (FStar_Range.mk_range
                                       "Pulse.Syntax.Printer.fst"
-                                      (Prims.of_int (181)) (Prims.of_int (6))
-                                      (Prims.of_int (191))
+                                      (Prims.of_int (214)) (Prims.of_int (6))
+                                      (Prims.of_int (224))
                                       (Prims.of_int (13)))))
                              (Obj.magic
                                 (FStar_Tactics_Effect.tac_bind
@@ -1651,17 +2233,17 @@ let rec (st_term_to_string' :
                                       (Obj.magic
                                          (FStar_Range.mk_range
                                             "Pulse.Syntax.Printer.fst"
-                                            (Prims.of_int (181))
+                                            (Prims.of_int (214))
                                             (Prims.of_int (6))
-                                            (Prims.of_int (191))
+                                            (Prims.of_int (224))
                                             (Prims.of_int (13)))))
                                    (FStar_Sealed.seal
                                       (Obj.magic
                                          (FStar_Range.mk_range
                                             "Pulse.Syntax.Printer.fst"
-                                            (Prims.of_int (181))
+                                            (Prims.of_int (214))
                                             (Prims.of_int (6))
-                                            (Prims.of_int (191))
+                                            (Prims.of_int (224))
                                             (Prims.of_int (13)))))
                                    (Obj.magic
                                       (FStar_Tactics_Effect.tac_bind
@@ -1669,17 +2251,17 @@ let rec (st_term_to_string' :
                                             (Obj.magic
                                                (FStar_Range.mk_range
                                                   "Pulse.Syntax.Printer.fst"
-                                                  (Prims.of_int (181))
+                                                  (Prims.of_int (214))
                                                   (Prims.of_int (6))
-                                                  (Prims.of_int (191))
+                                                  (Prims.of_int (224))
                                                   (Prims.of_int (13)))))
                                          (FStar_Sealed.seal
                                             (Obj.magic
                                                (FStar_Range.mk_range
                                                   "Pulse.Syntax.Printer.fst"
-                                                  (Prims.of_int (181))
+                                                  (Prims.of_int (214))
                                                   (Prims.of_int (6))
-                                                  (Prims.of_int (191))
+                                                  (Prims.of_int (224))
                                                   (Prims.of_int (13)))))
                                          (Obj.magic
                                             (FStar_Tactics_Effect.tac_bind
@@ -1687,17 +2269,17 @@ let rec (st_term_to_string' :
                                                   (Obj.magic
                                                      (FStar_Range.mk_range
                                                         "Pulse.Syntax.Printer.fst"
-                                                        (Prims.of_int (181))
+                                                        (Prims.of_int (214))
                                                         (Prims.of_int (6))
-                                                        (Prims.of_int (191))
+                                                        (Prims.of_int (224))
                                                         (Prims.of_int (13)))))
                                                (FStar_Sealed.seal
                                                   (Obj.magic
                                                      (FStar_Range.mk_range
                                                         "Pulse.Syntax.Printer.fst"
-                                                        (Prims.of_int (181))
+                                                        (Prims.of_int (214))
                                                         (Prims.of_int (6))
-                                                        (Prims.of_int (191))
+                                                        (Prims.of_int (224))
                                                         (Prims.of_int (13)))))
                                                (Obj.magic
                                                   (FStar_Tactics_Effect.tac_bind
@@ -1705,17 +2287,17 @@ let rec (st_term_to_string' :
                                                         (Obj.magic
                                                            (FStar_Range.mk_range
                                                               "Pulse.Syntax.Printer.fst"
-                                                              (Prims.of_int (181))
+                                                              (Prims.of_int (214))
                                                               (Prims.of_int (6))
-                                                              (Prims.of_int (191))
+                                                              (Prims.of_int (224))
                                                               (Prims.of_int (13)))))
                                                      (FStar_Sealed.seal
                                                         (Obj.magic
                                                            (FStar_Range.mk_range
                                                               "Pulse.Syntax.Printer.fst"
-                                                              (Prims.of_int (181))
+                                                              (Prims.of_int (214))
                                                               (Prims.of_int (6))
-                                                              (Prims.of_int (191))
+                                                              (Prims.of_int (224))
                                                               (Prims.of_int (13)))))
                                                      (Obj.magic
                                                         (FStar_Tactics_Effect.tac_bind
@@ -1723,17 +2305,17 @@ let rec (st_term_to_string' :
                                                               (Obj.magic
                                                                  (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (185))
+                                                                    (Prims.of_int (218))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (185))
+                                                                    (Prims.of_int (218))
                                                                     (Prims.of_int (49)))))
                                                            (FStar_Sealed.seal
                                                               (Obj.magic
                                                                  (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (181))
+                                                                    (Prims.of_int (214))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (191))
+                                                                    (Prims.of_int (224))
                                                                     (Prims.of_int (13)))))
                                                            (Obj.magic
                                                               (st_term_to_string'
@@ -1748,35 +2330,17 @@ let rec (st_term_to_string' :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (181))
+                                                                    (Prims.of_int (214))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (191))
+                                                                    (Prims.of_int (224))
                                                                     (Prims.of_int (13)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (181))
+                                                                    (Prims.of_int (214))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (191))
-                                                                    (Prims.of_int (13)))))
-                                                                    (Obj.magic
-                                                                    (FStar_Tactics_Effect.tac_bind
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (181))
-                                                                    (Prims.of_int (6))
-                                                                    (Prims.of_int (191))
-                                                                    (Prims.of_int (13)))))
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (181))
-                                                                    (Prims.of_int (6))
-                                                                    (Prims.of_int (191))
+                                                                    (Prims.of_int (224))
                                                                     (Prims.of_int (13)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1784,17 +2348,17 @@ let rec (st_term_to_string' :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (181))
+                                                                    (Prims.of_int (214))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (191))
+                                                                    (Prims.of_int (224))
                                                                     (Prims.of_int (13)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (181))
+                                                                    (Prims.of_int (214))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (191))
+                                                                    (Prims.of_int (224))
                                                                     (Prims.of_int (13)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1802,9 +2366,27 @@ let rec (st_term_to_string' :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (182))
+                                                                    (Prims.of_int (214))
+                                                                    (Prims.of_int (6))
+                                                                    (Prims.of_int (224))
+                                                                    (Prims.of_int (13)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Syntax.Printer.fst"
+                                                                    (Prims.of_int (214))
+                                                                    (Prims.of_int (6))
+                                                                    (Prims.of_int (224))
+                                                                    (Prims.of_int (13)))))
+                                                                    (Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Syntax.Printer.fst"
+                                                                    (Prims.of_int (215))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (182))
+                                                                    (Prims.of_int (215))
                                                                     (Prims.of_int (26)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -1914,13 +2496,13 @@ let rec (st_term_to_string' :
             (FStar_Sealed.seal
                (Obj.magic
                   (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                     (Prims.of_int (196)) (Prims.of_int (8))
-                     (Prims.of_int (196)) (Prims.of_int (32)))))
+                     (Prims.of_int (229)) (Prims.of_int (8))
+                     (Prims.of_int (229)) (Prims.of_int (32)))))
             (FStar_Sealed.seal
                (Obj.magic
                   (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                     (Prims.of_int (194)) (Prims.of_int (6))
-                     (Prims.of_int (196)) (Prims.of_int (32)))))
+                     (Prims.of_int (227)) (Prims.of_int (6))
+                     (Prims.of_int (229)) (Prims.of_int (32)))))
             (Obj.magic (branches_to_string brs))
             (fun uu___1 ->
                (fun uu___1 ->
@@ -1929,21 +2511,21 @@ let rec (st_term_to_string' :
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (194)) (Prims.of_int (6))
-                                (Prims.of_int (196)) (Prims.of_int (32)))))
+                                (Prims.of_int (227)) (Prims.of_int (6))
+                                (Prims.of_int (229)) (Prims.of_int (32)))))
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (194)) (Prims.of_int (6))
-                                (Prims.of_int (196)) (Prims.of_int (32)))))
+                                (Prims.of_int (227)) (Prims.of_int (6))
+                                (Prims.of_int (229)) (Prims.of_int (32)))))
                        (Obj.magic
                           (FStar_Tactics_Effect.tac_bind
                              (FStar_Sealed.seal
                                 (Obj.magic
                                    (FStar_Range.mk_range
                                       "Pulse.Syntax.Printer.fst"
-                                      (Prims.of_int (195)) (Prims.of_int (8))
-                                      (Prims.of_int (195))
+                                      (Prims.of_int (228)) (Prims.of_int (8))
+                                      (Prims.of_int (228))
                                       (Prims.of_int (27)))))
                              (FStar_Sealed.seal
                                 (Obj.magic
@@ -1968,8 +2550,8 @@ let rec (st_term_to_string' :
             (FStar_Sealed.seal
                (Obj.magic
                   (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                     (Prims.of_int (201)) (Prims.of_int (8))
-                     (Prims.of_int (201)) (Prims.of_int (42)))))
+                     (Prims.of_int (234)) (Prims.of_int (8))
+                     (Prims.of_int (234)) (Prims.of_int (42)))))
             (FStar_Sealed.seal
                (Obj.magic
                   (FStar_Range.mk_range "prims.fst" (Prims.of_int (590))
@@ -1988,8 +2570,8 @@ let rec (st_term_to_string' :
             (FStar_Sealed.seal
                (Obj.magic
                   (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                     (Prims.of_int (205)) (Prims.of_int (8))
-                     (Prims.of_int (205)) (Prims.of_int (26)))))
+                     (Prims.of_int (238)) (Prims.of_int (8))
+                     (Prims.of_int (238)) (Prims.of_int (26)))))
             (FStar_Sealed.seal
                (Obj.magic
                   (FStar_Range.mk_range "prims.fst" (Prims.of_int (590))
@@ -2007,13 +2589,13 @@ let rec (st_term_to_string' :
             (FStar_Sealed.seal
                (Obj.magic
                   (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                     (Prims.of_int (212)) (Prims.of_int (8))
-                     (Prims.of_int (212)) (Prims.of_int (43)))))
+                     (Prims.of_int (245)) (Prims.of_int (8))
+                     (Prims.of_int (245)) (Prims.of_int (43)))))
             (FStar_Sealed.seal
                (Obj.magic
                   (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                     (Prims.of_int (208)) (Prims.of_int (6))
-                     (Prims.of_int (212)) (Prims.of_int (43)))))
+                     (Prims.of_int (241)) (Prims.of_int (6))
+                     (Prims.of_int (245)) (Prims.of_int (43)))))
             (Obj.magic (term_list_to_string " " witnesses))
             (fun uu___ ->
                (fun uu___ ->
@@ -2022,28 +2604,28 @@ let rec (st_term_to_string' :
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (208)) (Prims.of_int (6))
-                                (Prims.of_int (212)) (Prims.of_int (43)))))
+                                (Prims.of_int (241)) (Prims.of_int (6))
+                                (Prims.of_int (245)) (Prims.of_int (43)))))
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (208)) (Prims.of_int (6))
-                                (Prims.of_int (212)) (Prims.of_int (43)))))
+                                (Prims.of_int (241)) (Prims.of_int (6))
+                                (Prims.of_int (245)) (Prims.of_int (43)))))
                        (Obj.magic
                           (FStar_Tactics_Effect.tac_bind
                              (FStar_Sealed.seal
                                 (Obj.magic
                                    (FStar_Range.mk_range
                                       "Pulse.Syntax.Printer.fst"
-                                      (Prims.of_int (208)) (Prims.of_int (6))
-                                      (Prims.of_int (212))
+                                      (Prims.of_int (241)) (Prims.of_int (6))
+                                      (Prims.of_int (245))
                                       (Prims.of_int (43)))))
                              (FStar_Sealed.seal
                                 (Obj.magic
                                    (FStar_Range.mk_range
                                       "Pulse.Syntax.Printer.fst"
-                                      (Prims.of_int (208)) (Prims.of_int (6))
-                                      (Prims.of_int (212))
+                                      (Prims.of_int (241)) (Prims.of_int (6))
+                                      (Prims.of_int (245))
                                       (Prims.of_int (43)))))
                              (Obj.magic
                                 (FStar_Tactics_Effect.tac_bind
@@ -2051,9 +2633,9 @@ let rec (st_term_to_string' :
                                       (Obj.magic
                                          (FStar_Range.mk_range
                                             "Pulse.Syntax.Printer.fst"
-                                            (Prims.of_int (210))
+                                            (Prims.of_int (243))
                                             (Prims.of_int (8))
-                                            (Prims.of_int (210))
+                                            (Prims.of_int (243))
                                             (Prims.of_int (42)))))
                                    (FStar_Sealed.seal
                                       (Obj.magic
@@ -2098,25 +2680,25 @@ let rec (st_term_to_string' :
             (FStar_Sealed.seal
                (Obj.magic
                   (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                     (Prims.of_int (215)) (Prims.of_int (6))
-                     (Prims.of_int (222)) (Prims.of_int (13)))))
+                     (Prims.of_int (248)) (Prims.of_int (6))
+                     (Prims.of_int (255)) (Prims.of_int (13)))))
             (FStar_Sealed.seal
                (Obj.magic
                   (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                     (Prims.of_int (215)) (Prims.of_int (6))
-                     (Prims.of_int (222)) (Prims.of_int (13)))))
+                     (Prims.of_int (248)) (Prims.of_int (6))
+                     (Prims.of_int (255)) (Prims.of_int (13)))))
             (Obj.magic
                (FStar_Tactics_Effect.tac_bind
                   (FStar_Sealed.seal
                      (Obj.magic
                         (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                           (Prims.of_int (221)) (Prims.of_int (8))
-                           (Prims.of_int (221)) (Prims.of_int (48)))))
+                           (Prims.of_int (254)) (Prims.of_int (8))
+                           (Prims.of_int (254)) (Prims.of_int (48)))))
                   (FStar_Sealed.seal
                      (Obj.magic
                         (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                           (Prims.of_int (215)) (Prims.of_int (6))
-                           (Prims.of_int (222)) (Prims.of_int (13)))))
+                           (Prims.of_int (248)) (Prims.of_int (6))
+                           (Prims.of_int (255)) (Prims.of_int (13)))))
                   (Obj.magic (st_term_to_string' (indent level) body))
                   (fun uu___1 ->
                      (fun uu___1 ->
@@ -2126,15 +2708,15 @@ let rec (st_term_to_string' :
                                 (Obj.magic
                                    (FStar_Range.mk_range
                                       "Pulse.Syntax.Printer.fst"
-                                      (Prims.of_int (215)) (Prims.of_int (6))
-                                      (Prims.of_int (222))
+                                      (Prims.of_int (248)) (Prims.of_int (6))
+                                      (Prims.of_int (255))
                                       (Prims.of_int (13)))))
                              (FStar_Sealed.seal
                                 (Obj.magic
                                    (FStar_Range.mk_range
                                       "Pulse.Syntax.Printer.fst"
-                                      (Prims.of_int (215)) (Prims.of_int (6))
-                                      (Prims.of_int (222))
+                                      (Prims.of_int (248)) (Prims.of_int (6))
+                                      (Prims.of_int (255))
                                       (Prims.of_int (13)))))
                              (Obj.magic
                                 (FStar_Tactics_Effect.tac_bind
@@ -2142,17 +2724,17 @@ let rec (st_term_to_string' :
                                       (Obj.magic
                                          (FStar_Range.mk_range
                                             "Pulse.Syntax.Printer.fst"
-                                            (Prims.of_int (215))
+                                            (Prims.of_int (248))
                                             (Prims.of_int (6))
-                                            (Prims.of_int (222))
+                                            (Prims.of_int (255))
                                             (Prims.of_int (13)))))
                                    (FStar_Sealed.seal
                                       (Obj.magic
                                          (FStar_Range.mk_range
                                             "Pulse.Syntax.Printer.fst"
-                                            (Prims.of_int (215))
+                                            (Prims.of_int (248))
                                             (Prims.of_int (6))
-                                            (Prims.of_int (222))
+                                            (Prims.of_int (255))
                                             (Prims.of_int (13)))))
                                    (Obj.magic
                                       (FStar_Tactics_Effect.tac_bind
@@ -2160,17 +2742,17 @@ let rec (st_term_to_string' :
                                             (Obj.magic
                                                (FStar_Range.mk_range
                                                   "Pulse.Syntax.Printer.fst"
-                                                  (Prims.of_int (215))
+                                                  (Prims.of_int (248))
                                                   (Prims.of_int (6))
-                                                  (Prims.of_int (222))
+                                                  (Prims.of_int (255))
                                                   (Prims.of_int (13)))))
                                          (FStar_Sealed.seal
                                             (Obj.magic
                                                (FStar_Range.mk_range
                                                   "Pulse.Syntax.Printer.fst"
-                                                  (Prims.of_int (215))
+                                                  (Prims.of_int (248))
                                                   (Prims.of_int (6))
-                                                  (Prims.of_int (222))
+                                                  (Prims.of_int (255))
                                                   (Prims.of_int (13)))))
                                          (Obj.magic
                                             (FStar_Tactics_Effect.tac_bind
@@ -2178,17 +2760,17 @@ let rec (st_term_to_string' :
                                                   (Obj.magic
                                                      (FStar_Range.mk_range
                                                         "Pulse.Syntax.Printer.fst"
-                                                        (Prims.of_int (218))
+                                                        (Prims.of_int (251))
                                                         (Prims.of_int (8))
-                                                        (Prims.of_int (218))
+                                                        (Prims.of_int (251))
                                                         (Prims.of_int (34)))))
                                                (FStar_Sealed.seal
                                                   (Obj.magic
                                                      (FStar_Range.mk_range
                                                         "Pulse.Syntax.Printer.fst"
-                                                        (Prims.of_int (215))
+                                                        (Prims.of_int (248))
                                                         (Prims.of_int (6))
-                                                        (Prims.of_int (222))
+                                                        (Prims.of_int (255))
                                                         (Prims.of_int (13)))))
                                                (Obj.magic
                                                   (term_to_string invariant))
@@ -2200,17 +2782,17 @@ let rec (st_term_to_string' :
                                                              (Obj.magic
                                                                 (FStar_Range.mk_range
                                                                    "Pulse.Syntax.Printer.fst"
-                                                                   (Prims.of_int (215))
+                                                                   (Prims.of_int (248))
                                                                    (Prims.of_int (6))
-                                                                   (Prims.of_int (222))
+                                                                   (Prims.of_int (255))
                                                                    (Prims.of_int (13)))))
                                                           (FStar_Sealed.seal
                                                              (Obj.magic
                                                                 (FStar_Range.mk_range
                                                                    "Pulse.Syntax.Printer.fst"
-                                                                   (Prims.of_int (215))
+                                                                   (Prims.of_int (248))
                                                                    (Prims.of_int (6))
-                                                                   (Prims.of_int (222))
+                                                                   (Prims.of_int (255))
                                                                    (Prims.of_int (13)))))
                                                           (Obj.magic
                                                              (FStar_Tactics_Effect.tac_bind
@@ -2218,17 +2800,17 @@ let rec (st_term_to_string' :
                                                                    (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (215))
+                                                                    (Prims.of_int (248))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (222))
+                                                                    (Prims.of_int (255))
                                                                     (Prims.of_int (13)))))
                                                                 (FStar_Sealed.seal
                                                                    (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (215))
+                                                                    (Prims.of_int (248))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (222))
+                                                                    (Prims.of_int (255))
                                                                     (Prims.of_int (13)))))
                                                                 (Obj.magic
                                                                    (FStar_Tactics_Effect.tac_bind
@@ -2236,9 +2818,9 @@ let rec (st_term_to_string' :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (216))
+                                                                    (Prims.of_int (249))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (216))
+                                                                    (Prims.of_int (249))
                                                                     (Prims.of_int (44)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -2321,13 +2903,13 @@ let rec (st_term_to_string' :
             (FStar_Sealed.seal
                (Obj.magic
                   (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                     (Prims.of_int (231)) (Prims.of_int (8))
-                     (Prims.of_int (231)) (Prims.of_int (30)))))
+                     (Prims.of_int (264)) (Prims.of_int (8))
+                     (Prims.of_int (264)) (Prims.of_int (30)))))
             (FStar_Sealed.seal
                (Obj.magic
                   (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                     (Prims.of_int (225)) (Prims.of_int (6))
-                     (Prims.of_int (231)) (Prims.of_int (30)))))
+                     (Prims.of_int (258)) (Prims.of_int (6))
+                     (Prims.of_int (264)) (Prims.of_int (30)))))
             (Obj.magic (term_to_string post2))
             (fun uu___ ->
                (fun uu___ ->
@@ -2336,28 +2918,28 @@ let rec (st_term_to_string' :
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (225)) (Prims.of_int (6))
-                                (Prims.of_int (231)) (Prims.of_int (30)))))
+                                (Prims.of_int (258)) (Prims.of_int (6))
+                                (Prims.of_int (264)) (Prims.of_int (30)))))
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (225)) (Prims.of_int (6))
-                                (Prims.of_int (231)) (Prims.of_int (30)))))
+                                (Prims.of_int (258)) (Prims.of_int (6))
+                                (Prims.of_int (264)) (Prims.of_int (30)))))
                        (Obj.magic
                           (FStar_Tactics_Effect.tac_bind
                              (FStar_Sealed.seal
                                 (Obj.magic
                                    (FStar_Range.mk_range
                                       "Pulse.Syntax.Printer.fst"
-                                      (Prims.of_int (230)) (Prims.of_int (8))
-                                      (Prims.of_int (230))
+                                      (Prims.of_int (263)) (Prims.of_int (8))
+                                      (Prims.of_int (263))
                                       (Prims.of_int (40)))))
                              (FStar_Sealed.seal
                                 (Obj.magic
                                    (FStar_Range.mk_range
                                       "Pulse.Syntax.Printer.fst"
-                                      (Prims.of_int (225)) (Prims.of_int (6))
-                                      (Prims.of_int (231))
+                                      (Prims.of_int (258)) (Prims.of_int (6))
+                                      (Prims.of_int (264))
                                       (Prims.of_int (30)))))
                              (Obj.magic (st_term_to_string' level body2))
                              (fun uu___1 ->
@@ -2368,17 +2950,17 @@ let rec (st_term_to_string' :
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.Syntax.Printer.fst"
-                                                 (Prims.of_int (225))
+                                                 (Prims.of_int (258))
                                                  (Prims.of_int (6))
-                                                 (Prims.of_int (231))
+                                                 (Prims.of_int (264))
                                                  (Prims.of_int (30)))))
                                         (FStar_Sealed.seal
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.Syntax.Printer.fst"
-                                                 (Prims.of_int (225))
+                                                 (Prims.of_int (258))
                                                  (Prims.of_int (6))
-                                                 (Prims.of_int (231))
+                                                 (Prims.of_int (264))
                                                  (Prims.of_int (30)))))
                                         (Obj.magic
                                            (FStar_Tactics_Effect.tac_bind
@@ -2386,17 +2968,17 @@ let rec (st_term_to_string' :
                                                  (Obj.magic
                                                     (FStar_Range.mk_range
                                                        "Pulse.Syntax.Printer.fst"
-                                                       (Prims.of_int (229))
+                                                       (Prims.of_int (262))
                                                        (Prims.of_int (8))
-                                                       (Prims.of_int (229))
+                                                       (Prims.of_int (262))
                                                        (Prims.of_int (29)))))
                                               (FStar_Sealed.seal
                                                  (Obj.magic
                                                     (FStar_Range.mk_range
                                                        "Pulse.Syntax.Printer.fst"
-                                                       (Prims.of_int (225))
+                                                       (Prims.of_int (258))
                                                        (Prims.of_int (6))
-                                                       (Prims.of_int (231))
+                                                       (Prims.of_int (264))
                                                        (Prims.of_int (30)))))
                                               (Obj.magic
                                                  (term_to_string pre2))
@@ -2408,17 +2990,17 @@ let rec (st_term_to_string' :
                                                             (Obj.magic
                                                                (FStar_Range.mk_range
                                                                   "Pulse.Syntax.Printer.fst"
-                                                                  (Prims.of_int (225))
+                                                                  (Prims.of_int (258))
                                                                   (Prims.of_int (6))
-                                                                  (Prims.of_int (231))
+                                                                  (Prims.of_int (264))
                                                                   (Prims.of_int (30)))))
                                                          (FStar_Sealed.seal
                                                             (Obj.magic
                                                                (FStar_Range.mk_range
                                                                   "Pulse.Syntax.Printer.fst"
-                                                                  (Prims.of_int (225))
+                                                                  (Prims.of_int (258))
                                                                   (Prims.of_int (6))
-                                                                  (Prims.of_int (231))
+                                                                  (Prims.of_int (264))
                                                                   (Prims.of_int (30)))))
                                                          (Obj.magic
                                                             (FStar_Tactics_Effect.tac_bind
@@ -2426,17 +3008,17 @@ let rec (st_term_to_string' :
                                                                   (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (228))
+                                                                    (Prims.of_int (261))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (228))
+                                                                    (Prims.of_int (261))
                                                                     (Prims.of_int (30)))))
                                                                (FStar_Sealed.seal
                                                                   (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (225))
+                                                                    (Prims.of_int (258))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (231))
+                                                                    (Prims.of_int (264))
                                                                     (Prims.of_int (30)))))
                                                                (Obj.magic
                                                                   (term_to_string
@@ -2450,17 +3032,17 @@ let rec (st_term_to_string' :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (225))
+                                                                    (Prims.of_int (258))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (231))
+                                                                    (Prims.of_int (264))
                                                                     (Prims.of_int (30)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (225))
+                                                                    (Prims.of_int (258))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (231))
+                                                                    (Prims.of_int (264))
                                                                     (Prims.of_int (30)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -2468,17 +3050,17 @@ let rec (st_term_to_string' :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (227))
+                                                                    (Prims.of_int (260))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (227))
+                                                                    (Prims.of_int (260))
                                                                     (Prims.of_int (40)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (225))
+                                                                    (Prims.of_int (258))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (231))
+                                                                    (Prims.of_int (264))
                                                                     (Prims.of_int (30)))))
                                                                     (Obj.magic
                                                                     (st_term_to_string'
@@ -2494,17 +3076,17 @@ let rec (st_term_to_string' :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (225))
+                                                                    (Prims.of_int (258))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (231))
+                                                                    (Prims.of_int (264))
                                                                     (Prims.of_int (30)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (225))
+                                                                    (Prims.of_int (258))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (231))
+                                                                    (Prims.of_int (264))
                                                                     (Prims.of_int (30)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -2512,9 +3094,9 @@ let rec (st_term_to_string' :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (226))
+                                                                    (Prims.of_int (259))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (226))
+                                                                    (Prims.of_int (259))
                                                                     (Prims.of_int (29)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -2592,13 +3174,13 @@ let rec (st_term_to_string' :
             (FStar_Sealed.seal
                (Obj.magic
                   (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                     (Prims.of_int (236)) (Prims.of_int (8))
-                     (Prims.of_int (236)) (Prims.of_int (27)))))
+                     (Prims.of_int (269)) (Prims.of_int (8))
+                     (Prims.of_int (269)) (Prims.of_int (27)))))
             (FStar_Sealed.seal
                (Obj.magic
                   (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                     (Prims.of_int (234)) (Prims.of_int (7))
-                     (Prims.of_int (236)) (Prims.of_int (27)))))
+                     (Prims.of_int (267)) (Prims.of_int (7))
+                     (Prims.of_int (269)) (Prims.of_int (27)))))
             (Obj.magic (term_to_string t2))
             (fun uu___ ->
                (fun uu___ ->
@@ -2607,21 +3189,21 @@ let rec (st_term_to_string' :
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (234)) (Prims.of_int (7))
-                                (Prims.of_int (236)) (Prims.of_int (27)))))
+                                (Prims.of_int (267)) (Prims.of_int (7))
+                                (Prims.of_int (269)) (Prims.of_int (27)))))
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (234)) (Prims.of_int (7))
-                                (Prims.of_int (236)) (Prims.of_int (27)))))
+                                (Prims.of_int (267)) (Prims.of_int (7))
+                                (Prims.of_int (269)) (Prims.of_int (27)))))
                        (Obj.magic
                           (FStar_Tactics_Effect.tac_bind
                              (FStar_Sealed.seal
                                 (Obj.magic
                                    (FStar_Range.mk_range
                                       "Pulse.Syntax.Printer.fst"
-                                      (Prims.of_int (235)) (Prims.of_int (8))
-                                      (Prims.of_int (235))
+                                      (Prims.of_int (268)) (Prims.of_int (8))
+                                      (Prims.of_int (268))
                                       (Prims.of_int (27)))))
                              (FStar_Sealed.seal
                                 (Obj.magic
@@ -2650,13 +3232,13 @@ let rec (st_term_to_string' :
             (FStar_Sealed.seal
                (Obj.magic
                   (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                     (Prims.of_int (243)) (Prims.of_int (8))
-                     (Prims.of_int (243)) (Prims.of_int (39)))))
+                     (Prims.of_int (276)) (Prims.of_int (8))
+                     (Prims.of_int (276)) (Prims.of_int (39)))))
             (FStar_Sealed.seal
                (Obj.magic
                   (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                     (Prims.of_int (239)) (Prims.of_int (6))
-                     (Prims.of_int (243)) (Prims.of_int (39)))))
+                     (Prims.of_int (272)) (Prims.of_int (6))
+                     (Prims.of_int (276)) (Prims.of_int (39)))))
             (Obj.magic (st_term_to_string' level body))
             (fun uu___ ->
                (fun uu___ ->
@@ -2665,28 +3247,28 @@ let rec (st_term_to_string' :
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (239)) (Prims.of_int (6))
-                                (Prims.of_int (243)) (Prims.of_int (39)))))
+                                (Prims.of_int (272)) (Prims.of_int (6))
+                                (Prims.of_int (276)) (Prims.of_int (39)))))
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (239)) (Prims.of_int (6))
-                                (Prims.of_int (243)) (Prims.of_int (39)))))
+                                (Prims.of_int (272)) (Prims.of_int (6))
+                                (Prims.of_int (276)) (Prims.of_int (39)))))
                        (Obj.magic
                           (FStar_Tactics_Effect.tac_bind
                              (FStar_Sealed.seal
                                 (Obj.magic
                                    (FStar_Range.mk_range
                                       "Pulse.Syntax.Printer.fst"
-                                      (Prims.of_int (239)) (Prims.of_int (6))
-                                      (Prims.of_int (243))
+                                      (Prims.of_int (272)) (Prims.of_int (6))
+                                      (Prims.of_int (276))
                                       (Prims.of_int (39)))))
                              (FStar_Sealed.seal
                                 (Obj.magic
                                    (FStar_Range.mk_range
                                       "Pulse.Syntax.Printer.fst"
-                                      (Prims.of_int (239)) (Prims.of_int (6))
-                                      (Prims.of_int (243))
+                                      (Prims.of_int (272)) (Prims.of_int (6))
+                                      (Prims.of_int (276))
                                       (Prims.of_int (39)))))
                              (Obj.magic
                                 (FStar_Tactics_Effect.tac_bind
@@ -2694,17 +3276,17 @@ let rec (st_term_to_string' :
                                       (Obj.magic
                                          (FStar_Range.mk_range
                                             "Pulse.Syntax.Printer.fst"
-                                            (Prims.of_int (241))
+                                            (Prims.of_int (274))
                                             (Prims.of_int (8))
-                                            (Prims.of_int (241))
+                                            (Prims.of_int (274))
                                             (Prims.of_int (36)))))
                                    (FStar_Sealed.seal
                                       (Obj.magic
                                          (FStar_Range.mk_range
                                             "Pulse.Syntax.Printer.fst"
-                                            (Prims.of_int (239))
+                                            (Prims.of_int (272))
                                             (Prims.of_int (6))
-                                            (Prims.of_int (243))
+                                            (Prims.of_int (276))
                                             (Prims.of_int (39)))))
                                    (Obj.magic (term_to_string initializer1))
                                    (fun uu___1 ->
@@ -2715,17 +3297,17 @@ let rec (st_term_to_string' :
                                                  (Obj.magic
                                                     (FStar_Range.mk_range
                                                        "Pulse.Syntax.Printer.fst"
-                                                       (Prims.of_int (239))
+                                                       (Prims.of_int (272))
                                                        (Prims.of_int (6))
-                                                       (Prims.of_int (243))
+                                                       (Prims.of_int (276))
                                                        (Prims.of_int (39)))))
                                               (FStar_Sealed.seal
                                                  (Obj.magic
                                                     (FStar_Range.mk_range
                                                        "Pulse.Syntax.Printer.fst"
-                                                       (Prims.of_int (239))
+                                                       (Prims.of_int (272))
                                                        (Prims.of_int (6))
-                                                       (Prims.of_int (243))
+                                                       (Prims.of_int (276))
                                                        (Prims.of_int (39)))))
                                               (Obj.magic
                                                  (FStar_Tactics_Effect.tac_bind
@@ -2733,9 +3315,9 @@ let rec (st_term_to_string' :
                                                        (Obj.magic
                                                           (FStar_Range.mk_range
                                                              "Pulse.Syntax.Printer.fst"
-                                                             (Prims.of_int (240))
+                                                             (Prims.of_int (273))
                                                              (Prims.of_int (8))
-                                                             (Prims.of_int (240))
+                                                             (Prims.of_int (273))
                                                              (Prims.of_int (33)))))
                                                     (FStar_Sealed.seal
                                                        (Obj.magic
@@ -2789,13 +3371,13 @@ let rec (st_term_to_string' :
             (FStar_Sealed.seal
                (Obj.magic
                   (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                     (Prims.of_int (253)) (Prims.of_int (8))
-                     (Prims.of_int (255)) (Prims.of_int (60)))))
+                     (Prims.of_int (286)) (Prims.of_int (8))
+                     (Prims.of_int (288)) (Prims.of_int (60)))))
             (FStar_Sealed.seal
                (Obj.magic
                   (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                     (Prims.of_int (246)) (Prims.of_int (6))
-                     (Prims.of_int (255)) (Prims.of_int (60)))))
+                     (Prims.of_int (279)) (Prims.of_int (6))
+                     (Prims.of_int (288)) (Prims.of_int (60)))))
             (match post with
              | FStar_Pervasives_Native.None ->
                  Obj.magic
@@ -2809,8 +3391,8 @@ let rec (st_term_to_string' :
                             (Obj.magic
                                (FStar_Range.mk_range
                                   "Pulse.Syntax.Printer.fst"
-                                  (Prims.of_int (255)) (Prims.of_int (38))
-                                  (Prims.of_int (255)) (Prims.of_int (59)))))
+                                  (Prims.of_int (288)) (Prims.of_int (38))
+                                  (Prims.of_int (288)) (Prims.of_int (59)))))
                          (FStar_Sealed.seal
                             (Obj.magic
                                (FStar_Range.mk_range "prims.fst"
@@ -2828,21 +3410,21 @@ let rec (st_term_to_string' :
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (246)) (Prims.of_int (6))
-                                (Prims.of_int (255)) (Prims.of_int (60)))))
+                                (Prims.of_int (279)) (Prims.of_int (6))
+                                (Prims.of_int (288)) (Prims.of_int (60)))))
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (246)) (Prims.of_int (6))
-                                (Prims.of_int (255)) (Prims.of_int (60)))))
+                                (Prims.of_int (279)) (Prims.of_int (6))
+                                (Prims.of_int (288)) (Prims.of_int (60)))))
                        (Obj.magic
                           (FStar_Tactics_Effect.tac_bind
                              (FStar_Sealed.seal
                                 (Obj.magic
                                    (FStar_Range.mk_range
                                       "Pulse.Syntax.Printer.fst"
-                                      (Prims.of_int (252)) (Prims.of_int (8))
-                                      (Prims.of_int (252))
+                                      (Prims.of_int (285)) (Prims.of_int (8))
+                                      (Prims.of_int (285))
                                       (Prims.of_int (28)))))
                              (FStar_Sealed.seal
                                 (Obj.magic
@@ -2886,13 +3468,13 @@ let rec (st_term_to_string' :
             (FStar_Sealed.seal
                (Obj.magic
                   (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                     (Prims.of_int (259)) (Prims.of_int (8))
-                     (Prims.of_int (261)) (Prims.of_int (86)))))
+                     (Prims.of_int (292)) (Prims.of_int (8))
+                     (Prims.of_int (294)) (Prims.of_int (86)))))
             (FStar_Sealed.seal
                (Obj.magic
                   (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                     (Prims.of_int (262)) (Prims.of_int (8))
-                     (Prims.of_int (285)) (Prims.of_int (36)))))
+                     (Prims.of_int (295)) (Prims.of_int (8))
+                     (Prims.of_int (318)) (Prims.of_int (36)))))
             (match binders with
              | [] ->
                  Obj.magic
@@ -2906,8 +3488,8 @@ let rec (st_term_to_string' :
                             (Obj.magic
                                (FStar_Range.mk_range
                                   "Pulse.Syntax.Printer.fst"
-                                  (Prims.of_int (261)) (Prims.of_int (34))
-                                  (Prims.of_int (261)) (Prims.of_int (86)))))
+                                  (Prims.of_int (294)) (Prims.of_int (34))
+                                  (Prims.of_int (294)) (Prims.of_int (86)))))
                          (FStar_Sealed.seal
                             (Obj.magic
                                (FStar_Range.mk_range "prims.fst"
@@ -2919,17 +3501,17 @@ let rec (st_term_to_string' :
                                   (Obj.magic
                                      (FStar_Range.mk_range
                                         "Pulse.Syntax.Printer.fst"
-                                        (Prims.of_int (261))
+                                        (Prims.of_int (294))
                                         (Prims.of_int (53))
-                                        (Prims.of_int (261))
+                                        (Prims.of_int (294))
                                         (Prims.of_int (85)))))
                                (FStar_Sealed.seal
                                   (Obj.magic
                                      (FStar_Range.mk_range
                                         "Pulse.Syntax.Printer.fst"
-                                        (Prims.of_int (261))
+                                        (Prims.of_int (294))
                                         (Prims.of_int (34))
-                                        (Prims.of_int (261))
+                                        (Prims.of_int (294))
                                         (Prims.of_int (86)))))
                                (Obj.magic
                                   (FStar_Tactics_Util.map binder_to_string
@@ -2950,13 +3532,13 @@ let rec (st_term_to_string' :
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (263)) (Prims.of_int (28))
-                                (Prims.of_int (265)) (Prims.of_int (58)))))
+                                (Prims.of_int (296)) (Prims.of_int (28))
+                                (Prims.of_int (298)) (Prims.of_int (58)))))
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (266)) (Prims.of_int (8))
-                                (Prims.of_int (285)) (Prims.of_int (36)))))
+                                (Prims.of_int (299)) (Prims.of_int (8))
+                                (Prims.of_int (318)) (Prims.of_int (36)))))
                        (FStar_Tactics_Effect.lift_div_tac
                           (fun uu___ ->
                              fun uu___1 ->
@@ -2974,17 +3556,17 @@ let rec (st_term_to_string' :
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "Pulse.Syntax.Printer.fst"
-                                           (Prims.of_int (268))
+                                           (Prims.of_int (301))
                                            (Prims.of_int (8))
-                                           (Prims.of_int (282))
+                                           (Prims.of_int (315))
                                            (Prims.of_int (80)))))
                                   (FStar_Sealed.seal
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "Pulse.Syntax.Printer.fst"
-                                           (Prims.of_int (266))
+                                           (Prims.of_int (299))
                                            (Prims.of_int (8))
-                                           (Prims.of_int (285))
+                                           (Prims.of_int (318))
                                            (Prims.of_int (36)))))
                                   (match hint_type with
                                    | Pulse_Syntax_Base.ASSERT
@@ -2995,17 +3577,17 @@ let rec (st_term_to_string' :
                                                (Obj.magic
                                                   (FStar_Range.mk_range
                                                      "Pulse.Syntax.Printer.fst"
-                                                     (Prims.of_int (269))
+                                                     (Prims.of_int (302))
                                                      (Prims.of_int (36))
-                                                     (Prims.of_int (269))
+                                                     (Prims.of_int (302))
                                                      (Prims.of_int (52)))))
                                             (FStar_Sealed.seal
                                                (Obj.magic
                                                   (FStar_Range.mk_range
                                                      "Pulse.Syntax.Printer.fst"
-                                                     (Prims.of_int (269))
+                                                     (Prims.of_int (302))
                                                      (Prims.of_int (26))
-                                                     (Prims.of_int (269))
+                                                     (Prims.of_int (302))
                                                      (Prims.of_int (52)))))
                                             (Obj.magic (term_to_string p))
                                             (fun uu___ ->
@@ -3022,17 +3604,17 @@ let rec (st_term_to_string' :
                                                (Obj.magic
                                                   (FStar_Range.mk_range
                                                      "Pulse.Syntax.Printer.fst"
-                                                     (Prims.of_int (270))
+                                                     (Prims.of_int (303))
                                                      (Prims.of_int (77))
-                                                     (Prims.of_int (270))
+                                                     (Prims.of_int (303))
                                                      (Prims.of_int (93)))))
                                             (FStar_Sealed.seal
                                                (Obj.magic
                                                   (FStar_Range.mk_range
                                                      "Pulse.Syntax.Printer.fst"
-                                                     (Prims.of_int (270))
+                                                     (Prims.of_int (303))
                                                      (Prims.of_int (33))
-                                                     (Prims.of_int (270))
+                                                     (Prims.of_int (303))
                                                      (Prims.of_int (93)))))
                                             (Obj.magic (term_to_string p))
                                             (fun uu___ ->
@@ -3053,17 +3635,17 @@ let rec (st_term_to_string' :
                                                (Obj.magic
                                                   (FStar_Range.mk_range
                                                      "Pulse.Syntax.Printer.fst"
-                                                     (Prims.of_int (271))
+                                                     (Prims.of_int (304))
                                                      (Prims.of_int (73))
-                                                     (Prims.of_int (271))
+                                                     (Prims.of_int (304))
                                                      (Prims.of_int (89)))))
                                             (FStar_Sealed.seal
                                                (Obj.magic
                                                   (FStar_Range.mk_range
                                                      "Pulse.Syntax.Printer.fst"
-                                                     (Prims.of_int (271))
+                                                     (Prims.of_int (304))
                                                      (Prims.of_int (31))
-                                                     (Prims.of_int (271))
+                                                     (Prims.of_int (304))
                                                      (Prims.of_int (89)))))
                                             (Obj.magic (term_to_string p))
                                             (fun uu___ ->
@@ -3084,17 +3666,17 @@ let rec (st_term_to_string' :
                                                (Obj.magic
                                                   (FStar_Range.mk_range
                                                      "Pulse.Syntax.Printer.fst"
-                                                     (Prims.of_int (273))
+                                                     (Prims.of_int (306))
                                                      (Prims.of_int (10))
-                                                     (Prims.of_int (277))
+                                                     (Prims.of_int (310))
                                                      (Prims.of_int (21)))))
                                             (FStar_Sealed.seal
                                                (Obj.magic
                                                   (FStar_Range.mk_range
                                                      "Pulse.Syntax.Printer.fst"
-                                                     (Prims.of_int (273))
+                                                     (Prims.of_int (306))
                                                      (Prims.of_int (10))
-                                                     (Prims.of_int (280))
+                                                     (Prims.of_int (313))
                                                      (Prims.of_int (60)))))
                                             (Obj.magic
                                                (FStar_Tactics_Effect.tac_bind
@@ -3102,9 +3684,9 @@ let rec (st_term_to_string' :
                                                      (Obj.magic
                                                         (FStar_Range.mk_range
                                                            "Pulse.Syntax.Printer.fst"
-                                                           (Prims.of_int (274))
+                                                           (Prims.of_int (307))
                                                            (Prims.of_int (12))
-                                                           (Prims.of_int (277))
+                                                           (Prims.of_int (310))
                                                            (Prims.of_int (21)))))
                                                   (FStar_Sealed.seal
                                                      (Obj.magic
@@ -3120,17 +3702,17 @@ let rec (st_term_to_string' :
                                                            (Obj.magic
                                                               (FStar_Range.mk_range
                                                                  "Pulse.Syntax.Printer.fst"
-                                                                 (Prims.of_int (275))
+                                                                 (Prims.of_int (308))
                                                                  (Prims.of_int (14))
-                                                                 (Prims.of_int (277))
+                                                                 (Prims.of_int (310))
                                                                  (Prims.of_int (20)))))
                                                         (FStar_Sealed.seal
                                                            (Obj.magic
                                                               (FStar_Range.mk_range
                                                                  "Pulse.Syntax.Printer.fst"
-                                                                 (Prims.of_int (274))
+                                                                 (Prims.of_int (307))
                                                                  (Prims.of_int (12))
-                                                                 (Prims.of_int (277))
+                                                                 (Prims.of_int (310))
                                                                  (Prims.of_int (21)))))
                                                         (Obj.magic
                                                            (FStar_Tactics_Util.map
@@ -3143,17 +3725,17 @@ let rec (st_term_to_string' :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (276))
+                                                                    (Prims.of_int (309))
                                                                     (Prims.of_int (69))
-                                                                    (Prims.of_int (276))
+                                                                    (Prims.of_int (309))
                                                                     (Prims.of_int (87)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (276))
+                                                                    (Prims.of_int (309))
                                                                     (Prims.of_int (31))
-                                                                    (Prims.of_int (276))
+                                                                    (Prims.of_int (309))
                                                                     (Prims.of_int (87)))))
                                                                     (Obj.magic
                                                                     (term_to_string
@@ -3168,17 +3750,17 @@ let rec (st_term_to_string' :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (276))
+                                                                    (Prims.of_int (309))
                                                                     (Prims.of_int (31))
-                                                                    (Prims.of_int (276))
+                                                                    (Prims.of_int (309))
                                                                     (Prims.of_int (87)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (276))
+                                                                    (Prims.of_int (309))
                                                                     (Prims.of_int (31))
-                                                                    (Prims.of_int (276))
+                                                                    (Prims.of_int (309))
                                                                     (Prims.of_int (87)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -3186,9 +3768,9 @@ let rec (st_term_to_string' :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (276))
+                                                                    (Prims.of_int (309))
                                                                     (Prims.of_int (50))
-                                                                    (Prims.of_int (276))
+                                                                    (Prims.of_int (309))
                                                                     (Prims.of_int (68)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -3244,17 +3826,17 @@ let rec (st_term_to_string' :
                                                           (Obj.magic
                                                              (FStar_Range.mk_range
                                                                 "Pulse.Syntax.Printer.fst"
-                                                                (Prims.of_int (278))
+                                                                (Prims.of_int (311))
                                                                 (Prims.of_int (12))
-                                                                (Prims.of_int (280))
+                                                                (Prims.of_int (313))
                                                                 (Prims.of_int (60)))))
                                                        (FStar_Sealed.seal
                                                           (Obj.magic
                                                              (FStar_Range.mk_range
                                                                 "Pulse.Syntax.Printer.fst"
-                                                                (Prims.of_int (273))
+                                                                (Prims.of_int (306))
                                                                 (Prims.of_int (10))
-                                                                (Prims.of_int (280))
+                                                                (Prims.of_int (313))
                                                                 (Prims.of_int (60)))))
                                                        (match goal with
                                                         | FStar_Pervasives_Native.None
@@ -3276,9 +3858,9 @@ let rec (st_term_to_string' :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (280))
+                                                                    (Prims.of_int (313))
                                                                     (Prims.of_int (41))
-                                                                    (Prims.of_int (280))
+                                                                    (Prims.of_int (313))
                                                                     (Prims.of_int (59)))))
                                                                     (
                                                                     FStar_Sealed.seal
@@ -3319,17 +3901,17 @@ let rec (st_term_to_string' :
                                                (Obj.magic
                                                   (FStar_Range.mk_range
                                                      "Pulse.Syntax.Printer.fst"
-                                                     (Prims.of_int (282))
+                                                     (Prims.of_int (315))
                                                      (Prims.of_int (10))
-                                                     (Prims.of_int (282))
+                                                     (Prims.of_int (315))
                                                      (Prims.of_int (76)))))
                                             (FStar_Sealed.seal
                                                (Obj.magic
                                                   (FStar_Range.mk_range
                                                      "Pulse.Syntax.Printer.fst"
-                                                     (Prims.of_int (282))
+                                                     (Prims.of_int (315))
                                                      (Prims.of_int (10))
-                                                     (Prims.of_int (282))
+                                                     (Prims.of_int (315))
                                                      (Prims.of_int (80)))))
                                             (Obj.magic
                                                (FStar_Tactics_Effect.tac_bind
@@ -3337,17 +3919,17 @@ let rec (st_term_to_string' :
                                                      (Obj.magic
                                                         (FStar_Range.mk_range
                                                            "Pulse.Syntax.Printer.fst"
-                                                           (Prims.of_int (282))
+                                                           (Prims.of_int (315))
                                                            (Prims.of_int (57))
-                                                           (Prims.of_int (282))
+                                                           (Prims.of_int (315))
                                                            (Prims.of_int (76)))))
                                                   (FStar_Sealed.seal
                                                      (Obj.magic
                                                         (FStar_Range.mk_range
                                                            "Pulse.Syntax.Printer.fst"
-                                                           (Prims.of_int (282))
+                                                           (Prims.of_int (315))
                                                            (Prims.of_int (10))
-                                                           (Prims.of_int (282))
+                                                           (Prims.of_int (315))
                                                            (Prims.of_int (76)))))
                                                   (Obj.magic
                                                      (term_to_string t2))
@@ -3359,17 +3941,17 @@ let rec (st_term_to_string' :
                                                                 (Obj.magic
                                                                    (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (282))
+                                                                    (Prims.of_int (315))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (282))
+                                                                    (Prims.of_int (315))
                                                                     (Prims.of_int (76)))))
                                                              (FStar_Sealed.seal
                                                                 (Obj.magic
                                                                    (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (282))
+                                                                    (Prims.of_int (315))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (282))
+                                                                    (Prims.of_int (315))
                                                                     (Prims.of_int (76)))))
                                                              (Obj.magic
                                                                 (FStar_Tactics_Effect.tac_bind
@@ -3377,9 +3959,9 @@ let rec (st_term_to_string' :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (282))
+                                                                    (Prims.of_int (315))
                                                                     (Prims.of_int (37))
-                                                                    (Prims.of_int (282))
+                                                                    (Prims.of_int (315))
                                                                     (Prims.of_int (56)))))
                                                                    (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -3426,9 +4008,9 @@ let rec (st_term_to_string' :
                                                     (Obj.magic
                                                        (FStar_Range.mk_range
                                                           "Pulse.Syntax.Printer.fst"
-                                                          (Prims.of_int (285))
+                                                          (Prims.of_int (318))
                                                           (Prims.of_int (8))
-                                                          (Prims.of_int (285))
+                                                          (Prims.of_int (318))
                                                           (Prims.of_int (36)))))
                                                  (FStar_Sealed.seal
                                                     (Obj.magic
@@ -3477,13 +4059,13 @@ and (branches_to_string :
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                            (Prims.of_int (290)) (Prims.of_int (13))
-                            (Prims.of_int (290)) (Prims.of_int (31)))))
+                            (Prims.of_int (323)) (Prims.of_int (13))
+                            (Prims.of_int (323)) (Prims.of_int (31)))))
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                            (Prims.of_int (290)) (Prims.of_int (13))
-                            (Prims.of_int (290)) (Prims.of_int (55)))))
+                            (Prims.of_int (323)) (Prims.of_int (13))
+                            (Prims.of_int (323)) (Prims.of_int (55)))))
                    (Obj.magic (branch_to_string b))
                    (fun uu___ ->
                       (fun uu___ ->
@@ -3493,9 +4075,9 @@ and (branches_to_string :
                                  (Obj.magic
                                     (FStar_Range.mk_range
                                        "Pulse.Syntax.Printer.fst"
-                                       (Prims.of_int (290))
+                                       (Prims.of_int (323))
                                        (Prims.of_int (34))
-                                       (Prims.of_int (290))
+                                       (Prims.of_int (323))
                                        (Prims.of_int (55)))))
                               (FStar_Sealed.seal
                                  (Obj.magic
@@ -3518,12 +4100,12 @@ and (branch_to_string :
       (FStar_Sealed.seal
          (Obj.magic
             (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-               (Prims.of_int (293)) (Prims.of_int (17)) (Prims.of_int (293))
+               (Prims.of_int (326)) (Prims.of_int (17)) (Prims.of_int (326))
                (Prims.of_int (19)))))
       (FStar_Sealed.seal
          (Obj.magic
             (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-               (Prims.of_int (292)) (Prims.of_int (35)) (Prims.of_int (294))
+               (Prims.of_int (325)) (Prims.of_int (35)) (Prims.of_int (327))
                (Prims.of_int (25)))))
       (FStar_Tactics_Effect.lift_div_tac (fun uu___ -> br))
       (fun uu___ ->
@@ -3589,8 +4171,8 @@ let (tag_of_comp :
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                            (Prims.of_int (335)) (Prims.of_int (31))
-                            (Prims.of_int (335)) (Prims.of_int (49)))))
+                            (Prims.of_int (368)) (Prims.of_int (31))
+                            (Prims.of_int (368)) (Prims.of_int (49)))))
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "prims.fst"
@@ -3608,8 +4190,8 @@ let (tag_of_comp :
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                            (Prims.of_int (337)) (Prims.of_int (30))
-                            (Prims.of_int (337)) (Prims.of_int (48)))))
+                            (Prims.of_int (370)) (Prims.of_int (30))
+                            (Prims.of_int (370)) (Prims.of_int (48)))))
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "prims.fst"

--- a/src/ocaml/plugin/generated/Pulse_Typing_Env.ml
+++ b/src/ocaml/plugin/generated/Pulse_Typing_Env.ml
@@ -1163,83 +1163,100 @@ let fail_doc :
                            (FStar_Range.mk_range "Pulse.Typing.Env.fst"
                               (Prims.of_int (372)) (Prims.of_int (4))
                               (Prims.of_int (375)) (Prims.of_int (31)))))
-                     (if Pulse_RuntimeUtils.is_pulse_option_set "env_on_err"
-                      then
-                        Obj.magic
-                          (Obj.repr
-                             (FStar_Tactics_Effect.tac_bind
-                                (FStar_Sealed.seal
-                                   (Obj.magic
-                                      (FStar_Range.mk_range
-                                         "Pulse.Typing.Env.fst"
-                                         (Prims.of_int (370))
-                                         (Prims.of_int (15))
-                                         (Prims.of_int (370))
-                                         (Prims.of_int (64)))))
-                                (FStar_Sealed.seal
-                                   (Obj.magic
-                                      (FStar_Range.mk_range
-                                         "Pulse.Typing.Env.fst"
-                                         (Prims.of_int (370))
-                                         (Prims.of_int (9))
-                                         (Prims.of_int (370))
-                                         (Prims.of_int (64)))))
-                                (Obj.magic
-                                   (FStar_Tactics_Effect.tac_bind
-                                      (FStar_Sealed.seal
-                                         (Obj.magic
-                                            (FStar_Range.mk_range
-                                               "Pulse.Typing.Env.fst"
-                                               (Prims.of_int (370))
-                                               (Prims.of_int (16))
-                                               (Prims.of_int (370))
-                                               (Prims.of_int (63)))))
-                                      (FStar_Sealed.seal
-                                         (Obj.magic
-                                            (FStar_Range.mk_range
-                                               "Pulse.Typing.Env.fst"
-                                               (Prims.of_int (370))
-                                               (Prims.of_int (15))
-                                               (Prims.of_int (370))
-                                               (Prims.of_int (64)))))
-                                      (Obj.magic
-                                         (FStar_Tactics_Effect.tac_bind
-                                            (FStar_Sealed.seal
-                                               (Obj.magic
-                                                  (FStar_Range.mk_range
-                                                     "Pulse.Typing.Env.fst"
-                                                     (Prims.of_int (370))
-                                                     (Prims.of_int (51))
-                                                     (Prims.of_int (370))
-                                                     (Prims.of_int (63)))))
-                                            (FStar_Sealed.seal
-                                               (Obj.magic
-                                                  (FStar_Range.mk_range
-                                                     "Pulse.Typing.Env.fst"
-                                                     (Prims.of_int (370))
-                                                     (Prims.of_int (16))
-                                                     (Prims.of_int (370))
-                                                     (Prims.of_int (63)))))
-                                            (Obj.magic (env_to_doc g))
-                                            (fun uu___ ->
-                                               FStar_Tactics_Effect.lift_div_tac
+                     (Obj.magic
+                        (FStar_Tactics_Effect.tac_bind
+                           (FStar_Sealed.seal
+                              (Obj.magic
+                                 (FStar_Range.mk_range "Pulse.Typing.Env.fst"
+                                    (Prims.of_int (369)) (Prims.of_int (7))
+                                    (Prims.of_int (369)) (Prims.of_int (43)))))
+                           (FStar_Sealed.seal
+                              (Obj.magic
+                                 (FStar_Range.mk_range "Pulse.Typing.Env.fst"
+                                    (Prims.of_int (369)) (Prims.of_int (4))
+                                    (Prims.of_int (371)) (Prims.of_int (12)))))
+                           (Obj.magic (Pulse_Config.debug_flag "env_on_err"))
+                           (fun uu___ ->
+                              (fun uu___ ->
+                                 if uu___
+                                 then
+                                   Obj.magic
+                                     (Obj.repr
+                                        (FStar_Tactics_Effect.tac_bind
+                                           (FStar_Sealed.seal
+                                              (Obj.magic
+                                                 (FStar_Range.mk_range
+                                                    "Pulse.Typing.Env.fst"
+                                                    (Prims.of_int (370))
+                                                    (Prims.of_int (15))
+                                                    (Prims.of_int (370))
+                                                    (Prims.of_int (64)))))
+                                           (FStar_Sealed.seal
+                                              (Obj.magic
+                                                 (FStar_Range.mk_range
+                                                    "Pulse.Typing.Env.fst"
+                                                    (Prims.of_int (370))
+                                                    (Prims.of_int (9))
+                                                    (Prims.of_int (370))
+                                                    (Prims.of_int (64)))))
+                                           (Obj.magic
+                                              (FStar_Tactics_Effect.tac_bind
+                                                 (FStar_Sealed.seal
+                                                    (Obj.magic
+                                                       (FStar_Range.mk_range
+                                                          "Pulse.Typing.Env.fst"
+                                                          (Prims.of_int (370))
+                                                          (Prims.of_int (16))
+                                                          (Prims.of_int (370))
+                                                          (Prims.of_int (63)))))
+                                                 (FStar_Sealed.seal
+                                                    (Obj.magic
+                                                       (FStar_Range.mk_range
+                                                          "Pulse.Typing.Env.fst"
+                                                          (Prims.of_int (370))
+                                                          (Prims.of_int (15))
+                                                          (Prims.of_int (370))
+                                                          (Prims.of_int (64)))))
+                                                 (Obj.magic
+                                                    (FStar_Tactics_Effect.tac_bind
+                                                       (FStar_Sealed.seal
+                                                          (Obj.magic
+                                                             (FStar_Range.mk_range
+                                                                "Pulse.Typing.Env.fst"
+                                                                (Prims.of_int (370))
+                                                                (Prims.of_int (51))
+                                                                (Prims.of_int (370))
+                                                                (Prims.of_int (63)))))
+                                                       (FStar_Sealed.seal
+                                                          (Obj.magic
+                                                             (FStar_Range.mk_range
+                                                                "Pulse.Typing.Env.fst"
+                                                                (Prims.of_int (370))
+                                                                (Prims.of_int (16))
+                                                                (Prims.of_int (370))
+                                                                (Prims.of_int (63)))))
+                                                       (Obj.magic
+                                                          (env_to_doc g))
+                                                       (fun uu___1 ->
+                                                          FStar_Tactics_Effect.lift_div_tac
+                                                            (fun uu___2 ->
+                                                               FStar_Pprint.op_Hat_Slash_Hat
+                                                                 (FStar_Pprint.doc_of_string
+                                                                    "In environment")
+                                                                 uu___1))))
                                                  (fun uu___1 ->
-                                                    FStar_Pprint.op_Hat_Slash_Hat
-                                                      (FStar_Pprint.doc_of_string
-                                                         "In environment")
-                                                      uu___))))
-                                      (fun uu___ ->
-                                         FStar_Tactics_Effect.lift_div_tac
-                                           (fun uu___1 -> [uu___]))))
-                                (fun uu___ ->
-                                   FStar_Tactics_Effect.lift_div_tac
-                                     (fun uu___1 ->
-                                        FStar_List_Tot_Base.op_At msg uu___))))
-                      else
-                        Obj.magic
-                          (Obj.repr
-                             (FStar_Tactics_Effect.lift_div_tac
-                                (fun uu___1 -> msg))))
+                                                    FStar_Tactics_Effect.lift_div_tac
+                                                      (fun uu___2 -> [uu___1]))))
+                                           (fun uu___1 ->
+                                              FStar_Tactics_Effect.lift_div_tac
+                                                (fun uu___2 ->
+                                                   FStar_List_Tot_Base.op_At
+                                                     msg uu___1))))
+                                 else
+                                   Obj.magic
+                                     (Obj.repr
+                                        (FStar_Tactics_Effect.lift_div_tac
+                                           (fun uu___2 -> msg)))) uu___)))
                      (fun uu___ ->
                         (fun msg1 ->
                            Obj.magic

--- a/src/ocaml/plugin/generated/Pulse_Typing_Env.ml
+++ b/src/ocaml/plugin/generated/Pulse_Typing_Env.ml
@@ -850,6 +850,251 @@ let (env_to_string :
       (fun bs ->
          FStar_Tactics_Effect.lift_div_tac
            (fun uu___ -> FStar_String.concat "\n  " bs))
+let rec separate_map :
+  'a .
+    FStar_Pprint.document ->
+      ('a -> (FStar_Pprint.document, unit) FStar_Tactics_Effect.tac_repr) ->
+        'a Prims.list ->
+          (FStar_Pprint.document, unit) FStar_Tactics_Effect.tac_repr
+  =
+  fun uu___2 ->
+    fun uu___1 ->
+      fun uu___ ->
+        (fun sep ->
+           fun f ->
+             fun l ->
+               match l with
+               | [] ->
+                   Obj.magic
+                     (Obj.repr
+                        (FStar_Tactics_Effect.lift_div_tac
+                           (fun uu___ -> FStar_Pprint.empty)))
+               | x::[] -> Obj.magic (Obj.repr (f x))
+               | x::xs ->
+                   Obj.magic
+                     (Obj.repr
+                        (FStar_Tactics_Effect.tac_bind
+                           (FStar_Sealed.seal
+                              (Obj.magic
+                                 (FStar_Range.mk_range "Pulse.Typing.Env.fst"
+                                    (Prims.of_int (348)) (Prims.of_int (13))
+                                    (Prims.of_int (348)) (Prims.of_int (16)))))
+                           (FStar_Sealed.seal
+                              (Obj.magic
+                                 (FStar_Range.mk_range "Pulse.Typing.Env.fst"
+                                    (Prims.of_int (348)) (Prims.of_int (13))
+                                    (Prims.of_int (348)) (Prims.of_int (49)))))
+                           (Obj.magic (f x))
+                           (fun uu___ ->
+                              (fun uu___ ->
+                                 Obj.magic
+                                   (FStar_Tactics_Effect.tac_bind
+                                      (FStar_Sealed.seal
+                                         (Obj.magic
+                                            (FStar_Range.mk_range
+                                               "Pulse.Typing.Env.fst"
+                                               (Prims.of_int (348))
+                                               (Prims.of_int (20))
+                                               (Prims.of_int (348))
+                                               (Prims.of_int (49)))))
+                                      (FStar_Sealed.seal
+                                         (Obj.magic
+                                            (FStar_Range.mk_range
+                                               "Pulse.Typing.Env.fst"
+                                               (Prims.of_int (348))
+                                               (Prims.of_int (13))
+                                               (Prims.of_int (348))
+                                               (Prims.of_int (49)))))
+                                      (Obj.magic
+                                         (FStar_Tactics_Effect.tac_bind
+                                            (FStar_Sealed.seal
+                                               (Obj.magic
+                                                  (FStar_Range.mk_range
+                                                     "Pulse.Typing.Env.fst"
+                                                     (Prims.of_int (348))
+                                                     (Prims.of_int (28))
+                                                     (Prims.of_int (348))
+                                                     (Prims.of_int (49)))))
+                                            (FStar_Sealed.seal
+                                               (Obj.magic
+                                                  (FStar_Range.mk_range
+                                                     "Pulse.Typing.Env.fst"
+                                                     (Prims.of_int (348))
+                                                     (Prims.of_int (20))
+                                                     (Prims.of_int (348))
+                                                     (Prims.of_int (49)))))
+                                            (Obj.magic
+                                               (separate_map sep f xs))
+                                            (fun uu___1 ->
+                                               FStar_Tactics_Effect.lift_div_tac
+                                                 (fun uu___2 ->
+                                                    FStar_Pprint.op_Hat_Slash_Hat
+                                                      sep uu___1))))
+                                      (fun uu___1 ->
+                                         FStar_Tactics_Effect.lift_div_tac
+                                           (fun uu___2 ->
+                                              FStar_Pprint.op_Hat_Hat uu___
+                                                uu___1)))) uu___)))) uu___2
+          uu___1 uu___
+let (env_to_doc :
+  env -> (FStar_Pprint.document, unit) FStar_Tactics_Effect.tac_repr) =
+  fun e ->
+    FStar_Tactics_Effect.tac_bind
+      (FStar_Sealed.seal
+         (Obj.magic
+            (FStar_Range.mk_range "Pulse.Typing.Env.fst" (Prims.of_int (352))
+               (Prims.of_int (4)) (Prims.of_int (354)) (Prims.of_int (45)))))
+      (FStar_Sealed.seal
+         (Obj.magic
+            (FStar_Range.mk_range "Pulse.Typing.Env.fst" (Prims.of_int (356))
+               (Prims.of_int (2)) (Prims.of_int (356)) (Prims.of_int (56)))))
+      (FStar_Tactics_Effect.lift_div_tac
+         (fun uu___ ->
+            fun uu___1 ->
+              match uu___1 with
+              | ((n, t), x) ->
+                  FStar_Tactics_Effect.tac_bind
+                    (FStar_Sealed.seal
+                       (Obj.magic
+                          (FStar_Range.mk_range "Pulse.Typing.Env.fst"
+                             (Prims.of_int (353)) (Prims.of_int (6))
+                             (Prims.of_int (353)) (Prims.of_int (37)))))
+                    (FStar_Sealed.seal
+                       (Obj.magic
+                          (FStar_Range.mk_range "Pulse.Typing.Env.fst"
+                             (Prims.of_int (353)) (Prims.of_int (6))
+                             (Prims.of_int (354)) (Prims.of_int (45)))))
+                    (Obj.magic
+                       (FStar_Tactics_Effect.tac_bind
+                          (FStar_Sealed.seal
+                             (Obj.magic
+                                (FStar_Range.mk_range "Pulse.Typing.Env.fst"
+                                   (Prims.of_int (353)) (Prims.of_int (20))
+                                   (Prims.of_int (353)) (Prims.of_int (37)))))
+                          (FStar_Sealed.seal
+                             (Obj.magic
+                                (FStar_Range.mk_range "Pulse.Typing.Env.fst"
+                                   (Prims.of_int (353)) (Prims.of_int (6))
+                                   (Prims.of_int (353)) (Prims.of_int (37)))))
+                          (Obj.magic
+                             (FStar_Tactics_Unseal.unseal
+                                x.Pulse_Syntax_Base.name))
+                          (fun uu___2 ->
+                             FStar_Tactics_Effect.lift_div_tac
+                               (fun uu___3 ->
+                                  FStar_Pprint.doc_of_string uu___2))))
+                    (fun uu___2 ->
+                       (fun uu___2 ->
+                          Obj.magic
+                            (FStar_Tactics_Effect.tac_bind
+                               (FStar_Sealed.seal
+                                  (Obj.magic
+                                     (FStar_Range.mk_range
+                                        "Pulse.Typing.Env.fst"
+                                        (Prims.of_int (353))
+                                        (Prims.of_int (41))
+                                        (Prims.of_int (354))
+                                        (Prims.of_int (45)))))
+                               (FStar_Sealed.seal
+                                  (Obj.magic
+                                     (FStar_Range.mk_range
+                                        "Pulse.Typing.Env.fst"
+                                        (Prims.of_int (353))
+                                        (Prims.of_int (6))
+                                        (Prims.of_int (354))
+                                        (Prims.of_int (45)))))
+                               (Obj.magic
+                                  (FStar_Tactics_Effect.tac_bind
+                                     (FStar_Sealed.seal
+                                        (Obj.magic
+                                           (FStar_Range.mk_range
+                                              "Pulse.Typing.Env.fst"
+                                              (Prims.of_int (353))
+                                              (Prims.of_int (62))
+                                              (Prims.of_int (354))
+                                              (Prims.of_int (45)))))
+                                     (FStar_Sealed.seal
+                                        (Obj.magic
+                                           (FStar_Range.mk_range
+                                              "Pulse.Typing.Env.fst"
+                                              (Prims.of_int (353))
+                                              (Prims.of_int (41))
+                                              (Prims.of_int (354))
+                                              (Prims.of_int (45)))))
+                                     (Obj.magic
+                                        (FStar_Tactics_Effect.tac_bind
+                                           (FStar_Sealed.seal
+                                              (Obj.magic
+                                                 (FStar_Range.mk_range
+                                                    "Pulse.Typing.Env.fst"
+                                                    (Prims.of_int (354))
+                                                    (Prims.of_int (11))
+                                                    (Prims.of_int (354))
+                                                    (Prims.of_int (45)))))
+                                           (FStar_Sealed.seal
+                                              (Obj.magic
+                                                 (FStar_Range.mk_range
+                                                    "Pulse.Typing.Env.fst"
+                                                    (Prims.of_int (353))
+                                                    (Prims.of_int (62))
+                                                    (Prims.of_int (354))
+                                                    (Prims.of_int (45)))))
+                                           (Obj.magic
+                                              (Pulse_Syntax_Printer.term_to_doc
+                                                 t))
+                                           (fun uu___3 ->
+                                              FStar_Tactics_Effect.lift_div_tac
+                                                (fun uu___4 ->
+                                                   FStar_Pprint.op_Hat_Hat
+                                                     (FStar_Pprint.doc_of_string
+                                                        (Prims.string_of_int
+                                                           n)) uu___3))))
+                                     (fun uu___3 ->
+                                        FStar_Tactics_Effect.lift_div_tac
+                                          (fun uu___4 ->
+                                             FStar_Pprint.op_Hat_Hat
+                                               (FStar_Pprint.doc_of_string
+                                                  "#") uu___3))))
+                               (fun uu___3 ->
+                                  FStar_Tactics_Effect.lift_div_tac
+                                    (fun uu___4 ->
+                                       FStar_Pprint.op_Hat_Hat uu___2 uu___3))))
+                         uu___2)))
+      (fun uu___ ->
+         (fun pp1 ->
+            Obj.magic
+              (FStar_Tactics_Effect.tac_bind
+                 (FStar_Sealed.seal
+                    (Obj.magic
+                       (FStar_Range.mk_range "Pulse.Typing.Env.fst"
+                          (Prims.of_int (356)) (Prims.of_int (11))
+                          (Prims.of_int (356)) (Prims.of_int (56)))))
+                 (FStar_Sealed.seal
+                    (Obj.magic
+                       (FStar_Range.mk_range "Pulse.Typing.Env.fst"
+                          (Prims.of_int (356)) (Prims.of_int (2))
+                          (Prims.of_int (356)) (Prims.of_int (56)))))
+                 (Obj.magic
+                    (FStar_Tactics_Effect.tac_bind
+                       (FStar_Sealed.seal
+                          (Obj.magic
+                             (FStar_Range.mk_range "Pulse.Typing.Env.fst"
+                                (Prims.of_int (356)) (Prims.of_int (35))
+                                (Prims.of_int (356)) (Prims.of_int (55)))))
+                       (FStar_Sealed.seal
+                          (Obj.magic
+                             (FStar_Range.mk_range "Pulse.Typing.Env.fst"
+                                (Prims.of_int (356)) (Prims.of_int (11))
+                                (Prims.of_int (356)) (Prims.of_int (56)))))
+                       (Obj.magic (FStar_Tactics_Util.zip e.bs e.names))
+                       (fun uu___ ->
+                          (fun uu___ ->
+                             Obj.magic
+                               (separate_map FStar_Pprint.comma pp1 uu___))
+                            uu___)))
+                 (fun uu___ ->
+                    FStar_Tactics_Effect.lift_div_tac
+                      (fun uu___1 -> FStar_Pprint.brackets uu___)))) uu___)
 let (get_range :
   env ->
     Pulse_Syntax_Base.range FStar_Pervasives_Native.option ->
@@ -864,13 +1109,13 @@ let (get_range :
             (FStar_Sealed.seal
                (Obj.magic
                   (FStar_Range.mk_range "Pulse.Typing.Env.fst"
-                     (Prims.of_int (343)) (Prims.of_int (9))
-                     (Prims.of_int (343)) (Prims.of_int (27)))))
+                     (Prims.of_int (362)) (Prims.of_int (9))
+                     (Prims.of_int (362)) (Prims.of_int (27)))))
             (FStar_Sealed.seal
                (Obj.magic
                   (FStar_Range.mk_range "Pulse.Typing.Env.fst"
-                     (Prims.of_int (343)) (Prims.of_int (6))
-                     (Prims.of_int (345)) (Prims.of_int (12)))))
+                     (Prims.of_int (362)) (Prims.of_int (6))
+                     (Prims.of_int (364)) (Prims.of_int (12)))))
             (FStar_Tactics_Effect.lift_div_tac
                (fun uu___ -> Pulse_RuntimeUtils.is_range_zero r1))
             (fun uu___ ->
@@ -882,11 +1127,12 @@ let (get_range :
                       (Obj.repr
                          (FStar_Tactics_Effect.lift_div_tac
                             (fun uu___2 -> r1)))) uu___)
-let fail :
+let fail_doc :
   'a .
     env ->
       Pulse_Syntax_Base.range FStar_Pervasives_Native.option ->
-        Prims.string -> ('a, unit) FStar_Tactics_Effect.tac_repr
+        FStar_Pprint.document Prims.list ->
+          ('a, unit) FStar_Tactics_Effect.tac_repr
   =
   fun g ->
     fun r ->
@@ -895,13 +1141,13 @@ let fail :
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Typing.Env.fst"
-                   (Prims.of_int (348)) (Prims.of_int (10))
-                   (Prims.of_int (348)) (Prims.of_int (23)))))
+                   (Prims.of_int (367)) (Prims.of_int (10))
+                   (Prims.of_int (367)) (Prims.of_int (23)))))
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Typing.Env.fst"
-                   (Prims.of_int (348)) (Prims.of_int (26))
-                   (Prims.of_int (356)) (Prims.of_int (31)))))
+                   (Prims.of_int (367)) (Prims.of_int (26))
+                   (Prims.of_int (375)) (Prims.of_int (31)))))
           (Obj.magic (get_range g r))
           (fun uu___ ->
              (fun r1 ->
@@ -910,13 +1156,13 @@ let fail :
                      (FStar_Sealed.seal
                         (Obj.magic
                            (FStar_Range.mk_range "Pulse.Typing.Env.fst"
-                              (Prims.of_int (350)) (Prims.of_int (4))
-                              (Prims.of_int (352)) (Prims.of_int (12)))))
+                              (Prims.of_int (369)) (Prims.of_int (4))
+                              (Prims.of_int (371)) (Prims.of_int (12)))))
                      (FStar_Sealed.seal
                         (Obj.magic
                            (FStar_Range.mk_range "Pulse.Typing.Env.fst"
-                              (Prims.of_int (353)) (Prims.of_int (4))
-                              (Prims.of_int (356)) (Prims.of_int (31)))))
+                              (Prims.of_int (372)) (Prims.of_int (4))
+                              (Prims.of_int (375)) (Prims.of_int (31)))))
                      (if Pulse_RuntimeUtils.is_pulse_option_set "env_on_err"
                       then
                         Obj.magic
@@ -926,26 +1172,69 @@ let fail :
                                    (Obj.magic
                                       (FStar_Range.mk_range
                                          "Pulse.Typing.Env.fst"
-                                         (Prims.of_int (351))
-                                         (Prims.of_int (55))
-                                         (Prims.of_int (351))
-                                         (Prims.of_int (72)))))
+                                         (Prims.of_int (370))
+                                         (Prims.of_int (15))
+                                         (Prims.of_int (370))
+                                         (Prims.of_int (64)))))
                                 (FStar_Sealed.seal
                                    (Obj.magic
-                                      (FStar_Range.mk_range "prims.fst"
-                                         (Prims.of_int (590))
-                                         (Prims.of_int (19))
-                                         (Prims.of_int (590))
-                                         (Prims.of_int (31)))))
-                                (Obj.magic (env_to_string g))
+                                      (FStar_Range.mk_range
+                                         "Pulse.Typing.Env.fst"
+                                         (Prims.of_int (370))
+                                         (Prims.of_int (9))
+                                         (Prims.of_int (370))
+                                         (Prims.of_int (64)))))
+                                (Obj.magic
+                                   (FStar_Tactics_Effect.tac_bind
+                                      (FStar_Sealed.seal
+                                         (Obj.magic
+                                            (FStar_Range.mk_range
+                                               "Pulse.Typing.Env.fst"
+                                               (Prims.of_int (370))
+                                               (Prims.of_int (16))
+                                               (Prims.of_int (370))
+                                               (Prims.of_int (63)))))
+                                      (FStar_Sealed.seal
+                                         (Obj.magic
+                                            (FStar_Range.mk_range
+                                               "Pulse.Typing.Env.fst"
+                                               (Prims.of_int (370))
+                                               (Prims.of_int (15))
+                                               (Prims.of_int (370))
+                                               (Prims.of_int (64)))))
+                                      (Obj.magic
+                                         (FStar_Tactics_Effect.tac_bind
+                                            (FStar_Sealed.seal
+                                               (Obj.magic
+                                                  (FStar_Range.mk_range
+                                                     "Pulse.Typing.Env.fst"
+                                                     (Prims.of_int (370))
+                                                     (Prims.of_int (51))
+                                                     (Prims.of_int (370))
+                                                     (Prims.of_int (63)))))
+                                            (FStar_Sealed.seal
+                                               (Obj.magic
+                                                  (FStar_Range.mk_range
+                                                     "Pulse.Typing.Env.fst"
+                                                     (Prims.of_int (370))
+                                                     (Prims.of_int (16))
+                                                     (Prims.of_int (370))
+                                                     (Prims.of_int (63)))))
+                                            (Obj.magic (env_to_doc g))
+                                            (fun uu___ ->
+                                               FStar_Tactics_Effect.lift_div_tac
+                                                 (fun uu___1 ->
+                                                    FStar_Pprint.op_Hat_Slash_Hat
+                                                      (FStar_Pprint.doc_of_string
+                                                         "In environment")
+                                                      uu___))))
+                                      (fun uu___ ->
+                                         FStar_Tactics_Effect.lift_div_tac
+                                           (fun uu___1 -> [uu___]))))
                                 (fun uu___ ->
                                    FStar_Tactics_Effect.lift_div_tac
                                      (fun uu___1 ->
-                                        Prims.strcat
-                                          (Prims.strcat ""
-                                             (Prims.strcat msg
-                                                "\nIn environment\n"))
-                                          (Prims.strcat uu___ "\n")))))
+                                        FStar_List_Tot_Base.op_At msg uu___))))
                       else
                         Obj.magic
                           (Obj.repr
@@ -959,17 +1248,17 @@ let fail :
                                    (Obj.magic
                                       (FStar_Range.mk_range
                                          "Pulse.Typing.Env.fst"
-                                         (Prims.of_int (354))
+                                         (Prims.of_int (373))
                                          (Prims.of_int (14))
-                                         (Prims.of_int (354))
-                                         (Prims.of_int (77)))))
+                                         (Prims.of_int (373))
+                                         (Prims.of_int (81)))))
                                 (FStar_Sealed.seal
                                    (Obj.magic
                                       (FStar_Range.mk_range
                                          "Pulse.Typing.Env.fst"
-                                         (Prims.of_int (355))
+                                         (Prims.of_int (374))
                                          (Prims.of_int (2))
-                                         (Prims.of_int (356))
+                                         (Prims.of_int (375))
                                          (Prims.of_int (31)))))
                                 (Obj.magic
                                    (FStar_Tactics_Effect.tac_bind
@@ -977,26 +1266,24 @@ let fail :
                                          (Obj.magic
                                             (FStar_Range.mk_range
                                                "Pulse.Typing.Env.fst"
-                                               (Prims.of_int (354))
-                                               (Prims.of_int (61))
-                                               (Prims.of_int (354))
-                                               (Prims.of_int (77)))))
+                                               (Prims.of_int (373))
+                                               (Prims.of_int (65))
+                                               (Prims.of_int (373))
+                                               (Prims.of_int (81)))))
                                       (FStar_Sealed.seal
                                          (Obj.magic
                                             (FStar_Range.mk_range
-                                               "FStar.Issue.fsti"
-                                               (Prims.of_int (49))
-                                               (Prims.of_int (4))
-                                               (Prims.of_int (49))
-                                               (Prims.of_int (65)))))
+                                               "Pulse.Typing.Env.fst"
+                                               (Prims.of_int (373))
+                                               (Prims.of_int (14))
+                                               (Prims.of_int (373))
+                                               (Prims.of_int (81)))))
                                       (Obj.magic (ctxt_to_list g))
                                       (fun uu___ ->
                                          FStar_Tactics_Effect.lift_div_tac
                                            (fun uu___1 ->
                                               FStar_Issue.mk_issue_doc
-                                                "Error"
-                                                [FStar_Pprint.arbitrary_string
-                                                   msg1]
+                                                "Error" msg1
                                                 (FStar_Pervasives_Native.Some
                                                    r1)
                                                 FStar_Pervasives_Native.None
@@ -1009,17 +1296,17 @@ let fail :
                                               (Obj.magic
                                                  (FStar_Range.mk_range
                                                     "Pulse.Typing.Env.fst"
-                                                    (Prims.of_int (355))
+                                                    (Prims.of_int (374))
                                                     (Prims.of_int (2))
-                                                    (Prims.of_int (355))
+                                                    (Prims.of_int (374))
                                                     (Prims.of_int (22)))))
                                            (FStar_Sealed.seal
                                               (Obj.magic
                                                  (FStar_Range.mk_range
                                                     "Pulse.Typing.Env.fst"
-                                                    (Prims.of_int (356))
+                                                    (Prims.of_int (375))
                                                     (Prims.of_int (2))
-                                                    (Prims.of_int (356))
+                                                    (Prims.of_int (375))
                                                     (Prims.of_int (31)))))
                                            (Obj.magic
                                               (FStar_Tactics_V2_Builtins.log_issues
@@ -1028,121 +1315,143 @@ let fail :
                                               FStar_Tactics_V2_Derived.fail
                                                 "Pulse checker failed")))
                                      uu___))) uu___))) uu___)
+let (warn_doc :
+  env ->
+    Pulse_Syntax_Base.range FStar_Pervasives_Native.option ->
+      FStar_Pprint.document Prims.list ->
+        (unit, unit) FStar_Tactics_Effect.tac_repr)
+  =
+  fun g ->
+    fun r ->
+      fun msg ->
+        FStar_Tactics_Effect.tac_bind
+          (FStar_Sealed.seal
+             (Obj.magic
+                (FStar_Range.mk_range "Pulse.Typing.Env.fst"
+                   (Prims.of_int (378)) (Prims.of_int (10))
+                   (Prims.of_int (378)) (Prims.of_int (23)))))
+          (FStar_Sealed.seal
+             (Obj.magic
+                (FStar_Range.mk_range "Pulse.Typing.Env.fst"
+                   (Prims.of_int (378)) (Prims.of_int (26))
+                   (Prims.of_int (380)) (Prims.of_int (22)))))
+          (Obj.magic (get_range g r))
+          (fun uu___ ->
+             (fun r1 ->
+                Obj.magic
+                  (FStar_Tactics_Effect.tac_bind
+                     (FStar_Sealed.seal
+                        (Obj.magic
+                           (FStar_Range.mk_range "Pulse.Typing.Env.fst"
+                              (Prims.of_int (379)) (Prims.of_int (14))
+                              (Prims.of_int (379)) (Prims.of_int (83)))))
+                     (FStar_Sealed.seal
+                        (Obj.magic
+                           (FStar_Range.mk_range "Pulse.Typing.Env.fst"
+                              (Prims.of_int (380)) (Prims.of_int (2))
+                              (Prims.of_int (380)) (Prims.of_int (22)))))
+                     (Obj.magic
+                        (FStar_Tactics_Effect.tac_bind
+                           (FStar_Sealed.seal
+                              (Obj.magic
+                                 (FStar_Range.mk_range "Pulse.Typing.Env.fst"
+                                    (Prims.of_int (379)) (Prims.of_int (67))
+                                    (Prims.of_int (379)) (Prims.of_int (83)))))
+                           (FStar_Sealed.seal
+                              (Obj.magic
+                                 (FStar_Range.mk_range "Pulse.Typing.Env.fst"
+                                    (Prims.of_int (379)) (Prims.of_int (14))
+                                    (Prims.of_int (379)) (Prims.of_int (83)))))
+                           (Obj.magic (ctxt_to_list g))
+                           (fun uu___ ->
+                              FStar_Tactics_Effect.lift_div_tac
+                                (fun uu___1 ->
+                                   FStar_Issue.mk_issue_doc "Warning" msg
+                                     (FStar_Pervasives_Native.Some r1)
+                                     FStar_Pervasives_Native.None uu___))))
+                     (fun uu___ ->
+                        (fun issue ->
+                           Obj.magic
+                             (FStar_Tactics_V2_Builtins.log_issues [issue]))
+                          uu___))) uu___)
+let (info_doc :
+  env ->
+    Pulse_Syntax_Base.range FStar_Pervasives_Native.option ->
+      FStar_Pprint.document Prims.list ->
+        (unit, unit) FStar_Tactics_Effect.tac_repr)
+  =
+  fun g ->
+    fun r ->
+      fun msg ->
+        FStar_Tactics_Effect.tac_bind
+          (FStar_Sealed.seal
+             (Obj.magic
+                (FStar_Range.mk_range "Pulse.Typing.Env.fst"
+                   (Prims.of_int (383)) (Prims.of_int (10))
+                   (Prims.of_int (383)) (Prims.of_int (23)))))
+          (FStar_Sealed.seal
+             (Obj.magic
+                (FStar_Range.mk_range "Pulse.Typing.Env.fst"
+                   (Prims.of_int (383)) (Prims.of_int (26))
+                   (Prims.of_int (385)) (Prims.of_int (22)))))
+          (Obj.magic (get_range g r))
+          (fun uu___ ->
+             (fun r1 ->
+                Obj.magic
+                  (FStar_Tactics_Effect.tac_bind
+                     (FStar_Sealed.seal
+                        (Obj.magic
+                           (FStar_Range.mk_range "Pulse.Typing.Env.fst"
+                              (Prims.of_int (384)) (Prims.of_int (14))
+                              (Prims.of_int (384)) (Prims.of_int (80)))))
+                     (FStar_Sealed.seal
+                        (Obj.magic
+                           (FStar_Range.mk_range "Pulse.Typing.Env.fst"
+                              (Prims.of_int (385)) (Prims.of_int (2))
+                              (Prims.of_int (385)) (Prims.of_int (22)))))
+                     (Obj.magic
+                        (FStar_Tactics_Effect.tac_bind
+                           (FStar_Sealed.seal
+                              (Obj.magic
+                                 (FStar_Range.mk_range "Pulse.Typing.Env.fst"
+                                    (Prims.of_int (384)) (Prims.of_int (64))
+                                    (Prims.of_int (384)) (Prims.of_int (80)))))
+                           (FStar_Sealed.seal
+                              (Obj.magic
+                                 (FStar_Range.mk_range "Pulse.Typing.Env.fst"
+                                    (Prims.of_int (384)) (Prims.of_int (14))
+                                    (Prims.of_int (384)) (Prims.of_int (80)))))
+                           (Obj.magic (ctxt_to_list g))
+                           (fun uu___ ->
+                              FStar_Tactics_Effect.lift_div_tac
+                                (fun uu___1 ->
+                                   FStar_Issue.mk_issue_doc "Info" msg
+                                     (FStar_Pervasives_Native.Some r1)
+                                     FStar_Pervasives_Native.None uu___))))
+                     (fun uu___ ->
+                        (fun issue ->
+                           Obj.magic
+                             (FStar_Tactics_V2_Builtins.log_issues [issue]))
+                          uu___))) uu___)
+let fail :
+  'a .
+    env ->
+      Pulse_Syntax_Base.range FStar_Pervasives_Native.option ->
+        Prims.string -> ('a, unit) FStar_Tactics_Effect.tac_repr
+  =
+  fun g ->
+    fun r -> fun msg -> fail_doc g r [FStar_Pprint.arbitrary_string msg]
 let (warn :
   env ->
     Pulse_Syntax_Base.range FStar_Pervasives_Native.option ->
       Prims.string -> (unit, unit) FStar_Tactics_Effect.tac_repr)
   =
   fun g ->
-    fun r ->
-      fun msg ->
-        FStar_Tactics_Effect.tac_bind
-          (FStar_Sealed.seal
-             (Obj.magic
-                (FStar_Range.mk_range "Pulse.Typing.Env.fst"
-                   (Prims.of_int (359)) (Prims.of_int (10))
-                   (Prims.of_int (359)) (Prims.of_int (23)))))
-          (FStar_Sealed.seal
-             (Obj.magic
-                (FStar_Range.mk_range "Pulse.Typing.Env.fst"
-                   (Prims.of_int (359)) (Prims.of_int (26))
-                   (Prims.of_int (361)) (Prims.of_int (22)))))
-          (Obj.magic (get_range g r))
-          (fun uu___ ->
-             (fun r1 ->
-                Obj.magic
-                  (FStar_Tactics_Effect.tac_bind
-                     (FStar_Sealed.seal
-                        (Obj.magic
-                           (FStar_Range.mk_range "Pulse.Typing.Env.fst"
-                              (Prims.of_int (360)) (Prims.of_int (14))
-                              (Prims.of_int (360)) (Prims.of_int (79)))))
-                     (FStar_Sealed.seal
-                        (Obj.magic
-                           (FStar_Range.mk_range "Pulse.Typing.Env.fst"
-                              (Prims.of_int (361)) (Prims.of_int (2))
-                              (Prims.of_int (361)) (Prims.of_int (22)))))
-                     (Obj.magic
-                        (FStar_Tactics_Effect.tac_bind
-                           (FStar_Sealed.seal
-                              (Obj.magic
-                                 (FStar_Range.mk_range "Pulse.Typing.Env.fst"
-                                    (Prims.of_int (360)) (Prims.of_int (63))
-                                    (Prims.of_int (360)) (Prims.of_int (79)))))
-                           (FStar_Sealed.seal
-                              (Obj.magic
-                                 (FStar_Range.mk_range "FStar.Issue.fsti"
-                                    (Prims.of_int (49)) (Prims.of_int (4))
-                                    (Prims.of_int (49)) (Prims.of_int (65)))))
-                           (Obj.magic (ctxt_to_list g))
-                           (fun uu___ ->
-                              FStar_Tactics_Effect.lift_div_tac
-                                (fun uu___1 ->
-                                   FStar_Issue.mk_issue_doc "Warning"
-                                     [FStar_Pprint.arbitrary_string msg]
-                                     (FStar_Pervasives_Native.Some r1)
-                                     FStar_Pervasives_Native.None uu___))))
-                     (fun uu___ ->
-                        (fun issue ->
-                           Obj.magic
-                             (FStar_Tactics_V2_Builtins.log_issues [issue]))
-                          uu___))) uu___)
+    fun r -> fun msg -> warn_doc g r [FStar_Pprint.arbitrary_string msg]
 let (info :
   env ->
     Pulse_Syntax_Base.range FStar_Pervasives_Native.option ->
       Prims.string -> (unit, unit) FStar_Tactics_Effect.tac_repr)
   =
   fun g ->
-    fun r ->
-      fun msg ->
-        FStar_Tactics_Effect.tac_bind
-          (FStar_Sealed.seal
-             (Obj.magic
-                (FStar_Range.mk_range "Pulse.Typing.Env.fst"
-                   (Prims.of_int (364)) (Prims.of_int (10))
-                   (Prims.of_int (364)) (Prims.of_int (23)))))
-          (FStar_Sealed.seal
-             (Obj.magic
-                (FStar_Range.mk_range "Pulse.Typing.Env.fst"
-                   (Prims.of_int (364)) (Prims.of_int (26))
-                   (Prims.of_int (366)) (Prims.of_int (22)))))
-          (Obj.magic (get_range g r))
-          (fun uu___ ->
-             (fun r1 ->
-                Obj.magic
-                  (FStar_Tactics_Effect.tac_bind
-                     (FStar_Sealed.seal
-                        (Obj.magic
-                           (FStar_Range.mk_range "Pulse.Typing.Env.fst"
-                              (Prims.of_int (365)) (Prims.of_int (14))
-                              (Prims.of_int (365)) (Prims.of_int (76)))))
-                     (FStar_Sealed.seal
-                        (Obj.magic
-                           (FStar_Range.mk_range "Pulse.Typing.Env.fst"
-                              (Prims.of_int (366)) (Prims.of_int (2))
-                              (Prims.of_int (366)) (Prims.of_int (22)))))
-                     (Obj.magic
-                        (FStar_Tactics_Effect.tac_bind
-                           (FStar_Sealed.seal
-                              (Obj.magic
-                                 (FStar_Range.mk_range "Pulse.Typing.Env.fst"
-                                    (Prims.of_int (365)) (Prims.of_int (60))
-                                    (Prims.of_int (365)) (Prims.of_int (76)))))
-                           (FStar_Sealed.seal
-                              (Obj.magic
-                                 (FStar_Range.mk_range "FStar.Issue.fsti"
-                                    (Prims.of_int (49)) (Prims.of_int (4))
-                                    (Prims.of_int (49)) (Prims.of_int (65)))))
-                           (Obj.magic (ctxt_to_list g))
-                           (fun uu___ ->
-                              FStar_Tactics_Effect.lift_div_tac
-                                (fun uu___1 ->
-                                   FStar_Issue.mk_issue_doc "Info"
-                                     [FStar_Pprint.arbitrary_string msg]
-                                     (FStar_Pervasives_Native.Some r1)
-                                     FStar_Pervasives_Native.None uu___))))
-                     (fun uu___ ->
-                        (fun issue ->
-                           Obj.magic
-                             (FStar_Tactics_V2_Builtins.log_issues [issue]))
-                          uu___))) uu___)
+    fun r -> fun msg -> info_doc g r [FStar_Pprint.arbitrary_string msg]

--- a/src/ocaml/plugin/generated/Pulse_Typing_Env.ml
+++ b/src/ocaml/plugin/generated/Pulse_Typing_Env.ml
@@ -943,7 +943,7 @@ let (env_to_doc :
       (FStar_Sealed.seal
          (Obj.magic
             (FStar_Range.mk_range "Pulse.Typing.Env.fst" (Prims.of_int (352))
-               (Prims.of_int (4)) (Prims.of_int (354)) (Prims.of_int (45)))))
+               (Prims.of_int (4)) (Prims.of_int (354)) (Prims.of_int (68)))))
       (FStar_Sealed.seal
          (Obj.magic
             (FStar_Range.mk_range "Pulse.Typing.Env.fst" (Prims.of_int (356))
@@ -963,7 +963,7 @@ let (env_to_doc :
                        (Obj.magic
                           (FStar_Range.mk_range "Pulse.Typing.Env.fst"
                              (Prims.of_int (353)) (Prims.of_int (6))
-                             (Prims.of_int (354)) (Prims.of_int (45)))))
+                             (Prims.of_int (354)) (Prims.of_int (68)))))
                     (Obj.magic
                        (FStar_Tactics_Effect.tac_bind
                           (FStar_Sealed.seal
@@ -994,7 +994,7 @@ let (env_to_doc :
                                         (Prims.of_int (353))
                                         (Prims.of_int (41))
                                         (Prims.of_int (354))
-                                        (Prims.of_int (45)))))
+                                        (Prims.of_int (68)))))
                                (FStar_Sealed.seal
                                   (Obj.magic
                                      (FStar_Range.mk_range
@@ -1002,7 +1002,7 @@ let (env_to_doc :
                                         (Prims.of_int (353))
                                         (Prims.of_int (6))
                                         (Prims.of_int (354))
-                                        (Prims.of_int (45)))))
+                                        (Prims.of_int (68)))))
                                (Obj.magic
                                   (FStar_Tactics_Effect.tac_bind
                                      (FStar_Sealed.seal
@@ -1012,7 +1012,7 @@ let (env_to_doc :
                                               (Prims.of_int (353))
                                               (Prims.of_int (62))
                                               (Prims.of_int (354))
-                                              (Prims.of_int (45)))))
+                                              (Prims.of_int (68)))))
                                      (FStar_Sealed.seal
                                         (Obj.magic
                                            (FStar_Range.mk_range
@@ -1020,7 +1020,7 @@ let (env_to_doc :
                                               (Prims.of_int (353))
                                               (Prims.of_int (41))
                                               (Prims.of_int (354))
-                                              (Prims.of_int (45)))))
+                                              (Prims.of_int (68)))))
                                      (Obj.magic
                                         (FStar_Tactics_Effect.tac_bind
                                            (FStar_Sealed.seal
@@ -1030,7 +1030,7 @@ let (env_to_doc :
                                                     (Prims.of_int (354))
                                                     (Prims.of_int (11))
                                                     (Prims.of_int (354))
-                                                    (Prims.of_int (45)))))
+                                                    (Prims.of_int (68)))))
                                            (FStar_Sealed.seal
                                               (Obj.magic
                                                  (FStar_Range.mk_range
@@ -1038,10 +1038,34 @@ let (env_to_doc :
                                                     (Prims.of_int (353))
                                                     (Prims.of_int (62))
                                                     (Prims.of_int (354))
-                                                    (Prims.of_int (45)))))
+                                                    (Prims.of_int (68)))))
                                            (Obj.magic
-                                              (Pulse_Syntax_Printer.term_to_doc
-                                                 t))
+                                              (FStar_Tactics_Effect.tac_bind
+                                                 (FStar_Sealed.seal
+                                                    (Obj.magic
+                                                       (FStar_Range.mk_range
+                                                          "Pulse.Typing.Env.fst"
+                                                          (Prims.of_int (354))
+                                                          (Prims.of_int (34))
+                                                          (Prims.of_int (354))
+                                                          (Prims.of_int (68)))))
+                                                 (FStar_Sealed.seal
+                                                    (Obj.magic
+                                                       (FStar_Range.mk_range
+                                                          "Pulse.Typing.Env.fst"
+                                                          (Prims.of_int (354))
+                                                          (Prims.of_int (11))
+                                                          (Prims.of_int (354))
+                                                          (Prims.of_int (68)))))
+                                                 (Obj.magic
+                                                    (Pulse_Syntax_Printer.term_to_doc
+                                                       t))
+                                                 (fun uu___3 ->
+                                                    FStar_Tactics_Effect.lift_div_tac
+                                                      (fun uu___4 ->
+                                                         FStar_Pprint.op_Hat_Hat
+                                                           (FStar_Pprint.doc_of_string
+                                                              " : ") uu___3))))
                                            (fun uu___3 ->
                                               FStar_Tactics_Effect.lift_div_tac
                                                 (fun uu___4 ->
@@ -1147,7 +1171,7 @@ let fail_doc :
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Typing.Env.fst"
                    (Prims.of_int (367)) (Prims.of_int (26))
-                   (Prims.of_int (375)) (Prims.of_int (31)))))
+                   (Prims.of_int (376)) (Prims.of_int (31)))))
           (Obj.magic (get_range g r))
           (fun uu___ ->
              (fun r1 ->
@@ -1156,107 +1180,167 @@ let fail_doc :
                      (FStar_Sealed.seal
                         (Obj.magic
                            (FStar_Range.mk_range "Pulse.Typing.Env.fst"
-                              (Prims.of_int (369)) (Prims.of_int (4))
-                              (Prims.of_int (371)) (Prims.of_int (12)))))
+                              (Prims.of_int (368)) (Prims.of_int (11))
+                              (Prims.of_int (372)) (Prims.of_int (12)))))
                      (FStar_Sealed.seal
                         (Obj.magic
                            (FStar_Range.mk_range "Pulse.Typing.Env.fst"
-                              (Prims.of_int (372)) (Prims.of_int (4))
-                              (Prims.of_int (375)) (Prims.of_int (31)))))
+                              (Prims.of_int (373)) (Prims.of_int (4))
+                              (Prims.of_int (376)) (Prims.of_int (31)))))
                      (Obj.magic
                         (FStar_Tactics_Effect.tac_bind
                            (FStar_Sealed.seal
                               (Obj.magic
                                  (FStar_Range.mk_range "Pulse.Typing.Env.fst"
-                                    (Prims.of_int (369)) (Prims.of_int (7))
-                                    (Prims.of_int (369)) (Prims.of_int (43)))))
+                                    (Prims.of_int (369)) (Prims.of_int (19))
+                                    (Prims.of_int (369)) (Prims.of_int (47)))))
                            (FStar_Sealed.seal
                               (Obj.magic
                                  (FStar_Range.mk_range "Pulse.Typing.Env.fst"
-                                    (Prims.of_int (369)) (Prims.of_int (4))
-                                    (Prims.of_int (371)) (Prims.of_int (12)))))
-                           (Obj.magic (Pulse_Config.debug_flag "env_on_err"))
-                           (fun uu___ ->
+                                    (Prims.of_int (370)) (Prims.of_int (4))
+                                    (Prims.of_int (372)) (Prims.of_int (12)))))
+                           (FStar_Tactics_Effect.lift_div_tac
                               (fun uu___ ->
-                                 if uu___
-                                 then
-                                   Obj.magic
-                                     (Obj.repr
-                                        (FStar_Tactics_Effect.tac_bind
-                                           (FStar_Sealed.seal
-                                              (Obj.magic
-                                                 (FStar_Range.mk_range
-                                                    "Pulse.Typing.Env.fst"
-                                                    (Prims.of_int (370))
-                                                    (Prims.of_int (15))
-                                                    (Prims.of_int (370))
-                                                    (Prims.of_int (64)))))
-                                           (FStar_Sealed.seal
-                                              (Obj.magic
-                                                 (FStar_Range.mk_range
-                                                    "Pulse.Typing.Env.fst"
-                                                    (Prims.of_int (370))
-                                                    (Prims.of_int (9))
-                                                    (Prims.of_int (370))
-                                                    (Prims.of_int (64)))))
-                                           (Obj.magic
-                                              (FStar_Tactics_Effect.tac_bind
-                                                 (FStar_Sealed.seal
-                                                    (Obj.magic
-                                                       (FStar_Range.mk_range
-                                                          "Pulse.Typing.Env.fst"
-                                                          (Prims.of_int (370))
-                                                          (Prims.of_int (16))
-                                                          (Prims.of_int (370))
-                                                          (Prims.of_int (63)))))
-                                                 (FStar_Sealed.seal
-                                                    (Obj.magic
-                                                       (FStar_Range.mk_range
-                                                          "Pulse.Typing.Env.fst"
-                                                          (Prims.of_int (370))
-                                                          (Prims.of_int (15))
-                                                          (Prims.of_int (370))
-                                                          (Prims.of_int (64)))))
-                                                 (Obj.magic
-                                                    (FStar_Tactics_Effect.tac_bind
-                                                       (FStar_Sealed.seal
-                                                          (Obj.magic
-                                                             (FStar_Range.mk_range
-                                                                "Pulse.Typing.Env.fst"
-                                                                (Prims.of_int (370))
-                                                                (Prims.of_int (51))
-                                                                (Prims.of_int (370))
-                                                                (Prims.of_int (63)))))
-                                                       (FStar_Sealed.seal
-                                                          (Obj.magic
-                                                             (FStar_Range.mk_range
-                                                                "Pulse.Typing.Env.fst"
-                                                                (Prims.of_int (370))
-                                                                (Prims.of_int (16))
-                                                                (Prims.of_int (370))
-                                                                (Prims.of_int (63)))))
-                                                       (Obj.magic
-                                                          (env_to_doc g))
-                                                       (fun uu___1 ->
-                                                          FStar_Tactics_Effect.lift_div_tac
-                                                            (fun uu___2 ->
-                                                               FStar_Pprint.op_Hat_Slash_Hat
-                                                                 (FStar_Pprint.doc_of_string
-                                                                    "In environment")
-                                                                 uu___1))))
-                                                 (fun uu___1 ->
-                                                    FStar_Tactics_Effect.lift_div_tac
-                                                      (fun uu___2 -> [uu___1]))))
-                                           (fun uu___1 ->
-                                              FStar_Tactics_Effect.lift_div_tac
-                                                (fun uu___2 ->
-                                                   FStar_List_Tot_Base.op_At
-                                                     msg uu___1))))
-                                 else
-                                   Obj.magic
-                                     (Obj.repr
-                                        (FStar_Tactics_Effect.lift_div_tac
-                                           (fun uu___2 -> msg)))) uu___)))
+                                 fun d ->
+                                   FStar_Pprint.nest (Prims.of_int (2))
+                                     (FStar_Pprint.op_Hat_Hat
+                                        FStar_Pprint.hardline
+                                        (FStar_Pprint.align d))))
+                           (fun uu___ ->
+                              (fun indent ->
+                                 Obj.magic
+                                   (FStar_Tactics_Effect.tac_bind
+                                      (FStar_Sealed.seal
+                                         (Obj.magic
+                                            (FStar_Range.mk_range
+                                               "Pulse.Typing.Env.fst"
+                                               (Prims.of_int (370))
+                                               (Prims.of_int (7))
+                                               (Prims.of_int (370))
+                                               (Prims.of_int (43)))))
+                                      (FStar_Sealed.seal
+                                         (Obj.magic
+                                            (FStar_Range.mk_range
+                                               "Pulse.Typing.Env.fst"
+                                               (Prims.of_int (370))
+                                               (Prims.of_int (4))
+                                               (Prims.of_int (372))
+                                               (Prims.of_int (12)))))
+                                      (Obj.magic
+                                         (Pulse_Config.debug_flag
+                                            "env_on_err"))
+                                      (fun uu___ ->
+                                         (fun uu___ ->
+                                            if uu___
+                                            then
+                                              Obj.magic
+                                                (Obj.repr
+                                                   (FStar_Tactics_Effect.tac_bind
+                                                      (FStar_Sealed.seal
+                                                         (Obj.magic
+                                                            (FStar_Range.mk_range
+                                                               "Pulse.Typing.Env.fst"
+                                                               (Prims.of_int (371))
+                                                               (Prims.of_int (15))
+                                                               (Prims.of_int (371))
+                                                               (Prims.of_int (80)))))
+                                                      (FStar_Sealed.seal
+                                                         (Obj.magic
+                                                            (FStar_Range.mk_range
+                                                               "Pulse.Typing.Env.fst"
+                                                               (Prims.of_int (371))
+                                                               (Prims.of_int (9))
+                                                               (Prims.of_int (371))
+                                                               (Prims.of_int (80)))))
+                                                      (Obj.magic
+                                                         (FStar_Tactics_Effect.tac_bind
+                                                            (FStar_Sealed.seal
+                                                               (Obj.magic
+                                                                  (FStar_Range.mk_range
+                                                                    "Pulse.Typing.Env.fst"
+                                                                    (Prims.of_int (371))
+                                                                    (Prims.of_int (16))
+                                                                    (Prims.of_int (371))
+                                                                    (Prims.of_int (79)))))
+                                                            (FStar_Sealed.seal
+                                                               (Obj.magic
+                                                                  (FStar_Range.mk_range
+                                                                    "Pulse.Typing.Env.fst"
+                                                                    (Prims.of_int (371))
+                                                                    (Prims.of_int (15))
+                                                                    (Prims.of_int (371))
+                                                                    (Prims.of_int (80)))))
+                                                            (Obj.magic
+                                                               (FStar_Tactics_Effect.tac_bind
+                                                                  (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Typing.Env.fst"
+                                                                    (Prims.of_int (371))
+                                                                    (Prims.of_int (58))
+                                                                    (Prims.of_int (371))
+                                                                    (Prims.of_int (79)))))
+                                                                  (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Typing.Env.fst"
+                                                                    (Prims.of_int (371))
+                                                                    (Prims.of_int (16))
+                                                                    (Prims.of_int (371))
+                                                                    (Prims.of_int (79)))))
+                                                                  (Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Typing.Env.fst"
+                                                                    (Prims.of_int (371))
+                                                                    (Prims.of_int (65))
+                                                                    (Prims.of_int (371))
+                                                                    (Prims.of_int (79)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Typing.Env.fst"
+                                                                    (Prims.of_int (371))
+                                                                    (Prims.of_int (58))
+                                                                    (Prims.of_int (371))
+                                                                    (Prims.of_int (79)))))
+                                                                    (Obj.magic
+                                                                    (env_to_doc
+                                                                    g))
+                                                                    (fun
+                                                                    uu___1 ->
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___2 ->
+                                                                    indent
+                                                                    uu___1))))
+                                                                  (fun uu___1
+                                                                    ->
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___2 ->
+                                                                    FStar_Pprint.op_Hat_Hat
+                                                                    (FStar_Pprint.doc_of_string
+                                                                    "In typing environment:")
+                                                                    uu___1))))
+                                                            (fun uu___1 ->
+                                                               FStar_Tactics_Effect.lift_div_tac
+                                                                 (fun uu___2
+                                                                    ->
+                                                                    [uu___1]))))
+                                                      (fun uu___1 ->
+                                                         FStar_Tactics_Effect.lift_div_tac
+                                                           (fun uu___2 ->
+                                                              FStar_List_Tot_Base.op_At
+                                                                msg uu___1))))
+                                            else
+                                              Obj.magic
+                                                (Obj.repr
+                                                   (FStar_Tactics_Effect.lift_div_tac
+                                                      (fun uu___2 -> msg))))
+                                           uu___))) uu___)))
                      (fun uu___ ->
                         (fun msg1 ->
                            Obj.magic
@@ -1265,17 +1349,17 @@ let fail_doc :
                                    (Obj.magic
                                       (FStar_Range.mk_range
                                          "Pulse.Typing.Env.fst"
-                                         (Prims.of_int (373))
+                                         (Prims.of_int (374))
                                          (Prims.of_int (14))
-                                         (Prims.of_int (373))
+                                         (Prims.of_int (374))
                                          (Prims.of_int (81)))))
                                 (FStar_Sealed.seal
                                    (Obj.magic
                                       (FStar_Range.mk_range
                                          "Pulse.Typing.Env.fst"
-                                         (Prims.of_int (374))
-                                         (Prims.of_int (2))
                                          (Prims.of_int (375))
+                                         (Prims.of_int (2))
+                                         (Prims.of_int (376))
                                          (Prims.of_int (31)))))
                                 (Obj.magic
                                    (FStar_Tactics_Effect.tac_bind
@@ -1283,17 +1367,17 @@ let fail_doc :
                                          (Obj.magic
                                             (FStar_Range.mk_range
                                                "Pulse.Typing.Env.fst"
-                                               (Prims.of_int (373))
+                                               (Prims.of_int (374))
                                                (Prims.of_int (65))
-                                               (Prims.of_int (373))
+                                               (Prims.of_int (374))
                                                (Prims.of_int (81)))))
                                       (FStar_Sealed.seal
                                          (Obj.magic
                                             (FStar_Range.mk_range
                                                "Pulse.Typing.Env.fst"
-                                               (Prims.of_int (373))
+                                               (Prims.of_int (374))
                                                (Prims.of_int (14))
-                                               (Prims.of_int (373))
+                                               (Prims.of_int (374))
                                                (Prims.of_int (81)))))
                                       (Obj.magic (ctxt_to_list g))
                                       (fun uu___ ->
@@ -1313,17 +1397,17 @@ let fail_doc :
                                               (Obj.magic
                                                  (FStar_Range.mk_range
                                                     "Pulse.Typing.Env.fst"
-                                                    (Prims.of_int (374))
+                                                    (Prims.of_int (375))
                                                     (Prims.of_int (2))
-                                                    (Prims.of_int (374))
+                                                    (Prims.of_int (375))
                                                     (Prims.of_int (22)))))
                                            (FStar_Sealed.seal
                                               (Obj.magic
                                                  (FStar_Range.mk_range
                                                     "Pulse.Typing.Env.fst"
-                                                    (Prims.of_int (375))
+                                                    (Prims.of_int (376))
                                                     (Prims.of_int (2))
-                                                    (Prims.of_int (375))
+                                                    (Prims.of_int (376))
                                                     (Prims.of_int (31)))))
                                            (Obj.magic
                                               (FStar_Tactics_V2_Builtins.log_issues
@@ -1345,13 +1429,13 @@ let (warn_doc :
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Typing.Env.fst"
-                   (Prims.of_int (378)) (Prims.of_int (10))
-                   (Prims.of_int (378)) (Prims.of_int (23)))))
+                   (Prims.of_int (379)) (Prims.of_int (10))
+                   (Prims.of_int (379)) (Prims.of_int (23)))))
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Typing.Env.fst"
-                   (Prims.of_int (378)) (Prims.of_int (26))
-                   (Prims.of_int (380)) (Prims.of_int (22)))))
+                   (Prims.of_int (379)) (Prims.of_int (26))
+                   (Prims.of_int (381)) (Prims.of_int (22)))))
           (Obj.magic (get_range g r))
           (fun uu___ ->
              (fun r1 ->
@@ -1360,25 +1444,25 @@ let (warn_doc :
                      (FStar_Sealed.seal
                         (Obj.magic
                            (FStar_Range.mk_range "Pulse.Typing.Env.fst"
-                              (Prims.of_int (379)) (Prims.of_int (14))
-                              (Prims.of_int (379)) (Prims.of_int (83)))))
+                              (Prims.of_int (380)) (Prims.of_int (14))
+                              (Prims.of_int (380)) (Prims.of_int (83)))))
                      (FStar_Sealed.seal
                         (Obj.magic
                            (FStar_Range.mk_range "Pulse.Typing.Env.fst"
-                              (Prims.of_int (380)) (Prims.of_int (2))
-                              (Prims.of_int (380)) (Prims.of_int (22)))))
+                              (Prims.of_int (381)) (Prims.of_int (2))
+                              (Prims.of_int (381)) (Prims.of_int (22)))))
                      (Obj.magic
                         (FStar_Tactics_Effect.tac_bind
                            (FStar_Sealed.seal
                               (Obj.magic
                                  (FStar_Range.mk_range "Pulse.Typing.Env.fst"
-                                    (Prims.of_int (379)) (Prims.of_int (67))
-                                    (Prims.of_int (379)) (Prims.of_int (83)))))
+                                    (Prims.of_int (380)) (Prims.of_int (67))
+                                    (Prims.of_int (380)) (Prims.of_int (83)))))
                            (FStar_Sealed.seal
                               (Obj.magic
                                  (FStar_Range.mk_range "Pulse.Typing.Env.fst"
-                                    (Prims.of_int (379)) (Prims.of_int (14))
-                                    (Prims.of_int (379)) (Prims.of_int (83)))))
+                                    (Prims.of_int (380)) (Prims.of_int (14))
+                                    (Prims.of_int (380)) (Prims.of_int (83)))))
                            (Obj.magic (ctxt_to_list g))
                            (fun uu___ ->
                               FStar_Tactics_Effect.lift_div_tac
@@ -1404,13 +1488,13 @@ let (info_doc :
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Typing.Env.fst"
-                   (Prims.of_int (383)) (Prims.of_int (10))
-                   (Prims.of_int (383)) (Prims.of_int (23)))))
+                   (Prims.of_int (384)) (Prims.of_int (10))
+                   (Prims.of_int (384)) (Prims.of_int (23)))))
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Typing.Env.fst"
-                   (Prims.of_int (383)) (Prims.of_int (26))
-                   (Prims.of_int (385)) (Prims.of_int (22)))))
+                   (Prims.of_int (384)) (Prims.of_int (26))
+                   (Prims.of_int (386)) (Prims.of_int (22)))))
           (Obj.magic (get_range g r))
           (fun uu___ ->
              (fun r1 ->
@@ -1419,25 +1503,25 @@ let (info_doc :
                      (FStar_Sealed.seal
                         (Obj.magic
                            (FStar_Range.mk_range "Pulse.Typing.Env.fst"
-                              (Prims.of_int (384)) (Prims.of_int (14))
-                              (Prims.of_int (384)) (Prims.of_int (80)))))
+                              (Prims.of_int (385)) (Prims.of_int (14))
+                              (Prims.of_int (385)) (Prims.of_int (80)))))
                      (FStar_Sealed.seal
                         (Obj.magic
                            (FStar_Range.mk_range "Pulse.Typing.Env.fst"
-                              (Prims.of_int (385)) (Prims.of_int (2))
-                              (Prims.of_int (385)) (Prims.of_int (22)))))
+                              (Prims.of_int (386)) (Prims.of_int (2))
+                              (Prims.of_int (386)) (Prims.of_int (22)))))
                      (Obj.magic
                         (FStar_Tactics_Effect.tac_bind
                            (FStar_Sealed.seal
                               (Obj.magic
                                  (FStar_Range.mk_range "Pulse.Typing.Env.fst"
-                                    (Prims.of_int (384)) (Prims.of_int (64))
-                                    (Prims.of_int (384)) (Prims.of_int (80)))))
+                                    (Prims.of_int (385)) (Prims.of_int (64))
+                                    (Prims.of_int (385)) (Prims.of_int (80)))))
                            (FStar_Sealed.seal
                               (Obj.magic
                                  (FStar_Range.mk_range "Pulse.Typing.Env.fst"
-                                    (Prims.of_int (384)) (Prims.of_int (14))
-                                    (Prims.of_int (384)) (Prims.of_int (80)))))
+                                    (Prims.of_int (385)) (Prims.of_int (14))
+                                    (Prims.of_int (385)) (Prims.of_int (80)))))
                            (Obj.magic (ctxt_to_list g))
                            (fun uu___ ->
                               FStar_Tactics_Effect.lift_div_tac


### PR DESCRIPTION
This PR makes Pulse use the new error doc framework in F*, and improves the two most common errors with it: 'cannot prove vprop' and 'unmatched vprop in post'. See this example from `L0Crypto.fst`

Trying to free something twice:
<img width="509" alt="Screenshot 2023-09-18 173905" src="https://github.com/FStarLang/steel/assets/4195583/60c85016-b042-4da6-9404-b73a92c0f231">

Forgetting to free something:
<img width="481" alt="Screenshot 2023-09-18 174707" src="https://github.com/FStarLang/steel/assets/4195583/18a89421-6e55-42d4-a65f-33fb460cebfa">
