### PR TITLE
Improving error localization in typechecker callbacks

### DIFF
--- a/lib/steel/pulse/Pulse.RuntimeUtils.fsti
+++ b/lib/steel/pulse/Pulse.RuntimeUtils.fsti
@@ -40,4 +40,4 @@ val deep_compress (t:T.term) : r:T.term { t == r }
    nodes. If and when that is fixed, we should remove this function *)
 val deep_transform_to_unary_applications (t:T.term) : r:T.term { t == r }
 val map_seal (s:FStar.Sealed.sealed 't) (f: 't -> 'u) : FStar.Sealed.sealed 'u
-      
+val float_one : FStar.Float.float

--- a/src/ocaml/plugin/Pulse_RuntimeUtils.ml
+++ b/src/ocaml/plugin/Pulse_RuntimeUtils.ml
@@ -67,3 +67,4 @@ let deep_transform_to_unary_applications (t:S.term) =
 
 let deep_compress (t:S.term) = FStar_Syntax_Compress.deep_compress_uvars t
 let map_seal (t:'a) (f:'a -> 'b) : 'b = f t
+let float_one = FStar_Compiler_Util.float_of_string "1.0"

--- a/src/ocaml/plugin/generated/Pulse_Checker_Abs.ml
+++ b/src/ocaml/plugin/generated/Pulse_Checker_Abs.ml
@@ -1,4 +1,16 @@
 open Prims
+let (range_of_st_comp : Pulse_Syntax_Base.st_comp -> FStar_Range.range) =
+  fun st ->
+    Pulse_RuntimeUtils.union_ranges
+      (st.Pulse_Syntax_Base.pre).Pulse_Syntax_Base.range1
+      (st.Pulse_Syntax_Base.post).Pulse_Syntax_Base.range1
+let (range_of_comp : Pulse_Syntax_Base.comp -> FStar_Range.range) =
+  fun c ->
+    match c with
+    | Pulse_Syntax_Base.C_Tot t -> t.Pulse_Syntax_Base.range1
+    | Pulse_Syntax_Base.C_ST st -> range_of_st_comp st
+    | Pulse_Syntax_Base.C_STAtomic (uu___, st) -> range_of_st_comp st
+    | Pulse_Syntax_Base.C_STGhost (uu___, st) -> range_of_st_comp st
 let rec (arrow_of_abs :
   Pulse_Syntax_Base.st_term ->
     (Pulse_Syntax_Base.term, unit) FStar_Tactics_Effect.tac_repr)
@@ -7,12 +19,12 @@ let rec (arrow_of_abs :
     FStar_Tactics_Effect.tac_bind
       (FStar_Sealed.seal
          (Obj.magic
-            (FStar_Range.mk_range "Pulse.Checker.Abs.fst" (Prims.of_int (19))
-               (Prims.of_int (44)) (Prims.of_int (19)) (Prims.of_int (50)))))
+            (FStar_Range.mk_range "Pulse.Checker.Abs.fst" (Prims.of_int (30))
+               (Prims.of_int (44)) (Prims.of_int (30)) (Prims.of_int (50)))))
       (FStar_Sealed.seal
          (Obj.magic
-            (FStar_Range.mk_range "Pulse.Checker.Abs.fst" (Prims.of_int (19))
-               (Prims.of_int (3)) (Prims.of_int (26)) (Prims.of_int (29)))))
+            (FStar_Range.mk_range "Pulse.Checker.Abs.fst" (Prims.of_int (30))
+               (Prims.of_int (3)) (Prims.of_int (38)) (Prims.of_int (5)))))
       (FStar_Tactics_Effect.lift_div_tac
          (fun uu___ -> t.Pulse_Syntax_Base.term1))
       (fun uu___ ->
@@ -33,26 +45,39 @@ let rec (arrow_of_abs :
                           (FStar_Sealed.seal
                              (Obj.magic
                                 (FStar_Range.mk_range "Pulse.Checker.Abs.fst"
-                                   (Prims.of_int (22)) (Prims.of_int (16))
-                                   (Prims.of_int (22)) (Prims.of_int (33)))))
+                                   (Prims.of_int (33)) (Prims.of_int (16))
+                                   (Prims.of_int (33)) (Prims.of_int (33)))))
                           (FStar_Sealed.seal
                              (Obj.magic
                                 (FStar_Range.mk_range "Pulse.Checker.Abs.fst"
-                                   (Prims.of_int (23)) (Prims.of_int (6))
-                                   (Prims.of_int (23)) (Prims.of_int (30)))))
+                                   (Prims.of_int (34)) (Prims.of_int (8))
+                                   (Prims.of_int (34)) (Prims.of_int (89)))))
                           (Obj.magic (arrow_of_abs body))
                           (fun arr ->
                              FStar_Tactics_Effect.lift_div_tac
                                (fun uu___1 ->
-                                  Pulse_Syntax_Pure.tm_arrow b q
-                                    (Pulse_Syntax_Base.C_Tot arr)))))
+                                  {
+                                    Pulse_Syntax_Base.t =
+                                      ((Pulse_Syntax_Pure.tm_arrow b q
+                                          (Pulse_Syntax_Base.C_Tot arr)).Pulse_Syntax_Base.t);
+                                    Pulse_Syntax_Base.range1 =
+                                      (Pulse_RuntimeUtils.union_ranges
+                                         (b.Pulse_Syntax_Base.binder_ty).Pulse_Syntax_Base.range1
+                                         arr.Pulse_Syntax_Base.range1)
+                                  }))))
                 else
                   Obj.magic
                     (Obj.repr
                        (FStar_Tactics_Effect.lift_div_tac
                           (fun uu___2 ->
-                             Pulse_Syntax_Pure.tm_arrow b q ascription))))
-           uu___)
+                             {
+                               Pulse_Syntax_Base.t =
+                                 ((Pulse_Syntax_Pure.tm_arrow b q ascription).Pulse_Syntax_Base.t);
+                               Pulse_Syntax_Base.range1 =
+                                 (Pulse_RuntimeUtils.union_ranges
+                                    (b.Pulse_Syntax_Base.binder_ty).Pulse_Syntax_Base.range1
+                                    (range_of_comp ascription))
+                             })))) uu___)
 let rec (rebuild_abs :
   Pulse_Typing_Env.env ->
     Pulse_Syntax_Base.st_term ->
@@ -74,13 +99,13 @@ let rec (rebuild_abs :
               (FStar_Sealed.seal
                  (Obj.magic
                     (FStar_Range.mk_range "Pulse.Checker.Abs.fst"
-                       (Prims.of_int (33)) (Prims.of_int (15))
-                       (Prims.of_int (33)) (Prims.of_int (53)))))
+                       (Prims.of_int (45)) (Prims.of_int (15))
+                       (Prims.of_int (45)) (Prims.of_int (53)))))
               (FStar_Sealed.seal
                  (Obj.magic
                     (FStar_Range.mk_range "Pulse.Checker.Abs.fst"
-                       (Prims.of_int (33)) (Prims.of_int (56))
-                       (Prims.of_int (43)) (Prims.of_int (41)))))
+                       (Prims.of_int (45)) (Prims.of_int (56))
+                       (Prims.of_int (55)) (Prims.of_int (41)))))
               (FStar_Tactics_Effect.lift_div_tac
                  (fun uu___ ->
                     Pulse_Readback.readback_ty
@@ -92,13 +117,13 @@ let rec (rebuild_abs :
                          (FStar_Sealed.seal
                             (Obj.magic
                                (FStar_Range.mk_range "Pulse.Checker.Abs.fst"
-                                  (Prims.of_int (34)) (Prims.of_int (17))
-                                  (Prims.of_int (34)) (Prims.of_int (34)))))
+                                  (Prims.of_int (46)) (Prims.of_int (17))
+                                  (Prims.of_int (46)) (Prims.of_int (34)))))
                          (FStar_Sealed.seal
                             (Obj.magic
                                (FStar_Range.mk_range "Pulse.Checker.Abs.fst"
-                                  (Prims.of_int (35)) (Prims.of_int (6))
-                                  (Prims.of_int (43)) (Prims.of_int (41)))))
+                                  (Prims.of_int (47)) (Prims.of_int (6))
+                                  (Prims.of_int (55)) (Prims.of_int (41)))))
                          (FStar_Tactics_Effect.lift_div_tac
                             (fun uu___ ->
                                FStar_Reflection_V2_Builtins.inspect_comp c'))
@@ -113,17 +138,17 @@ let rec (rebuild_abs :
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.Checker.Abs.fst"
-                                                 (Prims.of_int (37))
+                                                 (Prims.of_int (49))
                                                  (Prims.of_int (18))
-                                                 (Prims.of_int (37))
+                                                 (Prims.of_int (49))
                                                  (Prims.of_int (66)))))
                                         (FStar_Sealed.seal
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.Checker.Abs.fst"
-                                                 (Prims.of_int (37))
+                                                 (Prims.of_int (49))
                                                  (Prims.of_int (71))
-                                                 (Prims.of_int (39))
+                                                 (Prims.of_int (51))
                                                  (Prims.of_int (67)))))
                                         (FStar_Tactics_Effect.lift_div_tac
                                            (fun uu___ ->
@@ -142,17 +167,17 @@ let rec (rebuild_abs :
                                                       (Obj.magic
                                                          (FStar_Range.mk_range
                                                             "Pulse.Checker.Abs.fst"
-                                                            (Prims.of_int (38))
+                                                            (Prims.of_int (50))
                                                             (Prims.of_int (19))
-                                                            (Prims.of_int (38))
+                                                            (Prims.of_int (50))
                                                             (Prims.of_int (44)))))
                                                    (FStar_Sealed.seal
                                                       (Obj.magic
                                                          (FStar_Range.mk_range
                                                             "Pulse.Checker.Abs.fst"
-                                                            (Prims.of_int (39))
+                                                            (Prims.of_int (51))
                                                             (Prims.of_int (10))
-                                                            (Prims.of_int (39))
+                                                            (Prims.of_int (51))
                                                             (Prims.of_int (66)))))
                                                    (Obj.magic
                                                       (rebuild_abs g body
@@ -190,17 +215,17 @@ let rec (rebuild_abs :
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.Checker.Abs.fst"
-                                                 (Prims.of_int (42))
+                                                 (Prims.of_int (54))
                                                  (Prims.of_int (12))
-                                                 (Prims.of_int (43))
+                                                 (Prims.of_int (55))
                                                  (Prims.of_int (41)))))
                                         (FStar_Sealed.seal
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.Checker.Abs.fst"
-                                                 (Prims.of_int (41))
+                                                 (Prims.of_int (53))
                                                  (Prims.of_int (8))
-                                                 (Prims.of_int (43))
+                                                 (Prims.of_int (55))
                                                  (Prims.of_int (41)))))
                                         (Obj.magic
                                            (FStar_Tactics_Effect.tac_bind
@@ -208,9 +233,9 @@ let rec (rebuild_abs :
                                                  (Obj.magic
                                                     (FStar_Range.mk_range
                                                        "Pulse.Checker.Abs.fst"
-                                                       (Prims.of_int (43))
+                                                       (Prims.of_int (55))
                                                        (Prims.of_int (16))
-                                                       (Prims.of_int (43))
+                                                       (Prims.of_int (55))
                                                        (Prims.of_int (40)))))
                                               (FStar_Sealed.seal
                                                  (Obj.magic
@@ -247,13 +272,13 @@ let rec (rebuild_abs :
               (FStar_Sealed.seal
                  (Obj.magic
                     (FStar_Range.mk_range "Pulse.Checker.Abs.fst"
-                       (Prims.of_int (46)) (Prims.of_int (15))
-                       (Prims.of_int (46)) (Prims.of_int (53)))))
+                       (Prims.of_int (58)) (Prims.of_int (15))
+                       (Prims.of_int (58)) (Prims.of_int (53)))))
               (FStar_Sealed.seal
                  (Obj.magic
                     (FStar_Range.mk_range "Pulse.Checker.Abs.fst"
-                       (Prims.of_int (46)) (Prims.of_int (56))
-                       (Prims.of_int (63)) (Prims.of_int (51)))))
+                       (Prims.of_int (58)) (Prims.of_int (56))
+                       (Prims.of_int (75)) (Prims.of_int (51)))))
               (FStar_Tactics_Effect.lift_div_tac
                  (fun uu___1 ->
                     Pulse_Readback.readback_ty
@@ -265,13 +290,13 @@ let rec (rebuild_abs :
                          (FStar_Sealed.seal
                             (Obj.magic
                                (FStar_Range.mk_range "Pulse.Checker.Abs.fst"
-                                  (Prims.of_int (47)) (Prims.of_int (17))
-                                  (Prims.of_int (47)) (Prims.of_int (34)))))
+                                  (Prims.of_int (59)) (Prims.of_int (17))
+                                  (Prims.of_int (59)) (Prims.of_int (34)))))
                          (FStar_Sealed.seal
                             (Obj.magic
                                (FStar_Range.mk_range "Pulse.Checker.Abs.fst"
-                                  (Prims.of_int (48)) (Prims.of_int (6))
-                                  (Prims.of_int (63)) (Prims.of_int (51)))))
+                                  (Prims.of_int (60)) (Prims.of_int (6))
+                                  (Prims.of_int (75)) (Prims.of_int (51)))))
                          (FStar_Tactics_Effect.lift_div_tac
                             (fun uu___1 ->
                                FStar_Reflection_V2_Builtins.inspect_comp c'))
@@ -286,17 +311,17 @@ let rec (rebuild_abs :
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.Checker.Abs.fst"
-                                                 (Prims.of_int (50))
+                                                 (Prims.of_int (62))
                                                  (Prims.of_int (16))
-                                                 (Prims.of_int (50))
+                                                 (Prims.of_int (62))
                                                  (Prims.of_int (33)))))
                                         (FStar_Sealed.seal
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.Checker.Abs.fst"
-                                                 (Prims.of_int (51))
+                                                 (Prims.of_int (63))
                                                  (Prims.of_int (8))
-                                                 (Prims.of_int (58))
+                                                 (Prims.of_int (70))
                                                  (Prims.of_int (62)))))
                                         (FStar_Tactics_Effect.lift_div_tac
                                            (fun uu___1 ->
@@ -314,17 +339,17 @@ let rec (rebuild_abs :
                                                              (Obj.magic
                                                                 (FStar_Range.mk_range
                                                                    "Pulse.Checker.Abs.fst"
-                                                                   (Prims.of_int (54))
+                                                                   (Prims.of_int (66))
                                                                    (Prims.of_int (22))
-                                                                   (Prims.of_int (55))
+                                                                   (Prims.of_int (67))
                                                                    (Prims.of_int (49)))))
                                                           (FStar_Sealed.seal
                                                              (Obj.magic
                                                                 (FStar_Range.mk_range
                                                                    "Pulse.Checker.Abs.fst"
-                                                                   (Prims.of_int (53))
+                                                                   (Prims.of_int (65))
                                                                    (Prims.of_int (10))
-                                                                   (Prims.of_int (55))
+                                                                   (Prims.of_int (67))
                                                                    (Prims.of_int (49)))))
                                                           (Obj.magic
                                                              (FStar_Tactics_Effect.tac_bind
@@ -332,9 +357,9 @@ let rec (rebuild_abs :
                                                                    (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (55))
+                                                                    (Prims.of_int (67))
                                                                     (Prims.of_int (26))
-                                                                    (Prims.of_int (55))
+                                                                    (Prims.of_int (67))
                                                                     (Prims.of_int (48)))))
                                                                 (FStar_Sealed.seal
                                                                    (Obj.magic
@@ -406,17 +431,17 @@ let rec (rebuild_abs :
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.Checker.Abs.fst"
-                                                 (Prims.of_int (62))
+                                                 (Prims.of_int (74))
                                                  (Prims.of_int (20))
-                                                 (Prims.of_int (63))
+                                                 (Prims.of_int (75))
                                                  (Prims.of_int (51)))))
                                         (FStar_Sealed.seal
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.Checker.Abs.fst"
-                                                 (Prims.of_int (61))
+                                                 (Prims.of_int (73))
                                                  (Prims.of_int (8))
-                                                 (Prims.of_int (63))
+                                                 (Prims.of_int (75))
                                                  (Prims.of_int (51)))))
                                         (Obj.magic
                                            (FStar_Tactics_Effect.tac_bind
@@ -424,9 +449,9 @@ let rec (rebuild_abs :
                                                  (Obj.magic
                                                     (FStar_Range.mk_range
                                                        "Pulse.Checker.Abs.fst"
-                                                       (Prims.of_int (63))
+                                                       (Prims.of_int (75))
                                                        (Prims.of_int (26))
-                                                       (Prims.of_int (63))
+                                                       (Prims.of_int (75))
                                                        (Prims.of_int (50)))))
                                               (FStar_Sealed.seal
                                                  (Obj.magic
@@ -459,20 +484,20 @@ let rec (rebuild_abs :
               (FStar_Sealed.seal
                  (Obj.magic
                     (FStar_Range.mk_range "Pulse.Checker.Abs.fst"
-                       (Prims.of_int (67)) (Prims.of_int (16))
-                       (Prims.of_int (68)) (Prims.of_int (47)))))
+                       (Prims.of_int (79)) (Prims.of_int (16))
+                       (Prims.of_int (80)) (Prims.of_int (47)))))
               (FStar_Sealed.seal
                  (Obj.magic
                     (FStar_Range.mk_range "Pulse.Checker.Abs.fst"
-                       (Prims.of_int (66)) (Prims.of_int (6))
-                       (Prims.of_int (68)) (Prims.of_int (47)))))
+                       (Prims.of_int (78)) (Prims.of_int (6))
+                       (Prims.of_int (80)) (Prims.of_int (47)))))
               (Obj.magic
                  (FStar_Tactics_Effect.tac_bind
                     (FStar_Sealed.seal
                        (Obj.magic
                           (FStar_Range.mk_range "Pulse.Checker.Abs.fst"
-                             (Prims.of_int (68)) (Prims.of_int (22))
-                             (Prims.of_int (68)) (Prims.of_int (46)))))
+                             (Prims.of_int (80)) (Prims.of_int (22))
+                             (Prims.of_int (80)) (Prims.of_int (46)))))
                     (FStar_Sealed.seal
                        (Obj.magic
                           (FStar_Range.mk_range "prims.fst"
@@ -503,12 +528,12 @@ let (preprocess_abs :
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.Abs.fst"
-                 (Prims.of_int (74)) (Prims.of_int (16)) (Prims.of_int (74))
+                 (Prims.of_int (86)) (Prims.of_int (16)) (Prims.of_int (86))
                  (Prims.of_int (30)))))
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.Abs.fst"
-                 (Prims.of_int (74)) (Prims.of_int (33)) (Prims.of_int (82))
+                 (Prims.of_int (86)) (Prims.of_int (33)) (Prims.of_int (94))
                  (Prims.of_int (51))))) (Obj.magic (arrow_of_abs t))
         (fun uu___ ->
            (fun annot ->
@@ -517,13 +542,13 @@ let (preprocess_abs :
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Checker.Abs.fst"
-                            (Prims.of_int (75)) (Prims.of_int (19))
-                            (Prims.of_int (75)) (Prims.of_int (72)))))
+                            (Prims.of_int (87)) (Prims.of_int (19))
+                            (Prims.of_int (87)) (Prims.of_int (72)))))
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Checker.Abs.fst"
-                            (Prims.of_int (74)) (Prims.of_int (33))
-                            (Prims.of_int (82)) (Prims.of_int (51)))))
+                            (Prims.of_int (86)) (Prims.of_int (33))
+                            (Prims.of_int (94)) (Prims.of_int (51)))))
                    (Obj.magic
                       (Pulse_Checker_Pure.instantiate_term_implicits g annot))
                    (fun uu___ ->
@@ -540,17 +565,17 @@ let (preprocess_abs :
                                           (Obj.magic
                                              (FStar_Range.mk_range
                                                 "Pulse.Checker.Abs.fst"
-                                                (Prims.of_int (81))
+                                                (Prims.of_int (93))
                                                 (Prims.of_int (17))
-                                                (Prims.of_int (82))
+                                                (Prims.of_int (94))
                                                 (Prims.of_int (51)))))
                                        (FStar_Sealed.seal
                                           (Obj.magic
                                              (FStar_Range.mk_range
                                                 "Pulse.Checker.Abs.fst"
-                                                (Prims.of_int (80))
+                                                (Prims.of_int (92))
                                                 (Prims.of_int (6))
-                                                (Prims.of_int (82))
+                                                (Prims.of_int (94))
                                                 (Prims.of_int (51)))))
                                        (Obj.magic
                                           (FStar_Tactics_Effect.tac_bind
@@ -558,9 +583,9 @@ let (preprocess_abs :
                                                 (Obj.magic
                                                    (FStar_Range.mk_range
                                                       "Pulse.Checker.Abs.fst"
-                                                      (Prims.of_int (82))
+                                                      (Prims.of_int (94))
                                                       (Prims.of_int (26))
-                                                      (Prims.of_int (82))
+                                                      (Prims.of_int (94))
                                                       (Prims.of_int (50)))))
                                              (FStar_Sealed.seal
                                                 (Obj.magic
@@ -631,17 +656,17 @@ let (check_effect_annotation :
                                        (Obj.magic
                                           (FStar_Range.mk_range
                                              "Pulse.Checker.Abs.fst"
-                                             (Prims.of_int (93))
+                                             (Prims.of_int (105))
                                              (Prims.of_int (16))
-                                             (Prims.of_int (95))
+                                             (Prims.of_int (107))
                                              (Prims.of_int (39)))))
                                     (FStar_Sealed.seal
                                        (Obj.magic
                                           (FStar_Range.mk_range
                                              "Pulse.Checker.Abs.fst"
-                                             (Prims.of_int (92))
+                                             (Prims.of_int (104))
                                              (Prims.of_int (9))
-                                             (Prims.of_int (95))
+                                             (Prims.of_int (107))
                                              (Prims.of_int (39)))))
                                     (Obj.magic
                                        (FStar_Tactics_Effect.tac_bind
@@ -649,17 +674,17 @@ let (check_effect_annotation :
                                              (Obj.magic
                                                 (FStar_Range.mk_range
                                                    "Pulse.Checker.Abs.fst"
-                                                   (Prims.of_int (95))
+                                                   (Prims.of_int (107))
                                                    (Prims.of_int (18))
-                                                   (Prims.of_int (95))
+                                                   (Prims.of_int (107))
                                                    (Prims.of_int (38)))))
                                           (FStar_Sealed.seal
                                              (Obj.magic
                                                 (FStar_Range.mk_range
                                                    "Pulse.Checker.Abs.fst"
-                                                   (Prims.of_int (93))
+                                                   (Prims.of_int (105))
                                                    (Prims.of_int (16))
-                                                   (Prims.of_int (95))
+                                                   (Prims.of_int (107))
                                                    (Prims.of_int (39)))))
                                           (Obj.magic
                                              (Pulse_Syntax_Printer.term_to_string
@@ -672,17 +697,17 @@ let (check_effect_annotation :
                                                         (Obj.magic
                                                            (FStar_Range.mk_range
                                                               "Pulse.Checker.Abs.fst"
-                                                              (Prims.of_int (93))
+                                                              (Prims.of_int (105))
                                                               (Prims.of_int (16))
-                                                              (Prims.of_int (95))
+                                                              (Prims.of_int (107))
                                                               (Prims.of_int (39)))))
                                                      (FStar_Sealed.seal
                                                         (Obj.magic
                                                            (FStar_Range.mk_range
                                                               "Pulse.Checker.Abs.fst"
-                                                              (Prims.of_int (93))
+                                                              (Prims.of_int (105))
                                                               (Prims.of_int (16))
-                                                              (Prims.of_int (95))
+                                                              (Prims.of_int (107))
                                                               (Prims.of_int (39)))))
                                                      (Obj.magic
                                                         (FStar_Tactics_Effect.tac_bind
@@ -690,9 +715,9 @@ let (check_effect_annotation :
                                                               (Obj.magic
                                                                  (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (94))
+                                                                    (Prims.of_int (106))
                                                                     (Prims.of_int (18))
-                                                                    (Prims.of_int (94))
+                                                                    (Prims.of_int (106))
                                                                     (Prims.of_int (38)))))
                                                            (FStar_Sealed.seal
                                                               (Obj.magic
@@ -747,17 +772,17 @@ let (check_effect_annotation :
                                        (Obj.magic
                                           (FStar_Range.mk_range
                                              "Pulse.Checker.Abs.fst"
-                                             (Prims.of_int (93))
+                                             (Prims.of_int (105))
                                              (Prims.of_int (16))
-                                             (Prims.of_int (95))
+                                             (Prims.of_int (107))
                                              (Prims.of_int (39)))))
                                     (FStar_Sealed.seal
                                        (Obj.magic
                                           (FStar_Range.mk_range
                                              "Pulse.Checker.Abs.fst"
-                                             (Prims.of_int (92))
+                                             (Prims.of_int (104))
                                              (Prims.of_int (9))
-                                             (Prims.of_int (95))
+                                             (Prims.of_int (107))
                                              (Prims.of_int (39)))))
                                     (Obj.magic
                                        (FStar_Tactics_Effect.tac_bind
@@ -765,17 +790,17 @@ let (check_effect_annotation :
                                              (Obj.magic
                                                 (FStar_Range.mk_range
                                                    "Pulse.Checker.Abs.fst"
-                                                   (Prims.of_int (95))
+                                                   (Prims.of_int (107))
                                                    (Prims.of_int (18))
-                                                   (Prims.of_int (95))
+                                                   (Prims.of_int (107))
                                                    (Prims.of_int (38)))))
                                           (FStar_Sealed.seal
                                              (Obj.magic
                                                 (FStar_Range.mk_range
                                                    "Pulse.Checker.Abs.fst"
-                                                   (Prims.of_int (93))
+                                                   (Prims.of_int (105))
                                                    (Prims.of_int (16))
-                                                   (Prims.of_int (95))
+                                                   (Prims.of_int (107))
                                                    (Prims.of_int (39)))))
                                           (Obj.magic
                                              (Pulse_Syntax_Printer.term_to_string
@@ -788,17 +813,17 @@ let (check_effect_annotation :
                                                         (Obj.magic
                                                            (FStar_Range.mk_range
                                                               "Pulse.Checker.Abs.fst"
-                                                              (Prims.of_int (93))
+                                                              (Prims.of_int (105))
                                                               (Prims.of_int (16))
-                                                              (Prims.of_int (95))
+                                                              (Prims.of_int (107))
                                                               (Prims.of_int (39)))))
                                                      (FStar_Sealed.seal
                                                         (Obj.magic
                                                            (FStar_Range.mk_range
                                                               "Pulse.Checker.Abs.fst"
-                                                              (Prims.of_int (93))
+                                                              (Prims.of_int (105))
                                                               (Prims.of_int (16))
-                                                              (Prims.of_int (95))
+                                                              (Prims.of_int (107))
                                                               (Prims.of_int (39)))))
                                                      (Obj.magic
                                                         (FStar_Tactics_Effect.tac_bind
@@ -806,9 +831,9 @@ let (check_effect_annotation :
                                                               (Obj.magic
                                                                  (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (94))
+                                                                    (Prims.of_int (106))
                                                                     (Prims.of_int (18))
-                                                                    (Prims.of_int (94))
+                                                                    (Prims.of_int (106))
                                                                     (Prims.of_int (38)))))
                                                            (FStar_Sealed.seal
                                                               (Obj.magic
@@ -855,17 +880,17 @@ let (check_effect_annotation :
                                   (Obj.magic
                                      (FStar_Range.mk_range
                                         "Pulse.Checker.Abs.fst"
-                                        (Prims.of_int (98))
+                                        (Prims.of_int (110))
                                         (Prims.of_int (11))
-                                        (Prims.of_int (100))
+                                        (Prims.of_int (112))
                                         (Prims.of_int (45)))))
                                (FStar_Sealed.seal
                                   (Obj.magic
                                      (FStar_Range.mk_range
                                         "Pulse.Checker.Abs.fst"
-                                        (Prims.of_int (97))
+                                        (Prims.of_int (109))
                                         (Prims.of_int (4))
-                                        (Prims.of_int (100))
+                                        (Prims.of_int (112))
                                         (Prims.of_int (45)))))
                                (Obj.magic
                                   (FStar_Tactics_Effect.tac_bind
@@ -873,17 +898,17 @@ let (check_effect_annotation :
                                         (Obj.magic
                                            (FStar_Range.mk_range
                                               "Pulse.Checker.Abs.fst"
-                                              (Prims.of_int (100))
+                                              (Prims.of_int (112))
                                               (Prims.of_int (18))
-                                              (Prims.of_int (100))
+                                              (Prims.of_int (112))
                                               (Prims.of_int (44)))))
                                      (FStar_Sealed.seal
                                         (Obj.magic
                                            (FStar_Range.mk_range
                                               "Pulse.Checker.Abs.fst"
-                                              (Prims.of_int (98))
+                                              (Prims.of_int (110))
                                               (Prims.of_int (11))
-                                              (Prims.of_int (100))
+                                              (Prims.of_int (112))
                                               (Prims.of_int (45)))))
                                      (Obj.magic
                                         (Pulse_Syntax_Printer.tag_of_comp
@@ -896,17 +921,17 @@ let (check_effect_annotation :
                                                    (Obj.magic
                                                       (FStar_Range.mk_range
                                                          "Pulse.Checker.Abs.fst"
-                                                         (Prims.of_int (98))
+                                                         (Prims.of_int (110))
                                                          (Prims.of_int (11))
-                                                         (Prims.of_int (100))
+                                                         (Prims.of_int (112))
                                                          (Prims.of_int (45)))))
                                                 (FStar_Sealed.seal
                                                    (Obj.magic
                                                       (FStar_Range.mk_range
                                                          "Pulse.Checker.Abs.fst"
-                                                         (Prims.of_int (98))
+                                                         (Prims.of_int (110))
                                                          (Prims.of_int (11))
-                                                         (Prims.of_int (100))
+                                                         (Prims.of_int (112))
                                                          (Prims.of_int (45)))))
                                                 (Obj.magic
                                                    (FStar_Tactics_Effect.tac_bind
@@ -914,9 +939,9 @@ let (check_effect_annotation :
                                                          (Obj.magic
                                                             (FStar_Range.mk_range
                                                                "Pulse.Checker.Abs.fst"
-                                                               (Prims.of_int (99))
+                                                               (Prims.of_int (111))
                                                                (Prims.of_int (18))
-                                                               (Prims.of_int (99))
+                                                               (Prims.of_int (111))
                                                                (Prims.of_int (41)))))
                                                       (FStar_Sealed.seal
                                                          (Obj.magic
@@ -969,13 +994,13 @@ let rec (check_abs_core :
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Checker.Abs.fst"
-                   (Prims.of_int (109)) (Prims.of_int (14))
-                   (Prims.of_int (109)) (Prims.of_int (21)))))
+                   (Prims.of_int (121)) (Prims.of_int (14))
+                   (Prims.of_int (121)) (Prims.of_int (21)))))
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Checker.Abs.fst"
-                   (Prims.of_int (110)) (Prims.of_int (2))
-                   (Prims.of_int (170)) (Prims.of_int (29)))))
+                   (Prims.of_int (122)) (Prims.of_int (2))
+                   (Prims.of_int (182)) (Prims.of_int (29)))))
           (FStar_Tactics_Effect.lift_div_tac
              (fun uu___ -> t.Pulse_Syntax_Base.range2))
           (fun uu___ ->
@@ -995,13 +1020,13 @@ let rec (check_abs_core :
                          (FStar_Sealed.seal
                             (Obj.magic
                                (FStar_Range.mk_range "Pulse.Checker.Abs.fst"
-                                  (Prims.of_int (114)) (Prims.of_int (24))
-                                  (Prims.of_int (114)) (Prims.of_int (42)))))
+                                  (Prims.of_int (126)) (Prims.of_int (24))
+                                  (Prims.of_int (126)) (Prims.of_int (42)))))
                          (FStar_Sealed.seal
                             (Obj.magic
                                (FStar_Range.mk_range "Pulse.Checker.Abs.fst"
-                                  (Prims.of_int (111)) (Prims.of_int (84))
-                                  (Prims.of_int (170)) (Prims.of_int (29)))))
+                                  (Prims.of_int (123)) (Prims.of_int (84))
+                                  (Prims.of_int (182)) (Prims.of_int (29)))))
                          (Obj.magic (Pulse_Checker_Pure.check_tot_term g t1))
                          (fun uu___ ->
                             (fun uu___ ->
@@ -1014,17 +1039,17 @@ let rec (check_abs_core :
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.Checker.Abs.fst"
-                                                 (Prims.of_int (115))
+                                                 (Prims.of_int (127))
                                                  (Prims.of_int (28))
-                                                 (Prims.of_int (115))
+                                                 (Prims.of_int (127))
                                                  (Prims.of_int (46)))))
                                         (FStar_Sealed.seal
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.Checker.Abs.fst"
-                                                 (Prims.of_int (114))
+                                                 (Prims.of_int (126))
                                                  (Prims.of_int (45))
-                                                 (Prims.of_int (170))
+                                                 (Prims.of_int (182))
                                                  (Prims.of_int (29)))))
                                         (Obj.magic
                                            (Pulse_Checker_Pure.check_universe
@@ -1040,17 +1065,17 @@ let rec (check_abs_core :
                                                           (Obj.magic
                                                              (FStar_Range.mk_range
                                                                 "Pulse.Checker.Abs.fst"
-                                                                (Prims.of_int (116))
+                                                                (Prims.of_int (128))
                                                                 (Prims.of_int (12))
-                                                                (Prims.of_int (116))
+                                                                (Prims.of_int (128))
                                                                 (Prims.of_int (19)))))
                                                        (FStar_Sealed.seal
                                                           (Obj.magic
                                                              (FStar_Range.mk_range
                                                                 "Pulse.Checker.Abs.fst"
-                                                                (Prims.of_int (116))
+                                                                (Prims.of_int (128))
                                                                 (Prims.of_int (22))
-                                                                (Prims.of_int (170))
+                                                                (Prims.of_int (182))
                                                                 (Prims.of_int (29)))))
                                                        (FStar_Tactics_Effect.lift_div_tac
                                                           (fun uu___4 ->
@@ -1064,17 +1089,17 @@ let rec (check_abs_core :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (117))
+                                                                    (Prims.of_int (129))
                                                                     (Prims.of_int (13))
-                                                                    (Prims.of_int (117))
+                                                                    (Prims.of_int (129))
                                                                     (Prims.of_int (22)))))
                                                                   (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (117))
+                                                                    (Prims.of_int (129))
                                                                     (Prims.of_int (25))
-                                                                    (Prims.of_int (170))
+                                                                    (Prims.of_int (182))
                                                                     (Prims.of_int (29)))))
                                                                   (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -1091,17 +1116,17 @@ let rec (check_abs_core :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (118))
+                                                                    (Prims.of_int (130))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (118))
+                                                                    (Prims.of_int (130))
                                                                     (Prims.of_int (50)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (118))
+                                                                    (Prims.of_int (130))
                                                                     (Prims.of_int (53))
-                                                                    (Prims.of_int (170))
+                                                                    (Prims.of_int (182))
                                                                     (Prims.of_int (29)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -1123,17 +1148,17 @@ let rec (check_abs_core :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (119))
+                                                                    (Prims.of_int (131))
                                                                     (Prims.of_int (13))
-                                                                    (Prims.of_int (119))
+                                                                    (Prims.of_int (131))
                                                                     (Prims.of_int (38)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (119))
+                                                                    (Prims.of_int (131))
                                                                     (Prims.of_int (41))
-                                                                    (Prims.of_int (170))
+                                                                    (Prims.of_int (182))
                                                                     (Prims.of_int (29)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -1151,17 +1176,17 @@ let rec (check_abs_core :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (120))
+                                                                    (Prims.of_int (132))
                                                                     (Prims.of_int (22))
-                                                                    (Prims.of_int (120))
+                                                                    (Prims.of_int (132))
                                                                     (Prims.of_int (45)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (121))
+                                                                    (Prims.of_int (133))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (170))
+                                                                    (Prims.of_int (182))
                                                                     (Prims.of_int (29)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -1185,17 +1210,17 @@ let rec (check_abs_core :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (123))
+                                                                    (Prims.of_int (135))
                                                                     (Prims.of_int (44))
-                                                                    (Prims.of_int (123))
+                                                                    (Prims.of_int (135))
                                                                     (Prims.of_int (79)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (122))
+                                                                    (Prims.of_int (134))
                                                                     (Prims.of_int (17))
-                                                                    (Prims.of_int (131))
+                                                                    (Prims.of_int (143))
                                                                     (Prims.of_int (29)))))
                                                                     (Obj.magic
                                                                     (check_abs_core
@@ -1220,17 +1245,17 @@ let rec (check_abs_core :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (124))
+                                                                    (Prims.of_int (136))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (124))
+                                                                    (Prims.of_int (136))
                                                                     (Prims.of_int (52)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (131))
+                                                                    (Prims.of_int (143))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (131))
+                                                                    (Prims.of_int (143))
                                                                     (Prims.of_int (29)))))
                                                                     (Obj.magic
                                                                     (check_effect_annotation
@@ -1299,17 +1324,17 @@ let rec (check_abs_core :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (134))
+                                                                    (Prims.of_int (146))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (142))
+                                                                    (Prims.of_int (154))
                                                                     (Prims.of_int (47)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (132))
+                                                                    (Prims.of_int (144))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (170))
+                                                                    (Prims.of_int (182))
                                                                     (Prims.of_int (29)))))
                                                                     (match c
                                                                     with
@@ -1359,17 +1384,17 @@ let rec (check_abs_core :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (144))
+                                                                    (Prims.of_int (156))
                                                                     (Prims.of_int (41))
-                                                                    (Prims.of_int (144))
+                                                                    (Prims.of_int (156))
                                                                     (Prims.of_int (66)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (143))
+                                                                    (Prims.of_int (155))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (170))
+                                                                    (Prims.of_int (182))
                                                                     (Prims.of_int (29)))))
                                                                     (Obj.magic
                                                                     (Pulse_Checker_Pure.check_vprop
@@ -1392,17 +1417,17 @@ let rec (check_abs_core :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (145))
+                                                                    (Prims.of_int (157))
                                                                     (Prims.of_int (16))
-                                                                    (Prims.of_int (145))
+                                                                    (Prims.of_int (157))
                                                                     (Prims.of_int (39)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (145))
+                                                                    (Prims.of_int (157))
                                                                     (Prims.of_int (42))
-                                                                    (Prims.of_int (170))
+                                                                    (Prims.of_int (182))
                                                                     (Prims.of_int (29)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -1420,17 +1445,17 @@ let rec (check_abs_core :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (147))
+                                                                    (Prims.of_int (159))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (154))
+                                                                    (Prims.of_int (166))
                                                                     (Prims.of_int (31)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (155))
+                                                                    (Prims.of_int (167))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (170))
+                                                                    (Prims.of_int (182))
                                                                     (Prims.of_int (29)))))
                                                                     (match post_hint_body
                                                                     with
@@ -1452,17 +1477,17 @@ let rec (check_abs_core :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (152))
+                                                                    (Prims.of_int (164))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (152))
+                                                                    (Prims.of_int (164))
                                                                     (Prims.of_int (130)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (154))
+                                                                    (Prims.of_int (166))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (154))
+                                                                    (Prims.of_int (166))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (Pulse_Checker_Base.intro_post_hint
@@ -1492,17 +1517,17 @@ let rec (check_abs_core :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (157))
+                                                                    (Prims.of_int (169))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (157))
+                                                                    (Prims.of_int (169))
                                                                     (Prims.of_int (45)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (157))
+                                                                    (Prims.of_int (169))
                                                                     (Prims.of_int (48))
-                                                                    (Prims.of_int (170))
+                                                                    (Prims.of_int (182))
                                                                     (Prims.of_int (29)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -1520,17 +1545,17 @@ let rec (check_abs_core :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (158))
+                                                                    (Prims.of_int (170))
                                                                     (Prims.of_int (15))
-                                                                    (Prims.of_int (158))
+                                                                    (Prims.of_int (170))
                                                                     (Prims.of_int (69)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (158))
-                                                                    (Prims.of_int (73))
                                                                     (Prims.of_int (170))
+                                                                    (Prims.of_int (73))
+                                                                    (Prims.of_int (182))
                                                                     (Prims.of_int (29)))))
                                                                     (Obj.magic
                                                                     (check g'
@@ -1547,17 +1572,17 @@ let rec (check_abs_core :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (160))
+                                                                    (Prims.of_int (172))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (160))
+                                                                    (Prims.of_int (172))
                                                                     (Prims.of_int (61)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (158))
-                                                                    (Prims.of_int (73))
                                                                     (Prims.of_int (170))
+                                                                    (Prims.of_int (73))
+                                                                    (Prims.of_int (182))
                                                                     (Prims.of_int (29)))))
                                                                     (Obj.magic
                                                                     (Pulse_Checker_Base.apply_checker_result_k
@@ -1584,17 +1609,17 @@ let rec (check_abs_core :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (162))
+                                                                    (Prims.of_int (174))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (170))
+                                                                    (Prims.of_int (182))
                                                                     (Prims.of_int (29)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (162))
+                                                                    (Prims.of_int (174))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (170))
+                                                                    (Prims.of_int (182))
                                                                     (Prims.of_int (29)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -1610,17 +1635,17 @@ let rec (check_abs_core :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (162))
+                                                                    (Prims.of_int (174))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (162))
+                                                                    (Prims.of_int (174))
                                                                     (Prims.of_int (52)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (170))
+                                                                    (Prims.of_int (182))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (170))
+                                                                    (Prims.of_int (182))
                                                                     (Prims.of_int (29)))))
                                                                     (Obj.magic
                                                                     (check_effect_annotation
@@ -1711,13 +1736,13 @@ let (check_abs :
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Checker.Abs.fst"
-                   (Prims.of_int (174)) (Prims.of_int (10))
-                   (Prims.of_int (174)) (Prims.of_int (28)))))
+                   (Prims.of_int (186)) (Prims.of_int (10))
+                   (Prims.of_int (186)) (Prims.of_int (28)))))
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Checker.Abs.fst"
-                   (Prims.of_int (175)) (Prims.of_int (2))
-                   (Prims.of_int (175)) (Prims.of_int (26)))))
+                   (Prims.of_int (187)) (Prims.of_int (2))
+                   (Prims.of_int (187)) (Prims.of_int (26)))))
           (Obj.magic (preprocess_abs g t))
           (fun uu___ ->
              (fun t1 -> Obj.magic (check_abs_core g t1 check)) uu___)

--- a/src/ocaml/plugin/generated/Pulse_Checker_Pure.ml
+++ b/src/ocaml/plugin/generated/Pulse_Checker_Pure.ml
@@ -1699,45 +1699,61 @@ let (ill_typed_term :
 let maybe_fail_doc :
   'uuuuu .
     FStar_Issue.issue Prims.list ->
-      Prims.string ->
-        Pulse_Typing_Env.env ->
-          Pulse_Syntax_Base.range FStar_Pervasives_Native.option ->
-            FStar_Pprint.document Prims.list ->
-              ('uuuuu, unit) FStar_Tactics_Effect.tac_repr
+      Pulse_Typing_Env.env ->
+        Pulse_Syntax_Base.range ->
+          FStar_Pprint.document Prims.list ->
+            ('uuuuu, unit) FStar_Tactics_Effect.tac_repr
   =
   fun issues ->
-    fun msg ->
-      fun g ->
-        fun range ->
-          fun doc ->
-            FStar_Tactics_Effect.tac_bind
-              (FStar_Sealed.seal
-                 (Obj.magic
-                    (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                       (Prims.of_int (131)) (Prims.of_int (6))
-                       (Prims.of_int (135)) (Prims.of_int (14)))))
-              (FStar_Sealed.seal
-                 (Obj.magic
-                    (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                       (Prims.of_int (137)) (Prims.of_int (2))
-                       (Prims.of_int (139)) (Prims.of_int (27)))))
-              (FStar_Tactics_Effect.lift_div_tac
-                 (fun uu___ ->
-                    FStar_List_Tot_Base.existsb
-                      (fun i ->
-                         ((FStar_Issue.level_of_issue i) = "Error") &&
-                           (FStar_Pervasives_Native.uu___is_Some
-                              (FStar_Issue.range_of_issue i))) issues))
-              (fun uu___ ->
-                 (fun has_localized_error ->
-                    if has_localized_error
-                    then
-                      Obj.magic
-                        (Obj.repr (FStar_Tactics_V2_Derived.fail msg))
-                    else
-                      Obj.magic
-                        (Obj.repr (Pulse_Typing_Env.fail_doc g range doc)))
-                   uu___)
+    fun g ->
+      fun rng ->
+        fun doc ->
+          FStar_Tactics_Effect.tac_bind
+            (FStar_Sealed.seal
+               (Obj.magic
+                  (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
+                     (Prims.of_int (131)) (Prims.of_int (6))
+                     (Prims.of_int (135)) (Prims.of_int (14)))))
+            (FStar_Sealed.seal
+               (Obj.magic
+                  (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
+                     (Prims.of_int (137)) (Prims.of_int (2))
+                     (Prims.of_int (140)) (Prims.of_int (32)))))
+            (FStar_Tactics_Effect.lift_div_tac
+               (fun uu___ ->
+                  FStar_List_Tot_Base.existsb
+                    (fun i ->
+                       ((FStar_Issue.level_of_issue i) = "Error") &&
+                         (FStar_Pervasives_Native.uu___is_Some
+                            (FStar_Issue.range_of_issue i))) issues))
+            (fun uu___ ->
+               (fun has_localized_error ->
+                  if has_localized_error
+                  then
+                    Obj.magic
+                      (FStar_Tactics_Effect.tac_bind
+                         (FStar_Sealed.seal
+                            (Obj.magic
+                               (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
+                                  (Prims.of_int (138)) (Prims.of_int (41))
+                                  (Prims.of_int (138)) (Prims.of_int (83)))))
+                         (FStar_Sealed.seal
+                            (Obj.magic
+                               (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
+                                  (Prims.of_int (139)) (Prims.of_int (7))
+                                  (Prims.of_int (139)) (Prims.of_int (21)))))
+                         (FStar_Tactics_Effect.lift_div_tac
+                            (fun uu___ ->
+                               FStar_Pprint.pretty_string
+                                 Pulse_RuntimeUtils.float_one
+                                 (Prims.of_int (80))
+                                 (FStar_Pprint.concat doc)))
+                         (fun message ->
+                            FStar_Tactics_V2_Derived.fail message))
+                  else
+                    Obj.magic
+                      (Pulse_Typing_Env.fail_doc g
+                         (FStar_Pervasives_Native.Some rng) doc)) uu___)
 let (instantiate_term_implicits :
   Pulse_Typing_Env.env ->
     Pulse_Syntax_Base.term ->
@@ -1750,13 +1766,13 @@ let (instantiate_term_implicits :
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                 (Prims.of_int (142)) (Prims.of_int (10))
-                 (Prims.of_int (142)) (Prims.of_int (20)))))
+                 (Prims.of_int (143)) (Prims.of_int (10))
+                 (Prims.of_int (143)) (Prims.of_int (20)))))
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                 (Prims.of_int (142)) (Prims.of_int (23))
-                 (Prims.of_int (164)) (Prims.of_int (49)))))
+                 (Prims.of_int (143)) (Prims.of_int (23))
+                 (Prims.of_int (165)) (Prims.of_int (49)))))
         (FStar_Tactics_Effect.lift_div_tac
            (fun uu___ -> Pulse_Typing.elab_env g))
         (fun uu___ ->
@@ -1766,13 +1782,13 @@ let (instantiate_term_implicits :
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                            (Prims.of_int (143)) (Prims.of_int (11))
-                            (Prims.of_int (143)) (Prims.of_int (23)))))
+                            (Prims.of_int (144)) (Prims.of_int (11))
+                            (Prims.of_int (144)) (Prims.of_int (23)))))
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                            (Prims.of_int (143)) (Prims.of_int (26))
-                            (Prims.of_int (164)) (Prims.of_int (49)))))
+                            (Prims.of_int (144)) (Prims.of_int (26))
+                            (Prims.of_int (165)) (Prims.of_int (49)))))
                    (FStar_Tactics_Effect.lift_div_tac
                       (fun uu___ -> Pulse_Elaborate_Pure.elab_term t0))
                    (fun uu___ ->
@@ -1783,17 +1799,17 @@ let (instantiate_term_implicits :
                                  (Obj.magic
                                     (FStar_Range.mk_range
                                        "Pulse.Checker.Pure.fst"
-                                       (Prims.of_int (144))
+                                       (Prims.of_int (145))
                                        (Prims.of_int (10))
-                                       (Prims.of_int (144))
+                                       (Prims.of_int (145))
                                        (Prims.of_int (75)))))
                               (FStar_Sealed.seal
                                  (Obj.magic
                                     (FStar_Range.mk_range
                                        "Pulse.Checker.Pure.fst"
-                                       (Prims.of_int (144))
+                                       (Prims.of_int (145))
                                        (Prims.of_int (78))
-                                       (Prims.of_int (164))
+                                       (Prims.of_int (165))
                                        (Prims.of_int (49)))))
                               (Obj.magic
                                  (FStar_Tactics_Effect.tac_bind
@@ -1801,17 +1817,17 @@ let (instantiate_term_implicits :
                                        (Obj.magic
                                           (FStar_Range.mk_range
                                              "Pulse.Checker.Pure.fst"
-                                             (Prims.of_int (144))
+                                             (Prims.of_int (145))
                                              (Prims.of_int (29))
-                                             (Prims.of_int (144))
+                                             (Prims.of_int (145))
                                              (Prims.of_int (75)))))
                                     (FStar_Sealed.seal
                                        (Obj.magic
                                           (FStar_Range.mk_range
                                              "Pulse.Checker.Pure.fst"
-                                             (Prims.of_int (144))
+                                             (Prims.of_int (145))
                                              (Prims.of_int (10))
-                                             (Prims.of_int (144))
+                                             (Prims.of_int (145))
                                              (Prims.of_int (75)))))
                                     (Obj.magic
                                        (Pulse_Typing_Env.get_range g
@@ -1830,17 +1846,17 @@ let (instantiate_term_implicits :
                                             (Obj.magic
                                                (FStar_Range.mk_range
                                                   "Pulse.Checker.Pure.fst"
-                                                  (Prims.of_int (145))
+                                                  (Prims.of_int (146))
                                                   (Prims.of_int (21))
-                                                  (Prims.of_int (145))
+                                                  (Prims.of_int (146))
                                                   (Prims.of_int (74)))))
                                          (FStar_Sealed.seal
                                             (Obj.magic
                                                (FStar_Range.mk_range
                                                   "Pulse.Checker.Pure.fst"
-                                                  (Prims.of_int (144))
+                                                  (Prims.of_int (145))
                                                   (Prims.of_int (78))
-                                                  (Prims.of_int (164))
+                                                  (Prims.of_int (165))
                                                   (Prims.of_int (49)))))
                                          (Obj.magic
                                             (catch_all
@@ -1857,17 +1873,17 @@ let (instantiate_term_implicits :
                                                            (Obj.magic
                                                               (FStar_Range.mk_range
                                                                  "Pulse.Checker.Pure.fst"
-                                                                 (Prims.of_int (146))
+                                                                 (Prims.of_int (147))
                                                                  (Prims.of_int (2))
-                                                                 (Prims.of_int (146))
+                                                                 (Prims.of_int (147))
                                                                  (Prims.of_int (21)))))
                                                         (FStar_Sealed.seal
                                                            (Obj.magic
                                                               (FStar_Range.mk_range
                                                                  "Pulse.Checker.Pure.fst"
-                                                                 (Prims.of_int (147))
+                                                                 (Prims.of_int (148))
                                                                  (Prims.of_int (2))
-                                                                 (Prims.of_int (164))
+                                                                 (Prims.of_int (165))
                                                                  (Prims.of_int (49)))))
                                                         (Obj.magic
                                                            (FStar_Tactics_V2_Builtins.log_issues
@@ -1884,17 +1900,17 @@ let (instantiate_term_implicits :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (151))
-                                                                    (Prims.of_int (27))
-                                                                    (Prims.of_int (154))
+                                                                    (Prims.of_int (152))
+                                                                    (Prims.of_int (20))
+                                                                    (Prims.of_int (155))
                                                                     (Prims.of_int (13)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (150))
+                                                                    (Prims.of_int (151))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (154))
+                                                                    (Prims.of_int (155))
                                                                     (Prims.of_int (13)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1902,17 +1918,17 @@ let (instantiate_term_implicits :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (152))
-                                                                    (Prims.of_int (14))
                                                                     (Prims.of_int (153))
+                                                                    (Prims.of_int (14))
+                                                                    (Prims.of_int (154))
                                                                     (Prims.of_int (31)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (151))
-                                                                    (Prims.of_int (27))
-                                                                    (Prims.of_int (154))
+                                                                    (Prims.of_int (152))
+                                                                    (Prims.of_int (20))
+                                                                    (Prims.of_int (155))
                                                                     (Prims.of_int (13)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1920,17 +1936,17 @@ let (instantiate_term_implicits :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (153))
+                                                                    (Prims.of_int (154))
                                                                     (Prims.of_int (24))
-                                                                    (Prims.of_int (153))
+                                                                    (Prims.of_int (154))
                                                                     (Prims.of_int (31)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (152))
-                                                                    (Prims.of_int (14))
                                                                     (Prims.of_int (153))
+                                                                    (Prims.of_int (14))
+                                                                    (Prims.of_int (154))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (Pulse_PP.pp
@@ -1959,11 +1975,8 @@ let (instantiate_term_implicits :
                                                                     uu___2 ->
                                                                     Obj.magic
                                                                     (maybe_fail_doc
-                                                                    issues
-                                                                    "Could not infer implicit arguments"
-                                                                    g
-                                                                    (FStar_Pervasives_Native.Some
-                                                                    (t0.Pulse_Syntax_Base.range1))
+                                                                    issues g
+                                                                    t0.Pulse_Syntax_Base.range1
                                                                     uu___2))
                                                                     uu___2))
                                                               | FStar_Pervasives_Native.Some
@@ -1975,17 +1988,17 @@ let (instantiate_term_implicits :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (157))
+                                                                    (Prims.of_int (158))
                                                                     (Prims.of_int (15))
-                                                                    (Prims.of_int (157))
+                                                                    (Prims.of_int (158))
                                                                     (Prims.of_int (28)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (157))
+                                                                    (Prims.of_int (158))
                                                                     (Prims.of_int (31))
-                                                                    (Prims.of_int (164))
+                                                                    (Prims.of_int (165))
                                                                     (Prims.of_int (49)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -2002,17 +2015,17 @@ let (instantiate_term_implicits :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (158))
+                                                                    (Prims.of_int (159))
                                                                     (Prims.of_int (16))
-                                                                    (Prims.of_int (158))
+                                                                    (Prims.of_int (159))
                                                                     (Prims.of_int (30)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (159))
+                                                                    (Prims.of_int (160))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (164))
+                                                                    (Prims.of_int (165))
                                                                     (Prims.of_int (49)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -2050,17 +2063,17 @@ let (instantiate_term_implicits :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (162))
+                                                                    (Prims.of_int (163))
                                                                     (Prims.of_int (29))
-                                                                    (Prims.of_int (162))
+                                                                    (Prims.of_int (163))
                                                                     (Prims.of_int (50)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (162))
+                                                                    (Prims.of_int (163))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (162))
+                                                                    (Prims.of_int (163))
                                                                     (Prims.of_int (50)))))
                                                                     (Obj.magic
                                                                     (readback_failure
@@ -2087,17 +2100,17 @@ let (instantiate_term_implicits :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (164))
+                                                                    (Prims.of_int (165))
                                                                     (Prims.of_int (29))
-                                                                    (Prims.of_int (164))
+                                                                    (Prims.of_int (165))
                                                                     (Prims.of_int (49)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (164))
+                                                                    (Prims.of_int (165))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (164))
+                                                                    (Prims.of_int (165))
                                                                     (Prims.of_int (49)))))
                                                                     (Obj.magic
                                                                     (readback_failure
@@ -2129,13 +2142,13 @@ let (check_universe :
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                 (Prims.of_int (168)) (Prims.of_int (12))
-                 (Prims.of_int (168)) (Prims.of_int (22)))))
+                 (Prims.of_int (169)) (Prims.of_int (12))
+                 (Prims.of_int (169)) (Prims.of_int (22)))))
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                 (Prims.of_int (168)) (Prims.of_int (25))
-                 (Prims.of_int (183)) (Prims.of_int (23)))))
+                 (Prims.of_int (169)) (Prims.of_int (25))
+                 (Prims.of_int (184)) (Prims.of_int (23)))))
         (FStar_Tactics_Effect.lift_div_tac
            (fun uu___ -> Pulse_Typing.elab_env g))
         (fun uu___ ->
@@ -2145,13 +2158,13 @@ let (check_universe :
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                            (Prims.of_int (169)) (Prims.of_int (13))
-                            (Prims.of_int (169)) (Prims.of_int (24)))))
+                            (Prims.of_int (170)) (Prims.of_int (13))
+                            (Prims.of_int (170)) (Prims.of_int (24)))))
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                            (Prims.of_int (169)) (Prims.of_int (27))
-                            (Prims.of_int (183)) (Prims.of_int (23)))))
+                            (Prims.of_int (170)) (Prims.of_int (27))
+                            (Prims.of_int (184)) (Prims.of_int (23)))))
                    (FStar_Tactics_Effect.lift_div_tac
                       (fun uu___ -> Pulse_Elaborate_Pure.elab_term t))
                    (fun uu___ ->
@@ -2162,17 +2175,17 @@ let (check_universe :
                                  (Obj.magic
                                     (FStar_Range.mk_range
                                        "Pulse.Checker.Pure.fst"
-                                       (Prims.of_int (170))
+                                       (Prims.of_int (171))
                                        (Prims.of_int (25))
-                                       (Prims.of_int (170))
+                                       (Prims.of_int (171))
                                        (Prims.of_int (68)))))
                               (FStar_Sealed.seal
                                  (Obj.magic
                                     (FStar_Range.mk_range
                                        "Pulse.Checker.Pure.fst"
-                                       (Prims.of_int (169))
+                                       (Prims.of_int (170))
                                        (Prims.of_int (27))
-                                       (Prims.of_int (183))
+                                       (Prims.of_int (184))
                                        (Prims.of_int (23)))))
                               (Obj.magic
                                  (catch_all
@@ -2187,17 +2200,17 @@ let (check_universe :
                                                 (Obj.magic
                                                    (FStar_Range.mk_range
                                                       "Pulse.Checker.Pure.fst"
-                                                      (Prims.of_int (171))
+                                                      (Prims.of_int (172))
                                                       (Prims.of_int (4))
-                                                      (Prims.of_int (171))
+                                                      (Prims.of_int (172))
                                                       (Prims.of_int (23)))))
                                              (FStar_Sealed.seal
                                                 (Obj.magic
                                                    (FStar_Range.mk_range
                                                       "Pulse.Checker.Pure.fst"
-                                                      (Prims.of_int (172))
+                                                      (Prims.of_int (173))
                                                       (Prims.of_int (4))
-                                                      (Prims.of_int (183))
+                                                      (Prims.of_int (184))
                                                       (Prims.of_int (23)))))
                                              (Obj.magic
                                                 (FStar_Tactics_V2_Builtins.log_issues
@@ -2214,18 +2227,18 @@ let (check_universe :
                                                                   (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (176))
-                                                                    (Prims.of_int (25))
-                                                                    (Prims.of_int (176))
-                                                                    (Prims.of_int (75)))))
+                                                                    (Prims.of_int (177))
+                                                                    (Prims.of_int (18))
+                                                                    (Prims.of_int (177))
+                                                                    (Prims.of_int (68)))))
                                                                (FStar_Sealed.seal
                                                                   (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (174))
+                                                                    (Prims.of_int (175))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (176))
-                                                                    (Prims.of_int (75)))))
+                                                                    (Prims.of_int (177))
+                                                                    (Prims.of_int (68)))))
                                                                (Obj.magic
                                                                   (ill_typed_term
                                                                     t
@@ -2238,11 +2251,8 @@ let (check_universe :
                                                                     ->
                                                                     Obj.magic
                                                                     (maybe_fail_doc
-                                                                    issues
-                                                                    "Could not infer universe"
-                                                                    g
-                                                                    (FStar_Pervasives_Native.Some
-                                                                    (t.Pulse_Syntax_Base.range1))
+                                                                    issues g
+                                                                    t.Pulse_Syntax_Base.range1
                                                                     uu___2))
                                                                     uu___2)))
                                                    | FStar_Pervasives_Native.Some
@@ -2273,25 +2283,25 @@ let (tc_meta_callback :
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                   (Prims.of_int (188)) (Prims.of_int (6))
-                   (Prims.of_int (193)) (Prims.of_int (14)))))
+                   (Prims.of_int (189)) (Prims.of_int (6))
+                   (Prims.of_int (194)) (Prims.of_int (14)))))
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                   (Prims.of_int (187)) (Prims.of_int (8))
-                   (Prims.of_int (187)) (Prims.of_int (11)))))
+                   (Prims.of_int (188)) (Prims.of_int (8))
+                   (Prims.of_int (188)) (Prims.of_int (11)))))
           (Obj.magic
              (FStar_Tactics_Effect.tac_bind
                 (FStar_Sealed.seal
                    (Obj.magic
                       (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                         (Prims.of_int (188)) (Prims.of_int (12))
-                         (Prims.of_int (188)) (Prims.of_int (50)))))
+                         (Prims.of_int (189)) (Prims.of_int (12))
+                         (Prims.of_int (189)) (Prims.of_int (50)))))
                 (FStar_Sealed.seal
                    (Obj.magic
                       (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                         (Prims.of_int (188)) (Prims.of_int (6))
-                         (Prims.of_int (193)) (Prims.of_int (14)))))
+                         (Prims.of_int (189)) (Prims.of_int (6))
+                         (Prims.of_int (194)) (Prims.of_int (14)))))
                 (Obj.magic (catch_all (fun uu___ -> rtb_tc_term g f e)))
                 (fun uu___ ->
                    FStar_Tactics_Effect.lift_div_tac
@@ -2320,13 +2330,13 @@ let (check_term :
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                 (Prims.of_int (202)) (Prims.of_int (13))
-                 (Prims.of_int (202)) (Prims.of_int (23)))))
+                 (Prims.of_int (203)) (Prims.of_int (13))
+                 (Prims.of_int (203)) (Prims.of_int (23)))))
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                 (Prims.of_int (202)) (Prims.of_int (26))
-                 (Prims.of_int (218)) (Prims.of_int (50)))))
+                 (Prims.of_int (203)) (Prims.of_int (26))
+                 (Prims.of_int (219)) (Prims.of_int (50)))))
         (FStar_Tactics_Effect.lift_div_tac
            (fun uu___ -> Pulse_Typing.elab_env g))
         (fun uu___ ->
@@ -2336,13 +2346,13 @@ let (check_term :
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                            (Prims.of_int (203)) (Prims.of_int (13))
-                            (Prims.of_int (203)) (Prims.of_int (24)))))
+                            (Prims.of_int (204)) (Prims.of_int (13))
+                            (Prims.of_int (204)) (Prims.of_int (24)))))
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                            (Prims.of_int (204)) (Prims.of_int (4))
-                            (Prims.of_int (218)) (Prims.of_int (50)))))
+                            (Prims.of_int (205)) (Prims.of_int (4))
+                            (Prims.of_int (219)) (Prims.of_int (50)))))
                    (FStar_Tactics_Effect.lift_div_tac
                       (fun uu___ -> Pulse_Elaborate_Pure.elab_term t))
                    (fun uu___ ->
@@ -2353,17 +2363,17 @@ let (check_term :
                                  (Obj.magic
                                     (FStar_Range.mk_range
                                        "Pulse.Checker.Pure.fst"
-                                       (Prims.of_int (204))
+                                       (Prims.of_int (205))
                                        (Prims.of_int (4))
-                                       (Prims.of_int (207))
+                                       (Prims.of_int (208))
                                        (Prims.of_int (44)))))
                               (FStar_Sealed.seal
                                  (Obj.magic
                                     (FStar_Range.mk_range
                                        "Pulse.Checker.Pure.fst"
-                                       (Prims.of_int (207))
+                                       (Prims.of_int (208))
                                        (Prims.of_int (45))
-                                       (Prims.of_int (218))
+                                       (Prims.of_int (219))
                                        (Prims.of_int (50)))))
                               (Obj.magic
                                  (debug g
@@ -2373,17 +2383,17 @@ let (check_term :
                                             (Obj.magic
                                                (FStar_Range.mk_range
                                                   "Pulse.Checker.Pure.fst"
-                                                  (Prims.of_int (207))
+                                                  (Prims.of_int (208))
                                                   (Prims.of_int (22))
-                                                  (Prims.of_int (207))
+                                                  (Prims.of_int (208))
                                                   (Prims.of_int (43)))))
                                          (FStar_Sealed.seal
                                             (Obj.magic
                                                (FStar_Range.mk_range
                                                   "Pulse.Checker.Pure.fst"
-                                                  (Prims.of_int (205))
+                                                  (Prims.of_int (206))
                                                   (Prims.of_int (12))
-                                                  (Prims.of_int (207))
+                                                  (Prims.of_int (208))
                                                   (Prims.of_int (43)))))
                                          (Obj.magic
                                             (FStar_Tactics_V2_Builtins.term_to_string
@@ -2396,17 +2406,17 @@ let (check_term :
                                                        (Obj.magic
                                                           (FStar_Range.mk_range
                                                              "Pulse.Checker.Pure.fst"
-                                                             (Prims.of_int (205))
+                                                             (Prims.of_int (206))
                                                              (Prims.of_int (12))
-                                                             (Prims.of_int (207))
+                                                             (Prims.of_int (208))
                                                              (Prims.of_int (43)))))
                                                     (FStar_Sealed.seal
                                                        (Obj.magic
                                                           (FStar_Range.mk_range
                                                              "Pulse.Checker.Pure.fst"
-                                                             (Prims.of_int (205))
+                                                             (Prims.of_int (206))
                                                              (Prims.of_int (12))
-                                                             (Prims.of_int (207))
+                                                             (Prims.of_int (208))
                                                              (Prims.of_int (43)))))
                                                     (Obj.magic
                                                        (FStar_Tactics_Effect.tac_bind
@@ -2414,9 +2424,9 @@ let (check_term :
                                                              (Obj.magic
                                                                 (FStar_Range.mk_range
                                                                    "Pulse.Checker.Pure.fst"
-                                                                   (Prims.of_int (206))
+                                                                   (Prims.of_int (207))
                                                                    (Prims.of_int (22))
-                                                                   (Prims.of_int (206))
+                                                                   (Prims.of_int (207))
                                                                    (Prims.of_int (42)))))
                                                           (FStar_Sealed.seal
                                                              (Obj.magic
@@ -2454,17 +2464,17 @@ let (check_term :
                                             (Obj.magic
                                                (FStar_Range.mk_range
                                                   "Pulse.Checker.Pure.fst"
-                                                  (Prims.of_int (208))
+                                                  (Prims.of_int (209))
                                                   (Prims.of_int (22))
-                                                  (Prims.of_int (208))
+                                                  (Prims.of_int (209))
                                                   (Prims.of_int (46)))))
                                          (FStar_Sealed.seal
                                             (Obj.magic
                                                (FStar_Range.mk_range
                                                   "Pulse.Checker.Pure.fst"
-                                                  (Prims.of_int (207))
+                                                  (Prims.of_int (208))
                                                   (Prims.of_int (45))
-                                                  (Prims.of_int (218))
+                                                  (Prims.of_int (219))
                                                   (Prims.of_int (50)))))
                                          (Obj.magic
                                             (tc_meta_callback g fg rt))
@@ -2478,17 +2488,17 @@ let (check_term :
                                                            (Obj.magic
                                                               (FStar_Range.mk_range
                                                                  "Pulse.Checker.Pure.fst"
-                                                                 (Prims.of_int (209))
+                                                                 (Prims.of_int (210))
                                                                  (Prims.of_int (4))
-                                                                 (Prims.of_int (209))
+                                                                 (Prims.of_int (210))
                                                                  (Prims.of_int (23)))))
                                                         (FStar_Sealed.seal
                                                            (Obj.magic
                                                               (FStar_Range.mk_range
                                                                  "Pulse.Checker.Pure.fst"
-                                                                 (Prims.of_int (210))
+                                                                 (Prims.of_int (211))
                                                                  (Prims.of_int (4))
-                                                                 (Prims.of_int (218))
+                                                                 (Prims.of_int (219))
                                                                  (Prims.of_int (50)))))
                                                         (Obj.magic
                                                            (FStar_Tactics_V2_Builtins.log_issues
@@ -2506,18 +2516,18 @@ let (check_term :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (213))
-                                                                    (Prims.of_int (29))
-                                                                    (Prims.of_int (213))
-                                                                    (Prims.of_int (57)))))
+                                                                    (Prims.of_int (214))
+                                                                    (Prims.of_int (22))
+                                                                    (Prims.of_int (214))
+                                                                    (Prims.of_int (50)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (212))
-                                                                    (Prims.of_int (6))
                                                                     (Prims.of_int (213))
-                                                                    (Prims.of_int (57)))))
+                                                                    (Prims.of_int (6))
+                                                                    (Prims.of_int (214))
+                                                                    (Prims.of_int (50)))))
                                                                     (Obj.magic
                                                                     (ill_typed_term
                                                                     t
@@ -2529,11 +2539,8 @@ let (check_term :
                                                                     uu___3 ->
                                                                     Obj.magic
                                                                     (maybe_fail_doc
-                                                                    issues
-                                                                    "Failed to typecheck term"
-                                                                    g
-                                                                    (FStar_Pervasives_Native.Some
-                                                                    (t.Pulse_Syntax_Base.range1))
+                                                                    issues g
+                                                                    t.Pulse_Syntax_Base.range1
                                                                     uu___3))
                                                                     uu___3)))
                                                               | FStar_Pervasives_Native.Some
@@ -2560,17 +2567,17 @@ let (check_term :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (216))
+                                                                    (Prims.of_int (217))
                                                                     (Prims.of_int (41))
-                                                                    (Prims.of_int (216))
+                                                                    (Prims.of_int (217))
                                                                     (Prims.of_int (62)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (216))
+                                                                    (Prims.of_int (217))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (216))
+                                                                    (Prims.of_int (217))
                                                                     (Prims.of_int (62)))))
                                                                     (Obj.magic
                                                                     (readback_failure
@@ -2596,17 +2603,17 @@ let (check_term :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (217))
+                                                                    (Prims.of_int (218))
                                                                     (Prims.of_int (41))
-                                                                    (Prims.of_int (217))
+                                                                    (Prims.of_int (218))
                                                                     (Prims.of_int (63)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (217))
+                                                                    (Prims.of_int (218))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (217))
+                                                                    (Prims.of_int (218))
                                                                     (Prims.of_int (63)))))
                                                                     (Obj.magic
                                                                     (readback_failure
@@ -2651,13 +2658,13 @@ let (check_term_and_type :
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                 (Prims.of_int (227)) (Prims.of_int (13))
-                 (Prims.of_int (227)) (Prims.of_int (23)))))
+                 (Prims.of_int (228)) (Prims.of_int (13))
+                 (Prims.of_int (228)) (Prims.of_int (23)))))
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                 (Prims.of_int (227)) (Prims.of_int (26))
-                 (Prims.of_int (242)) (Prims.of_int (45)))))
+                 (Prims.of_int (228)) (Prims.of_int (26))
+                 (Prims.of_int (243)) (Prims.of_int (45)))))
         (FStar_Tactics_Effect.lift_div_tac
            (fun uu___ -> Pulse_Typing.elab_env g))
         (fun uu___ ->
@@ -2667,13 +2674,13 @@ let (check_term_and_type :
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                            (Prims.of_int (228)) (Prims.of_int (13))
-                            (Prims.of_int (228)) (Prims.of_int (24)))))
+                            (Prims.of_int (229)) (Prims.of_int (13))
+                            (Prims.of_int (229)) (Prims.of_int (24)))))
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                            (Prims.of_int (228)) (Prims.of_int (27))
-                            (Prims.of_int (242)) (Prims.of_int (45)))))
+                            (Prims.of_int (229)) (Prims.of_int (27))
+                            (Prims.of_int (243)) (Prims.of_int (45)))))
                    (FStar_Tactics_Effect.lift_div_tac
                       (fun uu___ -> Pulse_Elaborate_Pure.elab_term t))
                    (fun uu___ ->
@@ -2684,17 +2691,17 @@ let (check_term_and_type :
                                  (Obj.magic
                                     (FStar_Range.mk_range
                                        "Pulse.Checker.Pure.fst"
-                                       (Prims.of_int (229))
+                                       (Prims.of_int (230))
                                        (Prims.of_int (22))
-                                       (Prims.of_int (229))
+                                       (Prims.of_int (230))
                                        (Prims.of_int (46)))))
                               (FStar_Sealed.seal
                                  (Obj.magic
                                     (FStar_Range.mk_range
                                        "Pulse.Checker.Pure.fst"
-                                       (Prims.of_int (228))
+                                       (Prims.of_int (229))
                                        (Prims.of_int (27))
-                                       (Prims.of_int (242))
+                                       (Prims.of_int (243))
                                        (Prims.of_int (45)))))
                               (Obj.magic (tc_meta_callback g fg rt))
                               (fun uu___ ->
@@ -2707,17 +2714,17 @@ let (check_term_and_type :
                                                 (Obj.magic
                                                    (FStar_Range.mk_range
                                                       "Pulse.Checker.Pure.fst"
-                                                      (Prims.of_int (230))
+                                                      (Prims.of_int (231))
                                                       (Prims.of_int (4))
-                                                      (Prims.of_int (230))
+                                                      (Prims.of_int (231))
                                                       (Prims.of_int (23)))))
                                              (FStar_Sealed.seal
                                                 (Obj.magic
                                                    (FStar_Range.mk_range
                                                       "Pulse.Checker.Pure.fst"
-                                                      (Prims.of_int (231))
+                                                      (Prims.of_int (232))
                                                       (Prims.of_int (4))
-                                                      (Prims.of_int (242))
+                                                      (Prims.of_int (243))
                                                       (Prims.of_int (45)))))
                                              (Obj.magic
                                                 (FStar_Tactics_V2_Builtins.log_issues
@@ -2733,18 +2740,18 @@ let (check_term_and_type :
                                                                (Obj.magic
                                                                   (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (235))
-                                                                    (Prims.of_int (25))
-                                                                    (Prims.of_int (235))
-                                                                    (Prims.of_int (53)))))
+                                                                    (Prims.of_int (236))
+                                                                    (Prims.of_int (18))
+                                                                    (Prims.of_int (236))
+                                                                    (Prims.of_int (46)))))
                                                             (FStar_Sealed.seal
                                                                (Obj.magic
                                                                   (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (233))
+                                                                    (Prims.of_int (234))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (235))
-                                                                    (Prims.of_int (53)))))
+                                                                    (Prims.of_int (236))
+                                                                    (Prims.of_int (46)))))
                                                             (Obj.magic
                                                                (ill_typed_term
                                                                   t
@@ -2755,11 +2762,8 @@ let (check_term_and_type :
                                                                   Obj.magic
                                                                     (
                                                                     maybe_fail_doc
-                                                                    issues
-                                                                    "Failed to check term at expected type"
-                                                                    g
-                                                                    (FStar_Pervasives_Native.Some
-                                                                    (t.Pulse_Syntax_Base.range1))
+                                                                    issues g
+                                                                    t.Pulse_Syntax_Base.range1
                                                                     uu___2))
                                                                  uu___2))
                                                    | FStar_Pervasives_Native.Some
@@ -2780,18 +2784,18 @@ let (check_term_and_type :
                                                                     Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (238))
+                                                                    (Prims.of_int (239))
                                                                     (Prims.of_int (41))
-                                                                    (Prims.of_int (238))
+                                                                    (Prims.of_int (239))
                                                                     (Prims.of_int (62)))))
                                                                  (FStar_Sealed.seal
                                                                     (
                                                                     Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (238))
+                                                                    (Prims.of_int (239))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (238))
+                                                                    (Prims.of_int (239))
                                                                     (Prims.of_int (62)))))
                                                                  (Obj.magic
                                                                     (
@@ -2818,18 +2822,18 @@ let (check_term_and_type :
                                                                     Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (239))
+                                                                    (Prims.of_int (240))
                                                                     (Prims.of_int (41))
-                                                                    (Prims.of_int (239))
+                                                                    (Prims.of_int (240))
                                                                     (Prims.of_int (63)))))
                                                                  (FStar_Sealed.seal
                                                                     (
                                                                     Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (239))
+                                                                    (Prims.of_int (240))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (239))
+                                                                    (Prims.of_int (240))
                                                                     (Prims.of_int (63)))))
                                                                  (Obj.magic
                                                                     (
@@ -2857,18 +2861,18 @@ let (check_term_and_type :
                                                                     Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (241))
+                                                                    (Prims.of_int (242))
                                                                     (Prims.of_int (27))
-                                                                    (Prims.of_int (241))
+                                                                    (Prims.of_int (242))
                                                                     (Prims.of_int (46)))))
                                                                  (FStar_Sealed.seal
                                                                     (
                                                                     Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (240))
+                                                                    (Prims.of_int (241))
                                                                     (Prims.of_int (26))
-                                                                    (Prims.of_int (242))
+                                                                    (Prims.of_int (243))
                                                                     (Prims.of_int (45)))))
                                                                  (Obj.magic
                                                                     (
@@ -2909,13 +2913,13 @@ let (check_term_with_expected_type_and_effect :
             (FStar_Sealed.seal
                (Obj.magic
                   (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                     (Prims.of_int (247)) (Prims.of_int (13))
-                     (Prims.of_int (247)) (Prims.of_int (43)))))
+                     (Prims.of_int (248)) (Prims.of_int (13))
+                     (Prims.of_int (248)) (Prims.of_int (43)))))
             (FStar_Sealed.seal
                (Obj.magic
                   (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                     (Prims.of_int (245)) (Prims.of_int (39))
-                     (Prims.of_int (264)) (Prims.of_int (78)))))
+                     (Prims.of_int (246)) (Prims.of_int (39))
+                     (Prims.of_int (265)) (Prims.of_int (78)))))
             (Obj.magic (instantiate_term_implicits g e))
             (fun uu___ ->
                (fun uu___ ->
@@ -2927,14 +2931,14 @@ let (check_term_with_expected_type_and_effect :
                               (Obj.magic
                                  (FStar_Range.mk_range
                                     "Pulse.Checker.Pure.fst"
-                                    (Prims.of_int (249)) (Prims.of_int (11))
-                                    (Prims.of_int (249)) (Prims.of_int (21)))))
+                                    (Prims.of_int (250)) (Prims.of_int (11))
+                                    (Prims.of_int (250)) (Prims.of_int (21)))))
                            (FStar_Sealed.seal
                               (Obj.magic
                                  (FStar_Range.mk_range
                                     "Pulse.Checker.Pure.fst"
-                                    (Prims.of_int (249)) (Prims.of_int (24))
-                                    (Prims.of_int (264)) (Prims.of_int (78)))))
+                                    (Prims.of_int (250)) (Prims.of_int (24))
+                                    (Prims.of_int (265)) (Prims.of_int (78)))))
                            (FStar_Tactics_Effect.lift_div_tac
                               (fun uu___2 -> Pulse_Typing.elab_env g))
                            (fun uu___2 ->
@@ -2945,17 +2949,17 @@ let (check_term_with_expected_type_and_effect :
                                          (Obj.magic
                                             (FStar_Range.mk_range
                                                "Pulse.Checker.Pure.fst"
-                                               (Prims.of_int (250))
+                                               (Prims.of_int (251))
                                                (Prims.of_int (11))
-                                               (Prims.of_int (250))
+                                               (Prims.of_int (251))
                                                (Prims.of_int (22)))))
                                       (FStar_Sealed.seal
                                          (Obj.magic
                                             (FStar_Range.mk_range
                                                "Pulse.Checker.Pure.fst"
-                                               (Prims.of_int (250))
+                                               (Prims.of_int (251))
                                                (Prims.of_int (25))
-                                               (Prims.of_int (264))
+                                               (Prims.of_int (265))
                                                (Prims.of_int (78)))))
                                       (FStar_Tactics_Effect.lift_div_tac
                                          (fun uu___2 ->
@@ -2968,17 +2972,17 @@ let (check_term_with_expected_type_and_effect :
                                                     (Obj.magic
                                                        (FStar_Range.mk_range
                                                           "Pulse.Checker.Pure.fst"
-                                                          (Prims.of_int (251))
+                                                          (Prims.of_int (252))
                                                           (Prims.of_int (11))
-                                                          (Prims.of_int (251))
+                                                          (Prims.of_int (252))
                                                           (Prims.of_int (22)))))
                                                  (FStar_Sealed.seal
                                                     (Obj.magic
                                                        (FStar_Range.mk_range
                                                           "Pulse.Checker.Pure.fst"
-                                                          (Prims.of_int (251))
+                                                          (Prims.of_int (252))
                                                           (Prims.of_int (25))
-                                                          (Prims.of_int (264))
+                                                          (Prims.of_int (265))
                                                           (Prims.of_int (78)))))
                                                  (FStar_Tactics_Effect.lift_div_tac
                                                     (fun uu___2 ->
@@ -2992,17 +2996,17 @@ let (check_term_with_expected_type_and_effect :
                                                                (Obj.magic
                                                                   (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (254))
+                                                                    (Prims.of_int (255))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (257))
+                                                                    (Prims.of_int (258))
                                                                     (Prims.of_int (20)))))
                                                             (FStar_Sealed.seal
                                                                (Obj.magic
                                                                   (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (251))
+                                                                    (Prims.of_int (252))
                                                                     (Prims.of_int (25))
-                                                                    (Prims.of_int (264))
+                                                                    (Prims.of_int (265))
                                                                     (Prims.of_int (78)))))
                                                             (Obj.magic
                                                                (catch_all
@@ -3028,17 +3032,17 @@ let (check_term_with_expected_type_and_effect :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (258))
+                                                                    (Prims.of_int (259))
                                                                     (Prims.of_int (2))
-                                                                    (Prims.of_int (258))
+                                                                    (Prims.of_int (259))
                                                                     (Prims.of_int (21)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (259))
+                                                                    (Prims.of_int (260))
                                                                     (Prims.of_int (2))
-                                                                    (Prims.of_int (264))
+                                                                    (Prims.of_int (265))
                                                                     (Prims.of_int (78)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_V2_Builtins.log_issues
@@ -3059,18 +3063,18 @@ let (check_term_with_expected_type_and_effect :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (263))
-                                                                    (Prims.of_int (23))
-                                                                    (Prims.of_int (263))
-                                                                    (Prims.of_int (55)))))
+                                                                    (Prims.of_int (264))
+                                                                    (Prims.of_int (16))
+                                                                    (Prims.of_int (264))
+                                                                    (Prims.of_int (48)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (261))
+                                                                    (Prims.of_int (262))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (263))
-                                                                    (Prims.of_int (55)))))
+                                                                    (Prims.of_int (264))
+                                                                    (Prims.of_int (48)))))
                                                                     (Obj.magic
                                                                     (ill_typed_term
                                                                     e1
@@ -3083,11 +3087,8 @@ let (check_term_with_expected_type_and_effect :
                                                                     uu___4 ->
                                                                     Obj.magic
                                                                     (maybe_fail_doc
-                                                                    issues
-                                                                    "Failed to check term at expected type"
-                                                                    g
-                                                                    (FStar_Pervasives_Native.Some
-                                                                    (e1.Pulse_Syntax_Base.range1))
+                                                                    issues g
+                                                                    e1.Pulse_Syntax_Base.range1
                                                                     uu___4))
                                                                     uu___4)))
                                                                     | 
@@ -3123,13 +3124,13 @@ let (check_term_with_expected_type :
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                            (Prims.of_int (272)) (Prims.of_int (22))
-                            (Prims.of_int (272)) (Prims.of_int (78)))))
+                            (Prims.of_int (273)) (Prims.of_int (22))
+                            (Prims.of_int (273)) (Prims.of_int (78)))))
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                            (Prims.of_int (271)) (Prims.of_int (5))
-                            (Prims.of_int (273)) (Prims.of_int (78)))))
+                            (Prims.of_int (272)) (Prims.of_int (5))
+                            (Prims.of_int (274)) (Prims.of_int (78)))))
                    (Obj.magic
                       (check_term_with_expected_type_and_effect g e
                          FStar_TypeChecker_Core.E_Total t))
@@ -3145,13 +3146,13 @@ let (check_term_with_expected_type :
                (FStar_Sealed.seal
                   (Obj.magic
                      (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                        (Prims.of_int (275)) (Prims.of_int (22))
-                        (Prims.of_int (275)) (Prims.of_int (78)))))
+                        (Prims.of_int (276)) (Prims.of_int (22))
+                        (Prims.of_int (276)) (Prims.of_int (78)))))
                (FStar_Sealed.seal
                   (Obj.magic
                      (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                        (Prims.of_int (274)) (Prims.of_int (13))
-                        (Prims.of_int (276)) (Prims.of_int (26)))))
+                        (Prims.of_int (275)) (Prims.of_int (13))
+                        (Prims.of_int (277)) (Prims.of_int (26)))))
                (Obj.magic
                   (check_term_with_expected_type_and_effect g e
                      FStar_TypeChecker_Core.E_Ghost t))
@@ -3179,13 +3180,13 @@ let (tc_with_core :
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                   (Prims.of_int (280)) (Prims.of_int (23))
-                   (Prims.of_int (280)) (Prims.of_int (117)))))
+                   (Prims.of_int (281)) (Prims.of_int (23))
+                   (Prims.of_int (281)) (Prims.of_int (117)))))
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                   (Prims.of_int (280)) (Prims.of_int (3))
-                   (Prims.of_int (284)) (Prims.of_int (76)))))
+                   (Prims.of_int (281)) (Prims.of_int (3))
+                   (Prims.of_int (285)) (Prims.of_int (76)))))
           (Obj.magic
              (catch_all
                 (fun uu___ ->
@@ -3219,13 +3220,13 @@ let (core_check_term :
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                 (Prims.of_int (290)) (Prims.of_int (13))
-                 (Prims.of_int (290)) (Prims.of_int (23)))))
+                 (Prims.of_int (291)) (Prims.of_int (13))
+                 (Prims.of_int (291)) (Prims.of_int (23)))))
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                 (Prims.of_int (290)) (Prims.of_int (26))
-                 (Prims.of_int (304)) (Prims.of_int (30)))))
+                 (Prims.of_int (291)) (Prims.of_int (26))
+                 (Prims.of_int (305)) (Prims.of_int (30)))))
         (FStar_Tactics_Effect.lift_div_tac
            (fun uu___ -> Pulse_Typing.elab_env g))
         (fun uu___ ->
@@ -3235,13 +3236,13 @@ let (core_check_term :
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                            (Prims.of_int (291)) (Prims.of_int (13))
-                            (Prims.of_int (291)) (Prims.of_int (24)))))
+                            (Prims.of_int (292)) (Prims.of_int (13))
+                            (Prims.of_int (292)) (Prims.of_int (24)))))
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                            (Prims.of_int (291)) (Prims.of_int (27))
-                            (Prims.of_int (304)) (Prims.of_int (30)))))
+                            (Prims.of_int (292)) (Prims.of_int (27))
+                            (Prims.of_int (305)) (Prims.of_int (30)))))
                    (FStar_Tactics_Effect.lift_div_tac
                       (fun uu___ -> Pulse_Elaborate_Pure.elab_term t))
                    (fun uu___ ->
@@ -3252,17 +3253,17 @@ let (core_check_term :
                                  (Obj.magic
                                     (FStar_Range.mk_range
                                        "Pulse.Checker.Pure.fst"
-                                       (Prims.of_int (292))
+                                       (Prims.of_int (293))
                                        (Prims.of_int (22))
-                                       (Prims.of_int (292))
+                                       (Prims.of_int (293))
                                        (Prims.of_int (94)))))
                               (FStar_Sealed.seal
                                  (Obj.magic
                                     (FStar_Range.mk_range
                                        "Pulse.Checker.Pure.fst"
-                                       (Prims.of_int (291))
+                                       (Prims.of_int (292))
                                        (Prims.of_int (27))
-                                       (Prims.of_int (304))
+                                       (Prims.of_int (305))
                                        (Prims.of_int (30)))))
                               (Obj.magic
                                  (tc_with_core
@@ -3280,17 +3281,17 @@ let (core_check_term :
                                                 (Obj.magic
                                                    (FStar_Range.mk_range
                                                       "Pulse.Checker.Pure.fst"
-                                                      (Prims.of_int (293))
+                                                      (Prims.of_int (294))
                                                       (Prims.of_int (4))
-                                                      (Prims.of_int (293))
+                                                      (Prims.of_int (294))
                                                       (Prims.of_int (23)))))
                                              (FStar_Sealed.seal
                                                 (Obj.magic
                                                    (FStar_Range.mk_range
                                                       "Pulse.Checker.Pure.fst"
-                                                      (Prims.of_int (294))
+                                                      (Prims.of_int (295))
                                                       (Prims.of_int (4))
-                                                      (Prims.of_int (304))
+                                                      (Prims.of_int (305))
                                                       (Prims.of_int (30)))))
                                              (Obj.magic
                                                 (FStar_Tactics_V2_Builtins.log_issues
@@ -3307,18 +3308,18 @@ let (core_check_term :
                                                                   (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (298))
-                                                                    (Prims.of_int (25))
-                                                                    (Prims.of_int (298))
-                                                                    (Prims.of_int (53)))))
+                                                                    (Prims.of_int (299))
+                                                                    (Prims.of_int (18))
+                                                                    (Prims.of_int (299))
+                                                                    (Prims.of_int (46)))))
                                                                (FStar_Sealed.seal
                                                                   (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (296))
+                                                                    (Prims.of_int (297))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (298))
-                                                                    (Prims.of_int (53)))))
+                                                                    (Prims.of_int (299))
+                                                                    (Prims.of_int (46)))))
                                                                (Obj.magic
                                                                   (ill_typed_term
                                                                     t
@@ -3329,11 +3330,8 @@ let (core_check_term :
                                                                     ->
                                                                     Obj.magic
                                                                     (maybe_fail_doc
-                                                                    issues
-                                                                    "Failed to check term"
-                                                                    g
-                                                                    (FStar_Pervasives_Native.Some
-                                                                    (t.Pulse_Syntax_Base.range1))
+                                                                    issues g
+                                                                    t.Pulse_Syntax_Base.range1
                                                                     uu___2))
                                                                     uu___2)))
                                                    | FStar_Pervasives_Native.Some
@@ -3352,17 +3350,17 @@ let (core_check_term :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (302))
+                                                                    (Prims.of_int (303))
                                                                     (Prims.of_int (32))
-                                                                    (Prims.of_int (302))
+                                                                    (Prims.of_int (303))
                                                                     (Prims.of_int (54)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (302))
+                                                                    (Prims.of_int (303))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (302))
+                                                                    (Prims.of_int (303))
                                                                     (Prims.of_int (54)))))
                                                                     (Obj.magic
                                                                     (readback_failure
@@ -3403,13 +3401,13 @@ let (core_check_term_with_expected_type :
             (FStar_Sealed.seal
                (Obj.magic
                   (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                     (Prims.of_int (307)) (Prims.of_int (11))
-                     (Prims.of_int (307)) (Prims.of_int (21)))))
+                     (Prims.of_int (308)) (Prims.of_int (11))
+                     (Prims.of_int (308)) (Prims.of_int (21)))))
             (FStar_Sealed.seal
                (Obj.magic
                   (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                     (Prims.of_int (307)) (Prims.of_int (24))
-                     (Prims.of_int (321)) (Prims.of_int (69)))))
+                     (Prims.of_int (308)) (Prims.of_int (24))
+                     (Prims.of_int (322)) (Prims.of_int (69)))))
             (FStar_Tactics_Effect.lift_div_tac
                (fun uu___ -> Pulse_Typing.elab_env g))
             (fun uu___ ->
@@ -3419,13 +3417,13 @@ let (core_check_term_with_expected_type :
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                                (Prims.of_int (308)) (Prims.of_int (11))
-                                (Prims.of_int (308)) (Prims.of_int (22)))))
+                                (Prims.of_int (309)) (Prims.of_int (11))
+                                (Prims.of_int (309)) (Prims.of_int (22)))))
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                                (Prims.of_int (308)) (Prims.of_int (25))
-                                (Prims.of_int (321)) (Prims.of_int (69)))))
+                                (Prims.of_int (309)) (Prims.of_int (25))
+                                (Prims.of_int (322)) (Prims.of_int (69)))))
                        (FStar_Tactics_Effect.lift_div_tac
                           (fun uu___ -> Pulse_Elaborate_Pure.elab_term e))
                        (fun uu___ ->
@@ -3436,17 +3434,17 @@ let (core_check_term_with_expected_type :
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "Pulse.Checker.Pure.fst"
-                                           (Prims.of_int (309))
+                                           (Prims.of_int (310))
                                            (Prims.of_int (11))
-                                           (Prims.of_int (309))
+                                           (Prims.of_int (310))
                                            (Prims.of_int (22)))))
                                   (FStar_Sealed.seal
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "Pulse.Checker.Pure.fst"
-                                           (Prims.of_int (309))
+                                           (Prims.of_int (310))
                                            (Prims.of_int (25))
-                                           (Prims.of_int (321))
+                                           (Prims.of_int (322))
                                            (Prims.of_int (69)))))
                                   (FStar_Tactics_Effect.lift_div_tac
                                      (fun uu___ ->
@@ -3459,17 +3457,17 @@ let (core_check_term_with_expected_type :
                                                 (Obj.magic
                                                    (FStar_Range.mk_range
                                                       "Pulse.Checker.Pure.fst"
-                                                      (Prims.of_int (311))
+                                                      (Prims.of_int (312))
                                                       (Prims.of_int (4))
-                                                      (Prims.of_int (314))
+                                                      (Prims.of_int (315))
                                                       (Prims.of_int (20)))))
                                              (FStar_Sealed.seal
                                                 (Obj.magic
                                                    (FStar_Range.mk_range
                                                       "Pulse.Checker.Pure.fst"
-                                                      (Prims.of_int (309))
+                                                      (Prims.of_int (310))
                                                       (Prims.of_int (25))
-                                                      (Prims.of_int (321))
+                                                      (Prims.of_int (322))
                                                       (Prims.of_int (69)))))
                                              (Obj.magic
                                                 (catch_all
@@ -3491,17 +3489,17 @@ let (core_check_term_with_expected_type :
                                                                (Obj.magic
                                                                   (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (315))
+                                                                    (Prims.of_int (316))
                                                                     (Prims.of_int (2))
-                                                                    (Prims.of_int (315))
+                                                                    (Prims.of_int (316))
                                                                     (Prims.of_int (21)))))
                                                             (FStar_Sealed.seal
                                                                (Obj.magic
                                                                   (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (316))
+                                                                    (Prims.of_int (317))
                                                                     (Prims.of_int (2))
-                                                                    (Prims.of_int (321))
+                                                                    (Prims.of_int (322))
                                                                     (Prims.of_int (69)))))
                                                             (Obj.magic
                                                                (FStar_Tactics_V2_Builtins.log_issues
@@ -3519,18 +3517,18 @@ let (core_check_term_with_expected_type :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (320))
-                                                                    (Prims.of_int (23))
-                                                                    (Prims.of_int (320))
-                                                                    (Prims.of_int (55)))))
+                                                                    (Prims.of_int (321))
+                                                                    (Prims.of_int (16))
+                                                                    (Prims.of_int (321))
+                                                                    (Prims.of_int (48)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (318))
+                                                                    (Prims.of_int (319))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (320))
-                                                                    (Prims.of_int (55)))))
+                                                                    (Prims.of_int (321))
+                                                                    (Prims.of_int (48)))))
                                                                     (Obj.magic
                                                                     (ill_typed_term
                                                                     e
@@ -3543,11 +3541,8 @@ let (core_check_term_with_expected_type :
                                                                     uu___2 ->
                                                                     Obj.magic
                                                                     (maybe_fail_doc
-                                                                    issues
-                                                                    "Failed to check term"
-                                                                    g
-                                                                    (FStar_Pervasives_Native.Some
-                                                                    (e.Pulse_Syntax_Base.range1))
+                                                                    issues g
+                                                                    e.Pulse_Syntax_Base.range1
                                                                     uu___2))
                                                                     uu___2)))
                                                                   | FStar_Pervasives_Native.Some
@@ -3600,13 +3595,13 @@ let (get_non_informative_witness :
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                   (Prims.of_int (344)) (Prims.of_int (6))
-                   (Prims.of_int (348)) (Prims.of_int (7)))))
+                   (Prims.of_int (345)) (Prims.of_int (6))
+                   (Prims.of_int (349)) (Prims.of_int (7)))))
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                   (Prims.of_int (349)) (Prims.of_int (6))
-                   (Prims.of_int (383)) (Prims.of_int (39)))))
+                   (Prims.of_int (350)) (Prims.of_int (6))
+                   (Prims.of_int (384)) (Prims.of_int (39)))))
           (FStar_Tactics_Effect.lift_div_tac
              (fun uu___ ->
                 fun uu___1 ->
@@ -3614,44 +3609,44 @@ let (get_non_informative_witness :
                     (FStar_Sealed.seal
                        (Obj.magic
                           (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                             (Prims.of_int (345)) (Prims.of_int (32))
-                             (Prims.of_int (348)) (Prims.of_int (7)))))
+                             (Prims.of_int (346)) (Prims.of_int (32))
+                             (Prims.of_int (349)) (Prims.of_int (7)))))
                     (FStar_Sealed.seal
                        (Obj.magic
                           (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                             (Prims.of_int (345)) (Prims.of_int (6))
-                             (Prims.of_int (348)) (Prims.of_int (7)))))
+                             (Prims.of_int (346)) (Prims.of_int (6))
+                             (Prims.of_int (349)) (Prims.of_int (7)))))
                     (Obj.magic
                        (FStar_Tactics_Effect.tac_bind
                           (FStar_Sealed.seal
                              (Obj.magic
                                 (FStar_Range.mk_range
                                    "Pulse.Checker.Pure.fst"
-                                   (Prims.of_int (346)) (Prims.of_int (8))
-                                   (Prims.of_int (347)) (Prims.of_int (18)))))
+                                   (Prims.of_int (347)) (Prims.of_int (8))
+                                   (Prims.of_int (348)) (Prims.of_int (18)))))
                           (FStar_Sealed.seal
                              (Obj.magic
                                 (FStar_Range.mk_range
                                    "Pulse.Checker.Pure.fst"
-                                   (Prims.of_int (345)) (Prims.of_int (32))
-                                   (Prims.of_int (348)) (Prims.of_int (7)))))
+                                   (Prims.of_int (346)) (Prims.of_int (32))
+                                   (Prims.of_int (349)) (Prims.of_int (7)))))
                           (Obj.magic
                              (FStar_Tactics_Effect.tac_bind
                                 (FStar_Sealed.seal
                                    (Obj.magic
                                       (FStar_Range.mk_range
                                          "Pulse.Checker.Pure.fst"
-                                         (Prims.of_int (347))
+                                         (Prims.of_int (348))
                                          (Prims.of_int (14))
-                                         (Prims.of_int (347))
+                                         (Prims.of_int (348))
                                          (Prims.of_int (18)))))
                                 (FStar_Sealed.seal
                                    (Obj.magic
                                       (FStar_Range.mk_range
                                          "Pulse.Checker.Pure.fst"
-                                         (Prims.of_int (346))
-                                         (Prims.of_int (8))
                                          (Prims.of_int (347))
+                                         (Prims.of_int (8))
+                                         (Prims.of_int (348))
                                          (Prims.of_int (18)))))
                                 (Obj.magic (Pulse_PP.pp Pulse_PP.uu___44 t))
                                 (fun uu___2 ->
@@ -3678,13 +3673,13 @@ let (get_non_informative_witness :
                      (FStar_Sealed.seal
                         (Obj.magic
                            (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                              (Prims.of_int (350)) (Prims.of_int (14))
-                              (Prims.of_int (374)) (Prims.of_int (17)))))
+                              (Prims.of_int (351)) (Prims.of_int (14))
+                              (Prims.of_int (375)) (Prims.of_int (17)))))
                      (FStar_Sealed.seal
                         (Obj.magic
                            (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                              (Prims.of_int (376)) (Prims.of_int (4))
-                              (Prims.of_int (383)) (Prims.of_int (39)))))
+                              (Prims.of_int (377)) (Prims.of_int (4))
+                              (Prims.of_int (384)) (Prims.of_int (39)))))
                      (FStar_Tactics_Effect.lift_div_tac
                         (fun uu___ ->
                            match Pulse_Syntax_Pure.is_fvar_app t with
@@ -3783,13 +3778,13 @@ let (check_prop_validity :
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                   (Prims.of_int (387)) (Prims.of_int (24))
-                   (Prims.of_int (387)) (Prims.of_int (76)))))
+                   (Prims.of_int (388)) (Prims.of_int (24))
+                   (Prims.of_int (388)) (Prims.of_int (76)))))
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                   (Prims.of_int (387)) (Prims.of_int (3))
-                   (Prims.of_int (394)) (Prims.of_int (20)))))
+                   (Prims.of_int (388)) (Prims.of_int (3))
+                   (Prims.of_int (395)) (Prims.of_int (21)))))
           (Obj.magic
              (rtb_check_prop_validity g (Pulse_Typing.elab_env g)
                 (Pulse_Elaborate_Pure.elab_term p)))
@@ -3802,13 +3797,13 @@ let (check_prop_validity :
                          (FStar_Sealed.seal
                             (Obj.magic
                                (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                                  (Prims.of_int (388)) (Prims.of_int (4))
-                                  (Prims.of_int (388)) (Prims.of_int (23)))))
+                                  (Prims.of_int (389)) (Prims.of_int (4))
+                                  (Prims.of_int (389)) (Prims.of_int (23)))))
                          (FStar_Sealed.seal
                             (Obj.magic
                                (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                                  (Prims.of_int (389)) (Prims.of_int (4))
-                                  (Prims.of_int (394)) (Prims.of_int (20)))))
+                                  (Prims.of_int (390)) (Prims.of_int (4))
+                                  (Prims.of_int (395)) (Prims.of_int (21)))))
                          (Obj.magic
                             (FStar_Tactics_V2_Builtins.log_issues issues))
                          (fun uu___2 ->
@@ -3822,52 +3817,73 @@ let (check_prop_validity :
                                               (Obj.magic
                                                  (FStar_Range.mk_range
                                                     "Pulse.Checker.Pure.fst"
-                                                    (Prims.of_int (392))
-                                                    (Prims.of_int (13))
-                                                    (Prims.of_int (393))
-                                                    (Prims.of_int (62)))))
+                                                    (Prims.of_int (394))
+                                                    (Prims.of_int (21))
+                                                    (Prims.of_int (394))
+                                                    (Prims.of_int (64)))))
                                            (FStar_Sealed.seal
                                               (Obj.magic
                                                  (FStar_Range.mk_range
                                                     "Pulse.Checker.Pure.fst"
-                                                    (Prims.of_int (391))
-                                                    (Prims.of_int (6))
                                                     (Prims.of_int (393))
-                                                    (Prims.of_int (62)))))
+                                                    (Prims.of_int (6))
+                                                    (Prims.of_int (394))
+                                                    (Prims.of_int (64)))))
                                            (Obj.magic
                                               (FStar_Tactics_Effect.tac_bind
                                                  (FStar_Sealed.seal
                                                     (Obj.magic
                                                        (FStar_Range.mk_range
                                                           "Pulse.Checker.Pure.fst"
-                                                          (Prims.of_int (393))
+                                                          (Prims.of_int (394))
                                                           (Prims.of_int (22))
-                                                          (Prims.of_int (393))
-                                                          (Prims.of_int (61)))))
+                                                          (Prims.of_int (394))
+                                                          (Prims.of_int (63)))))
                                                  (FStar_Sealed.seal
                                                     (Obj.magic
                                                        (FStar_Range.mk_range
-                                                          "prims.fst"
-                                                          (Prims.of_int (590))
-                                                          (Prims.of_int (19))
-                                                          (Prims.of_int (590))
-                                                          (Prims.of_int (31)))))
+                                                          "Pulse.Checker.Pure.fst"
+                                                          (Prims.of_int (394))
+                                                          (Prims.of_int (21))
+                                                          (Prims.of_int (394))
+                                                          (Prims.of_int (64)))))
                                                  (Obj.magic
-                                                    (Pulse_Syntax_Printer.term_to_string
-                                                       p))
+                                                    (FStar_Tactics_Effect.tac_bind
+                                                       (FStar_Sealed.seal
+                                                          (Obj.magic
+                                                             (FStar_Range.mk_range
+                                                                "Pulse.Checker.Pure.fst"
+                                                                (Prims.of_int (394))
+                                                                (Prims.of_int (59))
+                                                                (Prims.of_int (394))
+                                                                (Prims.of_int (63)))))
+                                                       (FStar_Sealed.seal
+                                                          (Obj.magic
+                                                             (FStar_Range.mk_range
+                                                                "Pulse.Checker.Pure.fst"
+                                                                (Prims.of_int (394))
+                                                                (Prims.of_int (22))
+                                                                (Prims.of_int (394))
+                                                                (Prims.of_int (63)))))
+                                                       (Obj.magic
+                                                          (Pulse_PP.pp
+                                                             Pulse_PP.uu___44
+                                                             p))
+                                                       (fun uu___3 ->
+                                                          FStar_Tactics_Effect.lift_div_tac
+                                                            (fun uu___4 ->
+                                                               FStar_Pprint.op_Hat_Slash_Hat
+                                                                 (Pulse_PP.text
+                                                                    "Failed to prove property:")
+                                                                 uu___3))))
                                                  (fun uu___3 ->
                                                     FStar_Tactics_Effect.lift_div_tac
-                                                      (fun uu___4 ->
-                                                         Prims.strcat
-                                                           "Failed to prove property: "
-                                                           (Prims.strcat
-                                                              uu___3 "\n")))))
+                                                      (fun uu___4 -> [uu___3]))))
                                            (fun uu___3 ->
                                               (fun uu___3 ->
                                                  Obj.magic
-                                                   (Pulse_Typing_Env.fail g
-                                                      (FStar_Pervasives_Native.Some
-                                                         (p.Pulse_Syntax_Base.range1))
+                                                   (maybe_fail_doc issues g
+                                                      p.Pulse_Syntax_Base.range1
                                                       uu___3)) uu___3)))
                                | FStar_Pervasives_Native.Some tok ->
                                    Obj.magic
@@ -3886,20 +3902,20 @@ let fail_expected_tot_found_ghost :
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                 (Prims.of_int (398)) (Prims.of_int (4)) (Prims.of_int (398))
+                 (Prims.of_int (399)) (Prims.of_int (4)) (Prims.of_int (399))
                  (Prims.of_int (86)))))
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                 (Prims.of_int (397)) (Prims.of_int (2)) (Prims.of_int (398))
+                 (Prims.of_int (398)) (Prims.of_int (2)) (Prims.of_int (399))
                  (Prims.of_int (86)))))
         (Obj.magic
            (FStar_Tactics_Effect.tac_bind
               (FStar_Sealed.seal
                  (Obj.magic
                     (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                       (Prims.of_int (398)) (Prims.of_int (65))
-                       (Prims.of_int (398)) (Prims.of_int (85)))))
+                       (Prims.of_int (399)) (Prims.of_int (65))
+                       (Prims.of_int (399)) (Prims.of_int (85)))))
               (FStar_Sealed.seal
                  (Obj.magic
                     (FStar_Range.mk_range "prims.fst" (Prims.of_int (590))
@@ -3930,13 +3946,13 @@ let (check_tot_term :
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                 (Prims.of_int (401)) (Prims.of_int (35))
-                 (Prims.of_int (401)) (Prims.of_int (49)))))
+                 (Prims.of_int (402)) (Prims.of_int (35))
+                 (Prims.of_int (402)) (Prims.of_int (49)))))
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                 (Prims.of_int (400)) (Prims.of_int (24))
-                 (Prims.of_int (403)) (Prims.of_int (40)))))
+                 (Prims.of_int (401)) (Prims.of_int (24))
+                 (Prims.of_int (404)) (Prims.of_int (40)))))
         (Obj.magic (check_term g t))
         (fun uu___ ->
            (fun uu___ ->
@@ -3965,13 +3981,13 @@ let (check_tot_term_and_type :
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                 (Prims.of_int (406)) (Prims.of_int (55))
-                 (Prims.of_int (406)) (Prims.of_int (78)))))
+                 (Prims.of_int (407)) (Prims.of_int (55))
+                 (Prims.of_int (407)) (Prims.of_int (78)))))
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                 (Prims.of_int (405)) (Prims.of_int (33))
-                 (Prims.of_int (408)) (Prims.of_int (40)))))
+                 (Prims.of_int (406)) (Prims.of_int (33))
+                 (Prims.of_int (409)) (Prims.of_int (40)))))
         (Obj.magic (check_term_and_type g t))
         (fun uu___ ->
            (fun uu___ ->
@@ -4012,13 +4028,13 @@ let (core_check_tot_term :
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                 (Prims.of_int (414)) (Prims.of_int (25))
-                 (Prims.of_int (414)) (Prims.of_int (44)))))
+                 (Prims.of_int (415)) (Prims.of_int (25))
+                 (Prims.of_int (415)) (Prims.of_int (44)))))
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                 (Prims.of_int (413)) (Prims.of_int (29))
-                 (Prims.of_int (416)) (Prims.of_int (40)))))
+                 (Prims.of_int (414)) (Prims.of_int (29))
+                 (Prims.of_int (417)) (Prims.of_int (40)))))
         (Obj.magic (core_check_term g t))
         (fun uu___ ->
            (fun uu___ ->
@@ -4056,13 +4072,13 @@ let (is_non_informative :
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                 (Prims.of_int (422)) (Prims.of_int (21))
-                 (Prims.of_int (422)) (Prims.of_int (89)))))
+                 (Prims.of_int (423)) (Prims.of_int (21))
+                 (Prims.of_int (423)) (Prims.of_int (89)))))
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                 (Prims.of_int (421)) (Prims.of_int (28))
-                 (Prims.of_int (424)) (Prims.of_int (6)))))
+                 (Prims.of_int (422)) (Prims.of_int (28))
+                 (Prims.of_int (425)) (Prims.of_int (6)))))
         (Obj.magic
            (catch_all
               (fun uu___ ->
@@ -4078,13 +4094,13 @@ let (is_non_informative :
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                                (Prims.of_int (423)) (Prims.of_int (2))
-                                (Prims.of_int (423)) (Prims.of_int (21)))))
+                                (Prims.of_int (424)) (Prims.of_int (2))
+                                (Prims.of_int (424)) (Prims.of_int (21)))))
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                                (Prims.of_int (422)) (Prims.of_int (6))
-                                (Prims.of_int (422)) (Prims.of_int (10)))))
+                                (Prims.of_int (423)) (Prims.of_int (6))
+                                (Prims.of_int (423)) (Prims.of_int (10)))))
                        (Obj.magic
                           (FStar_Tactics_V2_Builtins.log_issues issues))
                        (fun uu___1 ->
@@ -4106,13 +4122,13 @@ let (check_subtyping :
                (FStar_Sealed.seal
                   (Obj.magic
                      (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                        (Prims.of_int (428)) (Prims.of_int (20))
-                        (Prims.of_int (428)) (Prims.of_int (47)))))
+                        (Prims.of_int (429)) (Prims.of_int (20))
+                        (Prims.of_int (429)) (Prims.of_int (47)))))
                (FStar_Sealed.seal
                   (Obj.magic
                      (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                        (Prims.of_int (427)) (Prims.of_int (34))
-                        (Prims.of_int (437)) (Prims.of_int (31)))))
+                        (Prims.of_int (428)) (Prims.of_int (34))
+                        (Prims.of_int (437)) (Prims.of_int (47)))))
                (Obj.magic (rtb_check_subtyping g t1 t2))
                (fun uu___1 ->
                   (fun uu___1 ->
@@ -4124,18 +4140,18 @@ let (check_subtyping :
                                  (Obj.magic
                                     (FStar_Range.mk_range
                                        "Pulse.Checker.Pure.fst"
-                                       (Prims.of_int (429))
+                                       (Prims.of_int (430))
                                        (Prims.of_int (2))
-                                       (Prims.of_int (429))
+                                       (Prims.of_int (430))
                                        (Prims.of_int (21)))))
                               (FStar_Sealed.seal
                                  (Obj.magic
                                     (FStar_Range.mk_range
                                        "Pulse.Checker.Pure.fst"
-                                       (Prims.of_int (430))
+                                       (Prims.of_int (431))
                                        (Prims.of_int (2))
                                        (Prims.of_int (437))
-                                       (Prims.of_int (31)))))
+                                       (Prims.of_int (47)))))
                               (Obj.magic
                                  (FStar_Tactics_V2_Builtins.log_issues issues))
                               (fun uu___2 ->
@@ -4154,112 +4170,156 @@ let (check_subtyping :
                                                    (Obj.magic
                                                       (FStar_Range.mk_range
                                                          "Pulse.Checker.Pure.fst"
-                                                         (Prims.of_int (434))
-                                                         (Prims.of_int (6))
+                                                         (Prims.of_int (436))
+                                                         (Prims.of_int (10))
                                                          (Prims.of_int (437))
-                                                         (Prims.of_int (31)))))
+                                                         (Prims.of_int (47)))))
                                                 (FStar_Sealed.seal
                                                    (Obj.magic
                                                       (FStar_Range.mk_range
                                                          "Pulse.Checker.Pure.fst"
-                                                         (Prims.of_int (433))
+                                                         (Prims.of_int (435))
                                                          (Prims.of_int (4))
                                                          (Prims.of_int (437))
-                                                         (Prims.of_int (31)))))
+                                                         (Prims.of_int (47)))))
                                                 (Obj.magic
                                                    (FStar_Tactics_Effect.tac_bind
                                                       (FStar_Sealed.seal
                                                          (Obj.magic
                                                             (FStar_Range.mk_range
                                                                "Pulse.Checker.Pure.fst"
+                                                               (Prims.of_int (436))
+                                                               (Prims.of_int (12))
                                                                (Prims.of_int (437))
-                                                               (Prims.of_int (9))
-                                                               (Prims.of_int (437))
-                                                               (Prims.of_int (30)))))
+                                                               (Prims.of_int (46)))))
                                                       (FStar_Sealed.seal
                                                          (Obj.magic
                                                             (FStar_Range.mk_range
                                                                "Pulse.Checker.Pure.fst"
-                                                               (Prims.of_int (434))
-                                                               (Prims.of_int (6))
+                                                               (Prims.of_int (436))
+                                                               (Prims.of_int (10))
                                                                (Prims.of_int (437))
-                                                               (Prims.of_int (31)))))
+                                                               (Prims.of_int (47)))))
                                                       (Obj.magic
-                                                         (Pulse_Syntax_Printer.term_to_string
-                                                            t2))
-                                                      (fun uu___3 ->
-                                                         (fun uu___3 ->
-                                                            Obj.magic
-                                                              (FStar_Tactics_Effect.tac_bind
-                                                                 (FStar_Sealed.seal
-                                                                    (
-                                                                    Obj.magic
-                                                                    (FStar_Range.mk_range
+                                                         (FStar_Tactics_Effect.tac_bind
+                                                            (FStar_Sealed.seal
+                                                               (Obj.magic
+                                                                  (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (434))
-                                                                    (Prims.of_int (6))
                                                                     (Prims.of_int (437))
-                                                                    (Prims.of_int (31)))))
-                                                                 (FStar_Sealed.seal
-                                                                    (
-                                                                    Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (434))
-                                                                    (Prims.of_int (6))
+                                                                    (Prims.of_int (16))
                                                                     (Prims.of_int (437))
-                                                                    (Prims.of_int (31)))))
-                                                                 (Obj.magic
-                                                                    (
-                                                                    FStar_Tactics_Effect.tac_bind
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
+                                                                    (Prims.of_int (46)))))
+                                                            (FStar_Sealed.seal
+                                                               (Obj.magic
+                                                                  (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
                                                                     (Prims.of_int (436))
-                                                                    (Prims.of_int (9))
-                                                                    (Prims.of_int (436))
-                                                                    (Prims.of_int (30)))))
-                                                                    (FStar_Sealed.seal
+                                                                    (Prims.of_int (12))
+                                                                    (Prims.of_int (437))
+                                                                    (Prims.of_int (46)))))
+                                                            (Obj.magic
+                                                               (FStar_Tactics_Effect.tac_bind
+                                                                  (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
-                                                                    "FStar.Printf.fst"
-                                                                    (Prims.of_int (121))
-                                                                    (Prims.of_int (8))
-                                                                    (Prims.of_int (123))
-                                                                    (Prims.of_int (44)))))
+                                                                    "Pulse.Checker.Pure.fst"
+                                                                    (Prims.of_int (437))
+                                                                    (Prims.of_int (16))
+                                                                    (Prims.of_int (437))
+                                                                    (Prims.of_int (21)))))
+                                                                  (FStar_Sealed.seal
                                                                     (Obj.magic
-                                                                    (Pulse_Syntax_Printer.term_to_string
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Pure.fst"
+                                                                    (Prims.of_int (437))
+                                                                    (Prims.of_int (16))
+                                                                    (Prims.of_int (437))
+                                                                    (Prims.of_int (46)))))
+                                                                  (Obj.magic
+                                                                    (Pulse_PP.pp
+                                                                    Pulse_PP.uu___44
                                                                     t1))
+                                                                  (fun uu___3
+                                                                    ->
+                                                                    (fun
+                                                                    uu___3 ->
+                                                                    Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Pure.fst"
+                                                                    (Prims.of_int (437))
+                                                                    (Prims.of_int (26))
+                                                                    (Prims.of_int (437))
+                                                                    (Prims.of_int (46)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Pure.fst"
+                                                                    (Prims.of_int (437))
+                                                                    (Prims.of_int (16))
+                                                                    (Prims.of_int (437))
+                                                                    (Prims.of_int (46)))))
+                                                                    (Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Pure.fst"
+                                                                    (Prims.of_int (437))
+                                                                    (Prims.of_int (41))
+                                                                    (Prims.of_int (437))
+                                                                    (Prims.of_int (46)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Pure.fst"
+                                                                    (Prims.of_int (437))
+                                                                    (Prims.of_int (26))
+                                                                    (Prims.of_int (437))
+                                                                    (Prims.of_int (46)))))
+                                                                    (Obj.magic
+                                                                    (Pulse_PP.pp
+                                                                    Pulse_PP.uu___44
+                                                                    t2))
                                                                     (fun
                                                                     uu___4 ->
                                                                     FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
                                                                     uu___5 ->
-                                                                    fun x ->
-                                                                    Prims.strcat
-                                                                    (Prims.strcat
-                                                                    "Could not prove subtyping of "
-                                                                    (Prims.strcat
-                                                                    uu___4
-                                                                    " and "))
-                                                                    (Prims.strcat
-                                                                    x "")))))
-                                                                 (fun uu___4
-                                                                    ->
+                                                                    FStar_Pprint.op_Hat_Slash_Hat
+                                                                    (Pulse_PP.text
+                                                                    "and")
+                                                                    uu___4))))
+                                                                    (fun
+                                                                    uu___4 ->
                                                                     FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
                                                                     uu___5 ->
-                                                                    uu___4
+                                                                    FStar_Pprint.op_Hat_Slash_Hat
+                                                                    uu___3
+                                                                    uu___4))))
+                                                                    uu___3)))
+                                                            (fun uu___3 ->
+                                                               FStar_Tactics_Effect.lift_div_tac
+                                                                 (fun uu___4
+                                                                    ->
+                                                                    FStar_Pprint.op_Hat_Slash_Hat
+                                                                    (Pulse_PP.text
+                                                                    "Could not prove subtyping of ")
                                                                     uu___3))))
-                                                           uu___3)))
+                                                      (fun uu___3 ->
+                                                         FStar_Tactics_Effect.lift_div_tac
+                                                           (fun uu___4 ->
+                                                              [uu___3]))))
                                                 (fun uu___3 ->
                                                    (fun uu___3 ->
                                                       Obj.magic
-                                                        (Pulse_Typing_Env.fail
-                                                           g
-                                                           (FStar_Pervasives_Native.Some
-                                                              (t1.Pulse_Syntax_Base.range1))
+                                                        (maybe_fail_doc
+                                                           issues g
+                                                           t1.Pulse_Syntax_Base.range1
                                                            uu___3)) uu___3))))
                                    uu___2))) uu___1))
 let (check_equiv :

--- a/src/ocaml/plugin/generated/Pulse_Checker_Pure.ml
+++ b/src/ocaml/plugin/generated/Pulse_Checker_Pure.ml
@@ -1696,6 +1696,48 @@ let (ill_typed_term :
                                          uu___1)))) uu___)))
               (fun uu___ ->
                  FStar_Tactics_Effect.lift_div_tac (fun uu___1 -> [uu___]))
+let maybe_fail_doc :
+  'uuuuu .
+    FStar_Issue.issue Prims.list ->
+      Prims.string ->
+        Pulse_Typing_Env.env ->
+          Pulse_Syntax_Base.range FStar_Pervasives_Native.option ->
+            FStar_Pprint.document Prims.list ->
+              ('uuuuu, unit) FStar_Tactics_Effect.tac_repr
+  =
+  fun issues ->
+    fun msg ->
+      fun g ->
+        fun range ->
+          fun doc ->
+            FStar_Tactics_Effect.tac_bind
+              (FStar_Sealed.seal
+                 (Obj.magic
+                    (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
+                       (Prims.of_int (131)) (Prims.of_int (6))
+                       (Prims.of_int (135)) (Prims.of_int (14)))))
+              (FStar_Sealed.seal
+                 (Obj.magic
+                    (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
+                       (Prims.of_int (137)) (Prims.of_int (2))
+                       (Prims.of_int (139)) (Prims.of_int (27)))))
+              (FStar_Tactics_Effect.lift_div_tac
+                 (fun uu___ ->
+                    FStar_List_Tot_Base.existsb
+                      (fun i ->
+                         ((FStar_Issue.level_of_issue i) = "Error") &&
+                           (FStar_Pervasives_Native.uu___is_Some
+                              (FStar_Issue.range_of_issue i))) issues))
+              (fun uu___ ->
+                 (fun has_localized_error ->
+                    if has_localized_error
+                    then
+                      Obj.magic
+                        (Obj.repr (FStar_Tactics_V2_Derived.fail msg))
+                    else
+                      Obj.magic
+                        (Obj.repr (Pulse_Typing_Env.fail_doc g range doc)))
+                   uu___)
 let (instantiate_term_implicits :
   Pulse_Typing_Env.env ->
     Pulse_Syntax_Base.term ->
@@ -1708,13 +1750,13 @@ let (instantiate_term_implicits :
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                 (Prims.of_int (129)) (Prims.of_int (10))
-                 (Prims.of_int (129)) (Prims.of_int (20)))))
+                 (Prims.of_int (142)) (Prims.of_int (10))
+                 (Prims.of_int (142)) (Prims.of_int (20)))))
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                 (Prims.of_int (129)) (Prims.of_int (23))
-                 (Prims.of_int (149)) (Prims.of_int (49)))))
+                 (Prims.of_int (142)) (Prims.of_int (23))
+                 (Prims.of_int (164)) (Prims.of_int (49)))))
         (FStar_Tactics_Effect.lift_div_tac
            (fun uu___ -> Pulse_Typing.elab_env g))
         (fun uu___ ->
@@ -1724,13 +1766,13 @@ let (instantiate_term_implicits :
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                            (Prims.of_int (130)) (Prims.of_int (11))
-                            (Prims.of_int (130)) (Prims.of_int (23)))))
+                            (Prims.of_int (143)) (Prims.of_int (11))
+                            (Prims.of_int (143)) (Prims.of_int (23)))))
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                            (Prims.of_int (130)) (Prims.of_int (26))
-                            (Prims.of_int (149)) (Prims.of_int (49)))))
+                            (Prims.of_int (143)) (Prims.of_int (26))
+                            (Prims.of_int (164)) (Prims.of_int (49)))))
                    (FStar_Tactics_Effect.lift_div_tac
                       (fun uu___ -> Pulse_Elaborate_Pure.elab_term t0))
                    (fun uu___ ->
@@ -1741,17 +1783,17 @@ let (instantiate_term_implicits :
                                  (Obj.magic
                                     (FStar_Range.mk_range
                                        "Pulse.Checker.Pure.fst"
-                                       (Prims.of_int (131))
+                                       (Prims.of_int (144))
                                        (Prims.of_int (10))
-                                       (Prims.of_int (131))
+                                       (Prims.of_int (144))
                                        (Prims.of_int (75)))))
                               (FStar_Sealed.seal
                                  (Obj.magic
                                     (FStar_Range.mk_range
                                        "Pulse.Checker.Pure.fst"
-                                       (Prims.of_int (131))
+                                       (Prims.of_int (144))
                                        (Prims.of_int (78))
-                                       (Prims.of_int (149))
+                                       (Prims.of_int (164))
                                        (Prims.of_int (49)))))
                               (Obj.magic
                                  (FStar_Tactics_Effect.tac_bind
@@ -1759,17 +1801,17 @@ let (instantiate_term_implicits :
                                        (Obj.magic
                                           (FStar_Range.mk_range
                                              "Pulse.Checker.Pure.fst"
-                                             (Prims.of_int (131))
+                                             (Prims.of_int (144))
                                              (Prims.of_int (29))
-                                             (Prims.of_int (131))
+                                             (Prims.of_int (144))
                                              (Prims.of_int (75)))))
                                     (FStar_Sealed.seal
                                        (Obj.magic
                                           (FStar_Range.mk_range
                                              "Pulse.Checker.Pure.fst"
-                                             (Prims.of_int (131))
+                                             (Prims.of_int (144))
                                              (Prims.of_int (10))
-                                             (Prims.of_int (131))
+                                             (Prims.of_int (144))
                                              (Prims.of_int (75)))))
                                     (Obj.magic
                                        (Pulse_Typing_Env.get_range g
@@ -1788,17 +1830,17 @@ let (instantiate_term_implicits :
                                             (Obj.magic
                                                (FStar_Range.mk_range
                                                   "Pulse.Checker.Pure.fst"
-                                                  (Prims.of_int (132))
+                                                  (Prims.of_int (145))
                                                   (Prims.of_int (21))
-                                                  (Prims.of_int (132))
+                                                  (Prims.of_int (145))
                                                   (Prims.of_int (74)))))
                                          (FStar_Sealed.seal
                                             (Obj.magic
                                                (FStar_Range.mk_range
                                                   "Pulse.Checker.Pure.fst"
-                                                  (Prims.of_int (131))
+                                                  (Prims.of_int (144))
                                                   (Prims.of_int (78))
-                                                  (Prims.of_int (149))
+                                                  (Prims.of_int (164))
                                                   (Prims.of_int (49)))))
                                          (Obj.magic
                                             (catch_all
@@ -1815,17 +1857,17 @@ let (instantiate_term_implicits :
                                                            (Obj.magic
                                                               (FStar_Range.mk_range
                                                                  "Pulse.Checker.Pure.fst"
-                                                                 (Prims.of_int (133))
+                                                                 (Prims.of_int (146))
                                                                  (Prims.of_int (2))
-                                                                 (Prims.of_int (133))
+                                                                 (Prims.of_int (146))
                                                                  (Prims.of_int (21)))))
                                                         (FStar_Sealed.seal
                                                            (Obj.magic
                                                               (FStar_Range.mk_range
                                                                  "Pulse.Checker.Pure.fst"
-                                                                 (Prims.of_int (134))
+                                                                 (Prims.of_int (147))
                                                                  (Prims.of_int (2))
-                                                                 (Prims.of_int (149))
+                                                                 (Prims.of_int (164))
                                                                  (Prims.of_int (49)))))
                                                         (Obj.magic
                                                            (FStar_Tactics_V2_Builtins.log_issues
@@ -1842,54 +1884,54 @@ let (instantiate_term_implicits :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (137))
-                                                                    (Prims.of_int (31))
-                                                                    (Prims.of_int (140))
-                                                                    (Prims.of_int (5)))))
+                                                                    (Prims.of_int (151))
+                                                                    (Prims.of_int (27))
+                                                                    (Prims.of_int (154))
+                                                                    (Prims.of_int (13)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (137))
+                                                                    (Prims.of_int (150))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (140))
-                                                                    (Prims.of_int (5)))))
+                                                                    (Prims.of_int (154))
+                                                                    (Prims.of_int (13)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (138))
-                                                                    (Prims.of_int (6))
-                                                                    (Prims.of_int (139))
-                                                                    (Prims.of_int (24)))))
+                                                                    (Prims.of_int (152))
+                                                                    (Prims.of_int (14))
+                                                                    (Prims.of_int (153))
+                                                                    (Prims.of_int (31)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (137))
-                                                                    (Prims.of_int (31))
-                                                                    (Prims.of_int (140))
-                                                                    (Prims.of_int (5)))))
+                                                                    (Prims.of_int (151))
+                                                                    (Prims.of_int (27))
+                                                                    (Prims.of_int (154))
+                                                                    (Prims.of_int (13)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (139))
-                                                                    (Prims.of_int (17))
-                                                                    (Prims.of_int (139))
-                                                                    (Prims.of_int (24)))))
+                                                                    (Prims.of_int (153))
+                                                                    (Prims.of_int (24))
+                                                                    (Prims.of_int (153))
+                                                                    (Prims.of_int (31)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (138))
-                                                                    (Prims.of_int (6))
-                                                                    (Prims.of_int (139))
-                                                                    (Prims.of_int (24)))))
+                                                                    (Prims.of_int (152))
+                                                                    (Prims.of_int (14))
+                                                                    (Prims.of_int (153))
+                                                                    (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (Pulse_PP.pp
                                                                     Pulse_PP.uu___44
@@ -1916,7 +1958,9 @@ let (instantiate_term_implicits :
                                                                     (fun
                                                                     uu___2 ->
                                                                     Obj.magic
-                                                                    (Pulse_Typing_Env.fail_doc
+                                                                    (maybe_fail_doc
+                                                                    issues
+                                                                    "Could not infer implicit arguments"
                                                                     g
                                                                     (FStar_Pervasives_Native.Some
                                                                     (t0.Pulse_Syntax_Base.range1))
@@ -1931,17 +1975,17 @@ let (instantiate_term_implicits :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (142))
+                                                                    (Prims.of_int (157))
                                                                     (Prims.of_int (15))
-                                                                    (Prims.of_int (142))
+                                                                    (Prims.of_int (157))
                                                                     (Prims.of_int (28)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (142))
+                                                                    (Prims.of_int (157))
                                                                     (Prims.of_int (31))
-                                                                    (Prims.of_int (149))
+                                                                    (Prims.of_int (164))
                                                                     (Prims.of_int (49)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -1958,17 +2002,17 @@ let (instantiate_term_implicits :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (143))
+                                                                    (Prims.of_int (158))
                                                                     (Prims.of_int (16))
-                                                                    (Prims.of_int (143))
+                                                                    (Prims.of_int (158))
                                                                     (Prims.of_int (30)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (144))
+                                                                    (Prims.of_int (159))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (149))
+                                                                    (Prims.of_int (164))
                                                                     (Prims.of_int (49)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -2006,17 +2050,17 @@ let (instantiate_term_implicits :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (147))
+                                                                    (Prims.of_int (162))
                                                                     (Prims.of_int (29))
-                                                                    (Prims.of_int (147))
+                                                                    (Prims.of_int (162))
                                                                     (Prims.of_int (50)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (147))
+                                                                    (Prims.of_int (162))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (147))
+                                                                    (Prims.of_int (162))
                                                                     (Prims.of_int (50)))))
                                                                     (Obj.magic
                                                                     (readback_failure
@@ -2043,17 +2087,17 @@ let (instantiate_term_implicits :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (149))
+                                                                    (Prims.of_int (164))
                                                                     (Prims.of_int (29))
-                                                                    (Prims.of_int (149))
+                                                                    (Prims.of_int (164))
                                                                     (Prims.of_int (49)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (149))
+                                                                    (Prims.of_int (164))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (149))
+                                                                    (Prims.of_int (164))
                                                                     (Prims.of_int (49)))))
                                                                     (Obj.magic
                                                                     (readback_failure
@@ -2085,13 +2129,13 @@ let (check_universe :
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                 (Prims.of_int (153)) (Prims.of_int (12))
-                 (Prims.of_int (153)) (Prims.of_int (22)))))
+                 (Prims.of_int (168)) (Prims.of_int (12))
+                 (Prims.of_int (168)) (Prims.of_int (22)))))
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                 (Prims.of_int (153)) (Prims.of_int (25))
-                 (Prims.of_int (166)) (Prims.of_int (23)))))
+                 (Prims.of_int (168)) (Prims.of_int (25))
+                 (Prims.of_int (183)) (Prims.of_int (23)))))
         (FStar_Tactics_Effect.lift_div_tac
            (fun uu___ -> Pulse_Typing.elab_env g))
         (fun uu___ ->
@@ -2101,13 +2145,13 @@ let (check_universe :
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                            (Prims.of_int (154)) (Prims.of_int (13))
-                            (Prims.of_int (154)) (Prims.of_int (24)))))
+                            (Prims.of_int (169)) (Prims.of_int (13))
+                            (Prims.of_int (169)) (Prims.of_int (24)))))
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                            (Prims.of_int (154)) (Prims.of_int (27))
-                            (Prims.of_int (166)) (Prims.of_int (23)))))
+                            (Prims.of_int (169)) (Prims.of_int (27))
+                            (Prims.of_int (183)) (Prims.of_int (23)))))
                    (FStar_Tactics_Effect.lift_div_tac
                       (fun uu___ -> Pulse_Elaborate_Pure.elab_term t))
                    (fun uu___ ->
@@ -2118,17 +2162,17 @@ let (check_universe :
                                  (Obj.magic
                                     (FStar_Range.mk_range
                                        "Pulse.Checker.Pure.fst"
-                                       (Prims.of_int (155))
+                                       (Prims.of_int (170))
                                        (Prims.of_int (25))
-                                       (Prims.of_int (155))
+                                       (Prims.of_int (170))
                                        (Prims.of_int (68)))))
                               (FStar_Sealed.seal
                                  (Obj.magic
                                     (FStar_Range.mk_range
                                        "Pulse.Checker.Pure.fst"
-                                       (Prims.of_int (154))
+                                       (Prims.of_int (169))
                                        (Prims.of_int (27))
-                                       (Prims.of_int (166))
+                                       (Prims.of_int (183))
                                        (Prims.of_int (23)))))
                               (Obj.magic
                                  (catch_all
@@ -2143,17 +2187,17 @@ let (check_universe :
                                                 (Obj.magic
                                                    (FStar_Range.mk_range
                                                       "Pulse.Checker.Pure.fst"
-                                                      (Prims.of_int (156))
+                                                      (Prims.of_int (171))
                                                       (Prims.of_int (4))
-                                                      (Prims.of_int (156))
+                                                      (Prims.of_int (171))
                                                       (Prims.of_int (23)))))
                                              (FStar_Sealed.seal
                                                 (Obj.magic
                                                    (FStar_Range.mk_range
                                                       "Pulse.Checker.Pure.fst"
-                                                      (Prims.of_int (157))
+                                                      (Prims.of_int (172))
                                                       (Prims.of_int (4))
-                                                      (Prims.of_int (166))
+                                                      (Prims.of_int (183))
                                                       (Prims.of_int (23)))))
                                              (Obj.magic
                                                 (FStar_Tactics_V2_Builtins.log_issues
@@ -2170,18 +2214,18 @@ let (check_universe :
                                                                   (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (159))
-                                                                    (Prims.of_int (32))
-                                                                    (Prims.of_int (159))
-                                                                    (Prims.of_int (82)))))
+                                                                    (Prims.of_int (176))
+                                                                    (Prims.of_int (25))
+                                                                    (Prims.of_int (176))
+                                                                    (Prims.of_int (75)))))
                                                                (FStar_Sealed.seal
                                                                   (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (159))
+                                                                    (Prims.of_int (174))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (159))
-                                                                    (Prims.of_int (82)))))
+                                                                    (Prims.of_int (176))
+                                                                    (Prims.of_int (75)))))
                                                                (Obj.magic
                                                                   (ill_typed_term
                                                                     t
@@ -2193,7 +2237,9 @@ let (check_universe :
                                                                   (fun uu___2
                                                                     ->
                                                                     Obj.magic
-                                                                    (Pulse_Typing_Env.fail_doc
+                                                                    (maybe_fail_doc
+                                                                    issues
+                                                                    "Could not infer universe"
                                                                     g
                                                                     (FStar_Pervasives_Native.Some
                                                                     (t.Pulse_Syntax_Base.range1))
@@ -2227,25 +2273,25 @@ let (tc_meta_callback :
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                   (Prims.of_int (171)) (Prims.of_int (6))
-                   (Prims.of_int (176)) (Prims.of_int (14)))))
+                   (Prims.of_int (188)) (Prims.of_int (6))
+                   (Prims.of_int (193)) (Prims.of_int (14)))))
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                   (Prims.of_int (170)) (Prims.of_int (8))
-                   (Prims.of_int (170)) (Prims.of_int (11)))))
+                   (Prims.of_int (187)) (Prims.of_int (8))
+                   (Prims.of_int (187)) (Prims.of_int (11)))))
           (Obj.magic
              (FStar_Tactics_Effect.tac_bind
                 (FStar_Sealed.seal
                    (Obj.magic
                       (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                         (Prims.of_int (171)) (Prims.of_int (12))
-                         (Prims.of_int (171)) (Prims.of_int (50)))))
+                         (Prims.of_int (188)) (Prims.of_int (12))
+                         (Prims.of_int (188)) (Prims.of_int (50)))))
                 (FStar_Sealed.seal
                    (Obj.magic
                       (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                         (Prims.of_int (171)) (Prims.of_int (6))
-                         (Prims.of_int (176)) (Prims.of_int (14)))))
+                         (Prims.of_int (188)) (Prims.of_int (6))
+                         (Prims.of_int (193)) (Prims.of_int (14)))))
                 (Obj.magic (catch_all (fun uu___ -> rtb_tc_term g f e)))
                 (fun uu___ ->
                    FStar_Tactics_Effect.lift_div_tac
@@ -2274,13 +2320,13 @@ let (check_term :
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                 (Prims.of_int (185)) (Prims.of_int (13))
-                 (Prims.of_int (185)) (Prims.of_int (23)))))
+                 (Prims.of_int (202)) (Prims.of_int (13))
+                 (Prims.of_int (202)) (Prims.of_int (23)))))
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                 (Prims.of_int (185)) (Prims.of_int (26))
-                 (Prims.of_int (200)) (Prims.of_int (50)))))
+                 (Prims.of_int (202)) (Prims.of_int (26))
+                 (Prims.of_int (218)) (Prims.of_int (50)))))
         (FStar_Tactics_Effect.lift_div_tac
            (fun uu___ -> Pulse_Typing.elab_env g))
         (fun uu___ ->
@@ -2290,13 +2336,13 @@ let (check_term :
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                            (Prims.of_int (186)) (Prims.of_int (13))
-                            (Prims.of_int (186)) (Prims.of_int (24)))))
+                            (Prims.of_int (203)) (Prims.of_int (13))
+                            (Prims.of_int (203)) (Prims.of_int (24)))))
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                            (Prims.of_int (187)) (Prims.of_int (4))
-                            (Prims.of_int (200)) (Prims.of_int (50)))))
+                            (Prims.of_int (204)) (Prims.of_int (4))
+                            (Prims.of_int (218)) (Prims.of_int (50)))))
                    (FStar_Tactics_Effect.lift_div_tac
                       (fun uu___ -> Pulse_Elaborate_Pure.elab_term t))
                    (fun uu___ ->
@@ -2307,17 +2353,17 @@ let (check_term :
                                  (Obj.magic
                                     (FStar_Range.mk_range
                                        "Pulse.Checker.Pure.fst"
-                                       (Prims.of_int (187))
+                                       (Prims.of_int (204))
                                        (Prims.of_int (4))
-                                       (Prims.of_int (190))
+                                       (Prims.of_int (207))
                                        (Prims.of_int (44)))))
                               (FStar_Sealed.seal
                                  (Obj.magic
                                     (FStar_Range.mk_range
                                        "Pulse.Checker.Pure.fst"
-                                       (Prims.of_int (190))
+                                       (Prims.of_int (207))
                                        (Prims.of_int (45))
-                                       (Prims.of_int (200))
+                                       (Prims.of_int (218))
                                        (Prims.of_int (50)))))
                               (Obj.magic
                                  (debug g
@@ -2327,17 +2373,17 @@ let (check_term :
                                             (Obj.magic
                                                (FStar_Range.mk_range
                                                   "Pulse.Checker.Pure.fst"
-                                                  (Prims.of_int (190))
+                                                  (Prims.of_int (207))
                                                   (Prims.of_int (22))
-                                                  (Prims.of_int (190))
+                                                  (Prims.of_int (207))
                                                   (Prims.of_int (43)))))
                                          (FStar_Sealed.seal
                                             (Obj.magic
                                                (FStar_Range.mk_range
                                                   "Pulse.Checker.Pure.fst"
-                                                  (Prims.of_int (188))
+                                                  (Prims.of_int (205))
                                                   (Prims.of_int (12))
-                                                  (Prims.of_int (190))
+                                                  (Prims.of_int (207))
                                                   (Prims.of_int (43)))))
                                          (Obj.magic
                                             (FStar_Tactics_V2_Builtins.term_to_string
@@ -2350,17 +2396,17 @@ let (check_term :
                                                        (Obj.magic
                                                           (FStar_Range.mk_range
                                                              "Pulse.Checker.Pure.fst"
-                                                             (Prims.of_int (188))
+                                                             (Prims.of_int (205))
                                                              (Prims.of_int (12))
-                                                             (Prims.of_int (190))
+                                                             (Prims.of_int (207))
                                                              (Prims.of_int (43)))))
                                                     (FStar_Sealed.seal
                                                        (Obj.magic
                                                           (FStar_Range.mk_range
                                                              "Pulse.Checker.Pure.fst"
-                                                             (Prims.of_int (188))
+                                                             (Prims.of_int (205))
                                                              (Prims.of_int (12))
-                                                             (Prims.of_int (190))
+                                                             (Prims.of_int (207))
                                                              (Prims.of_int (43)))))
                                                     (Obj.magic
                                                        (FStar_Tactics_Effect.tac_bind
@@ -2368,9 +2414,9 @@ let (check_term :
                                                              (Obj.magic
                                                                 (FStar_Range.mk_range
                                                                    "Pulse.Checker.Pure.fst"
-                                                                   (Prims.of_int (189))
+                                                                   (Prims.of_int (206))
                                                                    (Prims.of_int (22))
-                                                                   (Prims.of_int (189))
+                                                                   (Prims.of_int (206))
                                                                    (Prims.of_int (42)))))
                                                           (FStar_Sealed.seal
                                                              (Obj.magic
@@ -2408,17 +2454,17 @@ let (check_term :
                                             (Obj.magic
                                                (FStar_Range.mk_range
                                                   "Pulse.Checker.Pure.fst"
-                                                  (Prims.of_int (191))
+                                                  (Prims.of_int (208))
                                                   (Prims.of_int (22))
-                                                  (Prims.of_int (191))
+                                                  (Prims.of_int (208))
                                                   (Prims.of_int (46)))))
                                          (FStar_Sealed.seal
                                             (Obj.magic
                                                (FStar_Range.mk_range
                                                   "Pulse.Checker.Pure.fst"
-                                                  (Prims.of_int (190))
+                                                  (Prims.of_int (207))
                                                   (Prims.of_int (45))
-                                                  (Prims.of_int (200))
+                                                  (Prims.of_int (218))
                                                   (Prims.of_int (50)))))
                                          (Obj.magic
                                             (tc_meta_callback g fg rt))
@@ -2432,17 +2478,17 @@ let (check_term :
                                                            (Obj.magic
                                                               (FStar_Range.mk_range
                                                                  "Pulse.Checker.Pure.fst"
-                                                                 (Prims.of_int (192))
+                                                                 (Prims.of_int (209))
                                                                  (Prims.of_int (4))
-                                                                 (Prims.of_int (192))
+                                                                 (Prims.of_int (209))
                                                                  (Prims.of_int (23)))))
                                                         (FStar_Sealed.seal
                                                            (Obj.magic
                                                               (FStar_Range.mk_range
                                                                  "Pulse.Checker.Pure.fst"
-                                                                 (Prims.of_int (193))
+                                                                 (Prims.of_int (210))
                                                                  (Prims.of_int (4))
-                                                                 (Prims.of_int (200))
+                                                                 (Prims.of_int (218))
                                                                  (Prims.of_int (50)))))
                                                         (Obj.magic
                                                            (FStar_Tactics_V2_Builtins.log_issues
@@ -2460,18 +2506,18 @@ let (check_term :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (195))
-                                                                    (Prims.of_int (32))
-                                                                    (Prims.of_int (195))
-                                                                    (Prims.of_int (60)))))
+                                                                    (Prims.of_int (213))
+                                                                    (Prims.of_int (29))
+                                                                    (Prims.of_int (213))
+                                                                    (Prims.of_int (57)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (195))
+                                                                    (Prims.of_int (212))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (195))
-                                                                    (Prims.of_int (60)))))
+                                                                    (Prims.of_int (213))
+                                                                    (Prims.of_int (57)))))
                                                                     (Obj.magic
                                                                     (ill_typed_term
                                                                     t
@@ -2482,7 +2528,9 @@ let (check_term :
                                                                     (fun
                                                                     uu___3 ->
                                                                     Obj.magic
-                                                                    (Pulse_Typing_Env.fail_doc
+                                                                    (maybe_fail_doc
+                                                                    issues
+                                                                    "Failed to typecheck term"
                                                                     g
                                                                     (FStar_Pervasives_Native.Some
                                                                     (t.Pulse_Syntax_Base.range1))
@@ -2512,17 +2560,17 @@ let (check_term :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (198))
+                                                                    (Prims.of_int (216))
                                                                     (Prims.of_int (41))
-                                                                    (Prims.of_int (198))
+                                                                    (Prims.of_int (216))
                                                                     (Prims.of_int (62)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (198))
+                                                                    (Prims.of_int (216))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (198))
+                                                                    (Prims.of_int (216))
                                                                     (Prims.of_int (62)))))
                                                                     (Obj.magic
                                                                     (readback_failure
@@ -2548,17 +2596,17 @@ let (check_term :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (199))
+                                                                    (Prims.of_int (217))
                                                                     (Prims.of_int (41))
-                                                                    (Prims.of_int (199))
+                                                                    (Prims.of_int (217))
                                                                     (Prims.of_int (63)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (199))
+                                                                    (Prims.of_int (217))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (199))
+                                                                    (Prims.of_int (217))
                                                                     (Prims.of_int (63)))))
                                                                     (Obj.magic
                                                                     (readback_failure
@@ -2603,13 +2651,13 @@ let (check_term_and_type :
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                 (Prims.of_int (209)) (Prims.of_int (13))
-                 (Prims.of_int (209)) (Prims.of_int (23)))))
+                 (Prims.of_int (227)) (Prims.of_int (13))
+                 (Prims.of_int (227)) (Prims.of_int (23)))))
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                 (Prims.of_int (209)) (Prims.of_int (26))
-                 (Prims.of_int (222)) (Prims.of_int (45)))))
+                 (Prims.of_int (227)) (Prims.of_int (26))
+                 (Prims.of_int (242)) (Prims.of_int (45)))))
         (FStar_Tactics_Effect.lift_div_tac
            (fun uu___ -> Pulse_Typing.elab_env g))
         (fun uu___ ->
@@ -2619,13 +2667,13 @@ let (check_term_and_type :
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                            (Prims.of_int (210)) (Prims.of_int (13))
-                            (Prims.of_int (210)) (Prims.of_int (24)))))
+                            (Prims.of_int (228)) (Prims.of_int (13))
+                            (Prims.of_int (228)) (Prims.of_int (24)))))
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                            (Prims.of_int (210)) (Prims.of_int (27))
-                            (Prims.of_int (222)) (Prims.of_int (45)))))
+                            (Prims.of_int (228)) (Prims.of_int (27))
+                            (Prims.of_int (242)) (Prims.of_int (45)))))
                    (FStar_Tactics_Effect.lift_div_tac
                       (fun uu___ -> Pulse_Elaborate_Pure.elab_term t))
                    (fun uu___ ->
@@ -2636,17 +2684,17 @@ let (check_term_and_type :
                                  (Obj.magic
                                     (FStar_Range.mk_range
                                        "Pulse.Checker.Pure.fst"
-                                       (Prims.of_int (211))
+                                       (Prims.of_int (229))
                                        (Prims.of_int (22))
-                                       (Prims.of_int (211))
+                                       (Prims.of_int (229))
                                        (Prims.of_int (46)))))
                               (FStar_Sealed.seal
                                  (Obj.magic
                                     (FStar_Range.mk_range
                                        "Pulse.Checker.Pure.fst"
-                                       (Prims.of_int (210))
+                                       (Prims.of_int (228))
                                        (Prims.of_int (27))
-                                       (Prims.of_int (222))
+                                       (Prims.of_int (242))
                                        (Prims.of_int (45)))))
                               (Obj.magic (tc_meta_callback g fg rt))
                               (fun uu___ ->
@@ -2659,17 +2707,17 @@ let (check_term_and_type :
                                                 (Obj.magic
                                                    (FStar_Range.mk_range
                                                       "Pulse.Checker.Pure.fst"
-                                                      (Prims.of_int (212))
+                                                      (Prims.of_int (230))
                                                       (Prims.of_int (4))
-                                                      (Prims.of_int (212))
+                                                      (Prims.of_int (230))
                                                       (Prims.of_int (23)))))
                                              (FStar_Sealed.seal
                                                 (Obj.magic
                                                    (FStar_Range.mk_range
                                                       "Pulse.Checker.Pure.fst"
-                                                      (Prims.of_int (213))
+                                                      (Prims.of_int (231))
                                                       (Prims.of_int (4))
-                                                      (Prims.of_int (222))
+                                                      (Prims.of_int (242))
                                                       (Prims.of_int (45)))))
                                              (Obj.magic
                                                 (FStar_Tactics_V2_Builtins.log_issues
@@ -2685,18 +2733,18 @@ let (check_term_and_type :
                                                                (Obj.magic
                                                                   (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (215))
-                                                                    (Prims.of_int (32))
-                                                                    (Prims.of_int (215))
-                                                                    (Prims.of_int (60)))))
+                                                                    (Prims.of_int (235))
+                                                                    (Prims.of_int (25))
+                                                                    (Prims.of_int (235))
+                                                                    (Prims.of_int (53)))))
                                                             (FStar_Sealed.seal
                                                                (Obj.magic
                                                                   (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (215))
+                                                                    (Prims.of_int (233))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (215))
-                                                                    (Prims.of_int (60)))))
+                                                                    (Prims.of_int (235))
+                                                                    (Prims.of_int (53)))))
                                                             (Obj.magic
                                                                (ill_typed_term
                                                                   t
@@ -2706,7 +2754,9 @@ let (check_term_and_type :
                                                                (fun uu___2 ->
                                                                   Obj.magic
                                                                     (
-                                                                    Pulse_Typing_Env.fail_doc
+                                                                    maybe_fail_doc
+                                                                    issues
+                                                                    "Failed to check term at expected type"
                                                                     g
                                                                     (FStar_Pervasives_Native.Some
                                                                     (t.Pulse_Syntax_Base.range1))
@@ -2730,18 +2780,18 @@ let (check_term_and_type :
                                                                     Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (218))
+                                                                    (Prims.of_int (238))
                                                                     (Prims.of_int (41))
-                                                                    (Prims.of_int (218))
+                                                                    (Prims.of_int (238))
                                                                     (Prims.of_int (62)))))
                                                                  (FStar_Sealed.seal
                                                                     (
                                                                     Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (218))
+                                                                    (Prims.of_int (238))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (218))
+                                                                    (Prims.of_int (238))
                                                                     (Prims.of_int (62)))))
                                                                  (Obj.magic
                                                                     (
@@ -2768,18 +2818,18 @@ let (check_term_and_type :
                                                                     Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (219))
+                                                                    (Prims.of_int (239))
                                                                     (Prims.of_int (41))
-                                                                    (Prims.of_int (219))
+                                                                    (Prims.of_int (239))
                                                                     (Prims.of_int (63)))))
                                                                  (FStar_Sealed.seal
                                                                     (
                                                                     Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (219))
+                                                                    (Prims.of_int (239))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (219))
+                                                                    (Prims.of_int (239))
                                                                     (Prims.of_int (63)))))
                                                                  (Obj.magic
                                                                     (
@@ -2807,18 +2857,18 @@ let (check_term_and_type :
                                                                     Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (221))
+                                                                    (Prims.of_int (241))
                                                                     (Prims.of_int (27))
-                                                                    (Prims.of_int (221))
+                                                                    (Prims.of_int (241))
                                                                     (Prims.of_int (46)))))
                                                                  (FStar_Sealed.seal
                                                                     (
                                                                     Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (220))
+                                                                    (Prims.of_int (240))
                                                                     (Prims.of_int (26))
-                                                                    (Prims.of_int (222))
+                                                                    (Prims.of_int (242))
                                                                     (Prims.of_int (45)))))
                                                                  (Obj.magic
                                                                     (
@@ -2859,13 +2909,13 @@ let (check_term_with_expected_type_and_effect :
             (FStar_Sealed.seal
                (Obj.magic
                   (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                     (Prims.of_int (227)) (Prims.of_int (13))
-                     (Prims.of_int (227)) (Prims.of_int (43)))))
+                     (Prims.of_int (247)) (Prims.of_int (13))
+                     (Prims.of_int (247)) (Prims.of_int (43)))))
             (FStar_Sealed.seal
                (Obj.magic
                   (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                     (Prims.of_int (225)) (Prims.of_int (39))
-                     (Prims.of_int (242)) (Prims.of_int (78)))))
+                     (Prims.of_int (245)) (Prims.of_int (39))
+                     (Prims.of_int (264)) (Prims.of_int (78)))))
             (Obj.magic (instantiate_term_implicits g e))
             (fun uu___ ->
                (fun uu___ ->
@@ -2877,14 +2927,14 @@ let (check_term_with_expected_type_and_effect :
                               (Obj.magic
                                  (FStar_Range.mk_range
                                     "Pulse.Checker.Pure.fst"
-                                    (Prims.of_int (229)) (Prims.of_int (11))
-                                    (Prims.of_int (229)) (Prims.of_int (21)))))
+                                    (Prims.of_int (249)) (Prims.of_int (11))
+                                    (Prims.of_int (249)) (Prims.of_int (21)))))
                            (FStar_Sealed.seal
                               (Obj.magic
                                  (FStar_Range.mk_range
                                     "Pulse.Checker.Pure.fst"
-                                    (Prims.of_int (229)) (Prims.of_int (24))
-                                    (Prims.of_int (242)) (Prims.of_int (78)))))
+                                    (Prims.of_int (249)) (Prims.of_int (24))
+                                    (Prims.of_int (264)) (Prims.of_int (78)))))
                            (FStar_Tactics_Effect.lift_div_tac
                               (fun uu___2 -> Pulse_Typing.elab_env g))
                            (fun uu___2 ->
@@ -2895,17 +2945,17 @@ let (check_term_with_expected_type_and_effect :
                                          (Obj.magic
                                             (FStar_Range.mk_range
                                                "Pulse.Checker.Pure.fst"
-                                               (Prims.of_int (230))
+                                               (Prims.of_int (250))
                                                (Prims.of_int (11))
-                                               (Prims.of_int (230))
+                                               (Prims.of_int (250))
                                                (Prims.of_int (22)))))
                                       (FStar_Sealed.seal
                                          (Obj.magic
                                             (FStar_Range.mk_range
                                                "Pulse.Checker.Pure.fst"
-                                               (Prims.of_int (230))
+                                               (Prims.of_int (250))
                                                (Prims.of_int (25))
-                                               (Prims.of_int (242))
+                                               (Prims.of_int (264))
                                                (Prims.of_int (78)))))
                                       (FStar_Tactics_Effect.lift_div_tac
                                          (fun uu___2 ->
@@ -2918,17 +2968,17 @@ let (check_term_with_expected_type_and_effect :
                                                     (Obj.magic
                                                        (FStar_Range.mk_range
                                                           "Pulse.Checker.Pure.fst"
-                                                          (Prims.of_int (231))
+                                                          (Prims.of_int (251))
                                                           (Prims.of_int (11))
-                                                          (Prims.of_int (231))
+                                                          (Prims.of_int (251))
                                                           (Prims.of_int (22)))))
                                                  (FStar_Sealed.seal
                                                     (Obj.magic
                                                        (FStar_Range.mk_range
                                                           "Pulse.Checker.Pure.fst"
-                                                          (Prims.of_int (231))
+                                                          (Prims.of_int (251))
                                                           (Prims.of_int (25))
-                                                          (Prims.of_int (242))
+                                                          (Prims.of_int (264))
                                                           (Prims.of_int (78)))))
                                                  (FStar_Tactics_Effect.lift_div_tac
                                                     (fun uu___2 ->
@@ -2942,17 +2992,17 @@ let (check_term_with_expected_type_and_effect :
                                                                (Obj.magic
                                                                   (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (234))
+                                                                    (Prims.of_int (254))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (237))
+                                                                    (Prims.of_int (257))
                                                                     (Prims.of_int (20)))))
                                                             (FStar_Sealed.seal
                                                                (Obj.magic
                                                                   (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (231))
+                                                                    (Prims.of_int (251))
                                                                     (Prims.of_int (25))
-                                                                    (Prims.of_int (242))
+                                                                    (Prims.of_int (264))
                                                                     (Prims.of_int (78)))))
                                                             (Obj.magic
                                                                (catch_all
@@ -2978,17 +3028,17 @@ let (check_term_with_expected_type_and_effect :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (238))
+                                                                    (Prims.of_int (258))
                                                                     (Prims.of_int (2))
-                                                                    (Prims.of_int (238))
+                                                                    (Prims.of_int (258))
                                                                     (Prims.of_int (21)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (239))
+                                                                    (Prims.of_int (259))
                                                                     (Prims.of_int (2))
-                                                                    (Prims.of_int (242))
+                                                                    (Prims.of_int (264))
                                                                     (Prims.of_int (78)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_V2_Builtins.log_issues
@@ -3009,18 +3059,18 @@ let (check_term_with_expected_type_and_effect :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (241))
-                                                                    (Prims.of_int (30))
-                                                                    (Prims.of_int (241))
-                                                                    (Prims.of_int (62)))))
+                                                                    (Prims.of_int (263))
+                                                                    (Prims.of_int (23))
+                                                                    (Prims.of_int (263))
+                                                                    (Prims.of_int (55)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (241))
+                                                                    (Prims.of_int (261))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (241))
-                                                                    (Prims.of_int (62)))))
+                                                                    (Prims.of_int (263))
+                                                                    (Prims.of_int (55)))))
                                                                     (Obj.magic
                                                                     (ill_typed_term
                                                                     e1
@@ -3032,7 +3082,9 @@ let (check_term_with_expected_type_and_effect :
                                                                     (fun
                                                                     uu___4 ->
                                                                     Obj.magic
-                                                                    (Pulse_Typing_Env.fail_doc
+                                                                    (maybe_fail_doc
+                                                                    issues
+                                                                    "Failed to check term at expected type"
                                                                     g
                                                                     (FStar_Pervasives_Native.Some
                                                                     (e1.Pulse_Syntax_Base.range1))
@@ -3071,13 +3123,13 @@ let (check_term_with_expected_type :
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                            (Prims.of_int (250)) (Prims.of_int (22))
-                            (Prims.of_int (250)) (Prims.of_int (78)))))
+                            (Prims.of_int (272)) (Prims.of_int (22))
+                            (Prims.of_int (272)) (Prims.of_int (78)))))
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                            (Prims.of_int (249)) (Prims.of_int (5))
-                            (Prims.of_int (251)) (Prims.of_int (78)))))
+                            (Prims.of_int (271)) (Prims.of_int (5))
+                            (Prims.of_int (273)) (Prims.of_int (78)))))
                    (Obj.magic
                       (check_term_with_expected_type_and_effect g e
                          FStar_TypeChecker_Core.E_Total t))
@@ -3093,13 +3145,13 @@ let (check_term_with_expected_type :
                (FStar_Sealed.seal
                   (Obj.magic
                      (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                        (Prims.of_int (253)) (Prims.of_int (22))
-                        (Prims.of_int (253)) (Prims.of_int (78)))))
+                        (Prims.of_int (275)) (Prims.of_int (22))
+                        (Prims.of_int (275)) (Prims.of_int (78)))))
                (FStar_Sealed.seal
                   (Obj.magic
                      (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                        (Prims.of_int (252)) (Prims.of_int (13))
-                        (Prims.of_int (254)) (Prims.of_int (26)))))
+                        (Prims.of_int (274)) (Prims.of_int (13))
+                        (Prims.of_int (276)) (Prims.of_int (26)))))
                (Obj.magic
                   (check_term_with_expected_type_and_effect g e
                      FStar_TypeChecker_Core.E_Ghost t))
@@ -3127,13 +3179,13 @@ let (tc_with_core :
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                   (Prims.of_int (258)) (Prims.of_int (23))
-                   (Prims.of_int (258)) (Prims.of_int (117)))))
+                   (Prims.of_int (280)) (Prims.of_int (23))
+                   (Prims.of_int (280)) (Prims.of_int (117)))))
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                   (Prims.of_int (258)) (Prims.of_int (3))
-                   (Prims.of_int (262)) (Prims.of_int (76)))))
+                   (Prims.of_int (280)) (Prims.of_int (3))
+                   (Prims.of_int (284)) (Prims.of_int (76)))))
           (Obj.magic
              (catch_all
                 (fun uu___ ->
@@ -3167,13 +3219,13 @@ let (core_check_term :
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                 (Prims.of_int (268)) (Prims.of_int (13))
-                 (Prims.of_int (268)) (Prims.of_int (23)))))
+                 (Prims.of_int (290)) (Prims.of_int (13))
+                 (Prims.of_int (290)) (Prims.of_int (23)))))
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                 (Prims.of_int (268)) (Prims.of_int (26))
-                 (Prims.of_int (280)) (Prims.of_int (30)))))
+                 (Prims.of_int (290)) (Prims.of_int (26))
+                 (Prims.of_int (304)) (Prims.of_int (30)))))
         (FStar_Tactics_Effect.lift_div_tac
            (fun uu___ -> Pulse_Typing.elab_env g))
         (fun uu___ ->
@@ -3183,13 +3235,13 @@ let (core_check_term :
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                            (Prims.of_int (269)) (Prims.of_int (13))
-                            (Prims.of_int (269)) (Prims.of_int (24)))))
+                            (Prims.of_int (291)) (Prims.of_int (13))
+                            (Prims.of_int (291)) (Prims.of_int (24)))))
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                            (Prims.of_int (269)) (Prims.of_int (27))
-                            (Prims.of_int (280)) (Prims.of_int (30)))))
+                            (Prims.of_int (291)) (Prims.of_int (27))
+                            (Prims.of_int (304)) (Prims.of_int (30)))))
                    (FStar_Tactics_Effect.lift_div_tac
                       (fun uu___ -> Pulse_Elaborate_Pure.elab_term t))
                    (fun uu___ ->
@@ -3200,17 +3252,17 @@ let (core_check_term :
                                  (Obj.magic
                                     (FStar_Range.mk_range
                                        "Pulse.Checker.Pure.fst"
-                                       (Prims.of_int (270))
+                                       (Prims.of_int (292))
                                        (Prims.of_int (22))
-                                       (Prims.of_int (270))
+                                       (Prims.of_int (292))
                                        (Prims.of_int (94)))))
                               (FStar_Sealed.seal
                                  (Obj.magic
                                     (FStar_Range.mk_range
                                        "Pulse.Checker.Pure.fst"
-                                       (Prims.of_int (269))
+                                       (Prims.of_int (291))
                                        (Prims.of_int (27))
-                                       (Prims.of_int (280))
+                                       (Prims.of_int (304))
                                        (Prims.of_int (30)))))
                               (Obj.magic
                                  (tc_with_core
@@ -3228,17 +3280,17 @@ let (core_check_term :
                                                 (Obj.magic
                                                    (FStar_Range.mk_range
                                                       "Pulse.Checker.Pure.fst"
-                                                      (Prims.of_int (271))
+                                                      (Prims.of_int (293))
                                                       (Prims.of_int (4))
-                                                      (Prims.of_int (271))
+                                                      (Prims.of_int (293))
                                                       (Prims.of_int (23)))))
                                              (FStar_Sealed.seal
                                                 (Obj.magic
                                                    (FStar_Range.mk_range
                                                       "Pulse.Checker.Pure.fst"
-                                                      (Prims.of_int (272))
+                                                      (Prims.of_int (294))
                                                       (Prims.of_int (4))
-                                                      (Prims.of_int (280))
+                                                      (Prims.of_int (304))
                                                       (Prims.of_int (30)))))
                                              (Obj.magic
                                                 (FStar_Tactics_V2_Builtins.log_issues
@@ -3255,18 +3307,18 @@ let (core_check_term :
                                                                   (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (274))
-                                                                    (Prims.of_int (32))
-                                                                    (Prims.of_int (274))
-                                                                    (Prims.of_int (60)))))
+                                                                    (Prims.of_int (298))
+                                                                    (Prims.of_int (25))
+                                                                    (Prims.of_int (298))
+                                                                    (Prims.of_int (53)))))
                                                                (FStar_Sealed.seal
                                                                   (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (274))
+                                                                    (Prims.of_int (296))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (274))
-                                                                    (Prims.of_int (60)))))
+                                                                    (Prims.of_int (298))
+                                                                    (Prims.of_int (53)))))
                                                                (Obj.magic
                                                                   (ill_typed_term
                                                                     t
@@ -3276,7 +3328,9 @@ let (core_check_term :
                                                                   (fun uu___2
                                                                     ->
                                                                     Obj.magic
-                                                                    (Pulse_Typing_Env.fail_doc
+                                                                    (maybe_fail_doc
+                                                                    issues
+                                                                    "Failed to check term"
                                                                     g
                                                                     (FStar_Pervasives_Native.Some
                                                                     (t.Pulse_Syntax_Base.range1))
@@ -3298,17 +3352,17 @@ let (core_check_term :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (278))
+                                                                    (Prims.of_int (302))
                                                                     (Prims.of_int (32))
-                                                                    (Prims.of_int (278))
+                                                                    (Prims.of_int (302))
                                                                     (Prims.of_int (54)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (278))
+                                                                    (Prims.of_int (302))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (278))
+                                                                    (Prims.of_int (302))
                                                                     (Prims.of_int (54)))))
                                                                     (Obj.magic
                                                                     (readback_failure
@@ -3349,13 +3403,13 @@ let (core_check_term_with_expected_type :
             (FStar_Sealed.seal
                (Obj.magic
                   (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                     (Prims.of_int (283)) (Prims.of_int (11))
-                     (Prims.of_int (283)) (Prims.of_int (21)))))
+                     (Prims.of_int (307)) (Prims.of_int (11))
+                     (Prims.of_int (307)) (Prims.of_int (21)))))
             (FStar_Sealed.seal
                (Obj.magic
                   (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                     (Prims.of_int (283)) (Prims.of_int (24))
-                     (Prims.of_int (295)) (Prims.of_int (69)))))
+                     (Prims.of_int (307)) (Prims.of_int (24))
+                     (Prims.of_int (321)) (Prims.of_int (69)))))
             (FStar_Tactics_Effect.lift_div_tac
                (fun uu___ -> Pulse_Typing.elab_env g))
             (fun uu___ ->
@@ -3365,13 +3419,13 @@ let (core_check_term_with_expected_type :
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                                (Prims.of_int (284)) (Prims.of_int (11))
-                                (Prims.of_int (284)) (Prims.of_int (22)))))
+                                (Prims.of_int (308)) (Prims.of_int (11))
+                                (Prims.of_int (308)) (Prims.of_int (22)))))
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                                (Prims.of_int (284)) (Prims.of_int (25))
-                                (Prims.of_int (295)) (Prims.of_int (69)))))
+                                (Prims.of_int (308)) (Prims.of_int (25))
+                                (Prims.of_int (321)) (Prims.of_int (69)))))
                        (FStar_Tactics_Effect.lift_div_tac
                           (fun uu___ -> Pulse_Elaborate_Pure.elab_term e))
                        (fun uu___ ->
@@ -3382,17 +3436,17 @@ let (core_check_term_with_expected_type :
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "Pulse.Checker.Pure.fst"
-                                           (Prims.of_int (285))
+                                           (Prims.of_int (309))
                                            (Prims.of_int (11))
-                                           (Prims.of_int (285))
+                                           (Prims.of_int (309))
                                            (Prims.of_int (22)))))
                                   (FStar_Sealed.seal
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "Pulse.Checker.Pure.fst"
-                                           (Prims.of_int (285))
+                                           (Prims.of_int (309))
                                            (Prims.of_int (25))
-                                           (Prims.of_int (295))
+                                           (Prims.of_int (321))
                                            (Prims.of_int (69)))))
                                   (FStar_Tactics_Effect.lift_div_tac
                                      (fun uu___ ->
@@ -3405,17 +3459,17 @@ let (core_check_term_with_expected_type :
                                                 (Obj.magic
                                                    (FStar_Range.mk_range
                                                       "Pulse.Checker.Pure.fst"
-                                                      (Prims.of_int (287))
+                                                      (Prims.of_int (311))
                                                       (Prims.of_int (4))
-                                                      (Prims.of_int (290))
+                                                      (Prims.of_int (314))
                                                       (Prims.of_int (20)))))
                                              (FStar_Sealed.seal
                                                 (Obj.magic
                                                    (FStar_Range.mk_range
                                                       "Pulse.Checker.Pure.fst"
-                                                      (Prims.of_int (285))
+                                                      (Prims.of_int (309))
                                                       (Prims.of_int (25))
-                                                      (Prims.of_int (295))
+                                                      (Prims.of_int (321))
                                                       (Prims.of_int (69)))))
                                              (Obj.magic
                                                 (catch_all
@@ -3437,17 +3491,17 @@ let (core_check_term_with_expected_type :
                                                                (Obj.magic
                                                                   (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (291))
+                                                                    (Prims.of_int (315))
                                                                     (Prims.of_int (2))
-                                                                    (Prims.of_int (291))
+                                                                    (Prims.of_int (315))
                                                                     (Prims.of_int (21)))))
                                                             (FStar_Sealed.seal
                                                                (Obj.magic
                                                                   (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (292))
+                                                                    (Prims.of_int (316))
                                                                     (Prims.of_int (2))
-                                                                    (Prims.of_int (295))
+                                                                    (Prims.of_int (321))
                                                                     (Prims.of_int (69)))))
                                                             (Obj.magic
                                                                (FStar_Tactics_V2_Builtins.log_issues
@@ -3465,18 +3519,18 @@ let (core_check_term_with_expected_type :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (294))
-                                                                    (Prims.of_int (30))
-                                                                    (Prims.of_int (294))
-                                                                    (Prims.of_int (62)))))
+                                                                    (Prims.of_int (320))
+                                                                    (Prims.of_int (23))
+                                                                    (Prims.of_int (320))
+                                                                    (Prims.of_int (55)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (294))
+                                                                    (Prims.of_int (318))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (294))
-                                                                    (Prims.of_int (62)))))
+                                                                    (Prims.of_int (320))
+                                                                    (Prims.of_int (55)))))
                                                                     (Obj.magic
                                                                     (ill_typed_term
                                                                     e
@@ -3488,7 +3542,9 @@ let (core_check_term_with_expected_type :
                                                                     (fun
                                                                     uu___2 ->
                                                                     Obj.magic
-                                                                    (Pulse_Typing_Env.fail_doc
+                                                                    (maybe_fail_doc
+                                                                    issues
+                                                                    "Failed to check term"
                                                                     g
                                                                     (FStar_Pervasives_Native.Some
                                                                     (e.Pulse_Syntax_Base.range1))
@@ -3544,13 +3600,13 @@ let (get_non_informative_witness :
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                   (Prims.of_int (318)) (Prims.of_int (6))
-                   (Prims.of_int (322)) (Prims.of_int (7)))))
+                   (Prims.of_int (344)) (Prims.of_int (6))
+                   (Prims.of_int (348)) (Prims.of_int (7)))))
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                   (Prims.of_int (323)) (Prims.of_int (6))
-                   (Prims.of_int (357)) (Prims.of_int (39)))))
+                   (Prims.of_int (349)) (Prims.of_int (6))
+                   (Prims.of_int (383)) (Prims.of_int (39)))))
           (FStar_Tactics_Effect.lift_div_tac
              (fun uu___ ->
                 fun uu___1 ->
@@ -3558,44 +3614,44 @@ let (get_non_informative_witness :
                     (FStar_Sealed.seal
                        (Obj.magic
                           (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                             (Prims.of_int (319)) (Prims.of_int (32))
-                             (Prims.of_int (322)) (Prims.of_int (7)))))
+                             (Prims.of_int (345)) (Prims.of_int (32))
+                             (Prims.of_int (348)) (Prims.of_int (7)))))
                     (FStar_Sealed.seal
                        (Obj.magic
                           (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                             (Prims.of_int (319)) (Prims.of_int (6))
-                             (Prims.of_int (322)) (Prims.of_int (7)))))
+                             (Prims.of_int (345)) (Prims.of_int (6))
+                             (Prims.of_int (348)) (Prims.of_int (7)))))
                     (Obj.magic
                        (FStar_Tactics_Effect.tac_bind
                           (FStar_Sealed.seal
                              (Obj.magic
                                 (FStar_Range.mk_range
                                    "Pulse.Checker.Pure.fst"
-                                   (Prims.of_int (320)) (Prims.of_int (8))
-                                   (Prims.of_int (321)) (Prims.of_int (18)))))
+                                   (Prims.of_int (346)) (Prims.of_int (8))
+                                   (Prims.of_int (347)) (Prims.of_int (18)))))
                           (FStar_Sealed.seal
                              (Obj.magic
                                 (FStar_Range.mk_range
                                    "Pulse.Checker.Pure.fst"
-                                   (Prims.of_int (319)) (Prims.of_int (32))
-                                   (Prims.of_int (322)) (Prims.of_int (7)))))
+                                   (Prims.of_int (345)) (Prims.of_int (32))
+                                   (Prims.of_int (348)) (Prims.of_int (7)))))
                           (Obj.magic
                              (FStar_Tactics_Effect.tac_bind
                                 (FStar_Sealed.seal
                                    (Obj.magic
                                       (FStar_Range.mk_range
                                          "Pulse.Checker.Pure.fst"
-                                         (Prims.of_int (321))
+                                         (Prims.of_int (347))
                                          (Prims.of_int (14))
-                                         (Prims.of_int (321))
+                                         (Prims.of_int (347))
                                          (Prims.of_int (18)))))
                                 (FStar_Sealed.seal
                                    (Obj.magic
                                       (FStar_Range.mk_range
                                          "Pulse.Checker.Pure.fst"
-                                         (Prims.of_int (320))
+                                         (Prims.of_int (346))
                                          (Prims.of_int (8))
-                                         (Prims.of_int (321))
+                                         (Prims.of_int (347))
                                          (Prims.of_int (18)))))
                                 (Obj.magic (Pulse_PP.pp Pulse_PP.uu___44 t))
                                 (fun uu___2 ->
@@ -3622,13 +3678,13 @@ let (get_non_informative_witness :
                      (FStar_Sealed.seal
                         (Obj.magic
                            (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                              (Prims.of_int (324)) (Prims.of_int (14))
-                              (Prims.of_int (348)) (Prims.of_int (17)))))
+                              (Prims.of_int (350)) (Prims.of_int (14))
+                              (Prims.of_int (374)) (Prims.of_int (17)))))
                      (FStar_Sealed.seal
                         (Obj.magic
                            (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                              (Prims.of_int (350)) (Prims.of_int (4))
-                              (Prims.of_int (357)) (Prims.of_int (39)))))
+                              (Prims.of_int (376)) (Prims.of_int (4))
+                              (Prims.of_int (383)) (Prims.of_int (39)))))
                      (FStar_Tactics_Effect.lift_div_tac
                         (fun uu___ ->
                            match Pulse_Syntax_Pure.is_fvar_app t with
@@ -3727,13 +3783,13 @@ let (check_prop_validity :
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                   (Prims.of_int (361)) (Prims.of_int (24))
-                   (Prims.of_int (361)) (Prims.of_int (76)))))
+                   (Prims.of_int (387)) (Prims.of_int (24))
+                   (Prims.of_int (387)) (Prims.of_int (76)))))
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                   (Prims.of_int (361)) (Prims.of_int (3))
-                   (Prims.of_int (368)) (Prims.of_int (20)))))
+                   (Prims.of_int (387)) (Prims.of_int (3))
+                   (Prims.of_int (394)) (Prims.of_int (20)))))
           (Obj.magic
              (rtb_check_prop_validity g (Pulse_Typing.elab_env g)
                 (Pulse_Elaborate_Pure.elab_term p)))
@@ -3746,13 +3802,13 @@ let (check_prop_validity :
                          (FStar_Sealed.seal
                             (Obj.magic
                                (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                                  (Prims.of_int (362)) (Prims.of_int (4))
-                                  (Prims.of_int (362)) (Prims.of_int (23)))))
+                                  (Prims.of_int (388)) (Prims.of_int (4))
+                                  (Prims.of_int (388)) (Prims.of_int (23)))))
                          (FStar_Sealed.seal
                             (Obj.magic
                                (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                                  (Prims.of_int (363)) (Prims.of_int (4))
-                                  (Prims.of_int (368)) (Prims.of_int (20)))))
+                                  (Prims.of_int (389)) (Prims.of_int (4))
+                                  (Prims.of_int (394)) (Prims.of_int (20)))))
                          (Obj.magic
                             (FStar_Tactics_V2_Builtins.log_issues issues))
                          (fun uu___2 ->
@@ -3766,17 +3822,17 @@ let (check_prop_validity :
                                               (Obj.magic
                                                  (FStar_Range.mk_range
                                                     "Pulse.Checker.Pure.fst"
-                                                    (Prims.of_int (366))
+                                                    (Prims.of_int (392))
                                                     (Prims.of_int (13))
-                                                    (Prims.of_int (367))
+                                                    (Prims.of_int (393))
                                                     (Prims.of_int (62)))))
                                            (FStar_Sealed.seal
                                               (Obj.magic
                                                  (FStar_Range.mk_range
                                                     "Pulse.Checker.Pure.fst"
-                                                    (Prims.of_int (365))
+                                                    (Prims.of_int (391))
                                                     (Prims.of_int (6))
-                                                    (Prims.of_int (367))
+                                                    (Prims.of_int (393))
                                                     (Prims.of_int (62)))))
                                            (Obj.magic
                                               (FStar_Tactics_Effect.tac_bind
@@ -3784,9 +3840,9 @@ let (check_prop_validity :
                                                     (Obj.magic
                                                        (FStar_Range.mk_range
                                                           "Pulse.Checker.Pure.fst"
-                                                          (Prims.of_int (367))
+                                                          (Prims.of_int (393))
                                                           (Prims.of_int (22))
-                                                          (Prims.of_int (367))
+                                                          (Prims.of_int (393))
                                                           (Prims.of_int (61)))))
                                                  (FStar_Sealed.seal
                                                     (Obj.magic
@@ -3830,20 +3886,20 @@ let fail_expected_tot_found_ghost :
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                 (Prims.of_int (372)) (Prims.of_int (4)) (Prims.of_int (372))
+                 (Prims.of_int (398)) (Prims.of_int (4)) (Prims.of_int (398))
                  (Prims.of_int (86)))))
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                 (Prims.of_int (371)) (Prims.of_int (2)) (Prims.of_int (372))
+                 (Prims.of_int (397)) (Prims.of_int (2)) (Prims.of_int (398))
                  (Prims.of_int (86)))))
         (Obj.magic
            (FStar_Tactics_Effect.tac_bind
               (FStar_Sealed.seal
                  (Obj.magic
                     (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                       (Prims.of_int (372)) (Prims.of_int (65))
-                       (Prims.of_int (372)) (Prims.of_int (85)))))
+                       (Prims.of_int (398)) (Prims.of_int (65))
+                       (Prims.of_int (398)) (Prims.of_int (85)))))
               (FStar_Sealed.seal
                  (Obj.magic
                     (FStar_Range.mk_range "prims.fst" (Prims.of_int (590))
@@ -3874,13 +3930,13 @@ let (check_tot_term :
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                 (Prims.of_int (375)) (Prims.of_int (35))
-                 (Prims.of_int (375)) (Prims.of_int (49)))))
+                 (Prims.of_int (401)) (Prims.of_int (35))
+                 (Prims.of_int (401)) (Prims.of_int (49)))))
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                 (Prims.of_int (374)) (Prims.of_int (24))
-                 (Prims.of_int (377)) (Prims.of_int (40)))))
+                 (Prims.of_int (400)) (Prims.of_int (24))
+                 (Prims.of_int (403)) (Prims.of_int (40)))))
         (Obj.magic (check_term g t))
         (fun uu___ ->
            (fun uu___ ->
@@ -3909,13 +3965,13 @@ let (check_tot_term_and_type :
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                 (Prims.of_int (380)) (Prims.of_int (55))
-                 (Prims.of_int (380)) (Prims.of_int (78)))))
+                 (Prims.of_int (406)) (Prims.of_int (55))
+                 (Prims.of_int (406)) (Prims.of_int (78)))))
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                 (Prims.of_int (379)) (Prims.of_int (33))
-                 (Prims.of_int (382)) (Prims.of_int (40)))))
+                 (Prims.of_int (405)) (Prims.of_int (33))
+                 (Prims.of_int (408)) (Prims.of_int (40)))))
         (Obj.magic (check_term_and_type g t))
         (fun uu___ ->
            (fun uu___ ->
@@ -3956,13 +4012,13 @@ let (core_check_tot_term :
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                 (Prims.of_int (388)) (Prims.of_int (25))
-                 (Prims.of_int (388)) (Prims.of_int (44)))))
+                 (Prims.of_int (414)) (Prims.of_int (25))
+                 (Prims.of_int (414)) (Prims.of_int (44)))))
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                 (Prims.of_int (387)) (Prims.of_int (29))
-                 (Prims.of_int (390)) (Prims.of_int (40)))))
+                 (Prims.of_int (413)) (Prims.of_int (29))
+                 (Prims.of_int (416)) (Prims.of_int (40)))))
         (Obj.magic (core_check_term g t))
         (fun uu___ ->
            (fun uu___ ->
@@ -4000,13 +4056,13 @@ let (is_non_informative :
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                 (Prims.of_int (396)) (Prims.of_int (21))
-                 (Prims.of_int (396)) (Prims.of_int (89)))))
+                 (Prims.of_int (422)) (Prims.of_int (21))
+                 (Prims.of_int (422)) (Prims.of_int (89)))))
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                 (Prims.of_int (395)) (Prims.of_int (28))
-                 (Prims.of_int (398)) (Prims.of_int (6)))))
+                 (Prims.of_int (421)) (Prims.of_int (28))
+                 (Prims.of_int (424)) (Prims.of_int (6)))))
         (Obj.magic
            (catch_all
               (fun uu___ ->
@@ -4022,13 +4078,13 @@ let (is_non_informative :
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                                (Prims.of_int (397)) (Prims.of_int (2))
-                                (Prims.of_int (397)) (Prims.of_int (21)))))
+                                (Prims.of_int (423)) (Prims.of_int (2))
+                                (Prims.of_int (423)) (Prims.of_int (21)))))
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                                (Prims.of_int (396)) (Prims.of_int (6))
-                                (Prims.of_int (396)) (Prims.of_int (10)))))
+                                (Prims.of_int (422)) (Prims.of_int (6))
+                                (Prims.of_int (422)) (Prims.of_int (10)))))
                        (Obj.magic
                           (FStar_Tactics_V2_Builtins.log_issues issues))
                        (fun uu___1 ->
@@ -4050,13 +4106,13 @@ let (check_subtyping :
                (FStar_Sealed.seal
                   (Obj.magic
                      (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                        (Prims.of_int (402)) (Prims.of_int (20))
-                        (Prims.of_int (402)) (Prims.of_int (47)))))
+                        (Prims.of_int (428)) (Prims.of_int (20))
+                        (Prims.of_int (428)) (Prims.of_int (47)))))
                (FStar_Sealed.seal
                   (Obj.magic
                      (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                        (Prims.of_int (401)) (Prims.of_int (34))
-                        (Prims.of_int (411)) (Prims.of_int (31)))))
+                        (Prims.of_int (427)) (Prims.of_int (34))
+                        (Prims.of_int (437)) (Prims.of_int (31)))))
                (Obj.magic (rtb_check_subtyping g t1 t2))
                (fun uu___1 ->
                   (fun uu___1 ->
@@ -4068,17 +4124,17 @@ let (check_subtyping :
                                  (Obj.magic
                                     (FStar_Range.mk_range
                                        "Pulse.Checker.Pure.fst"
-                                       (Prims.of_int (403))
+                                       (Prims.of_int (429))
                                        (Prims.of_int (2))
-                                       (Prims.of_int (403))
+                                       (Prims.of_int (429))
                                        (Prims.of_int (21)))))
                               (FStar_Sealed.seal
                                  (Obj.magic
                                     (FStar_Range.mk_range
                                        "Pulse.Checker.Pure.fst"
-                                       (Prims.of_int (404))
+                                       (Prims.of_int (430))
                                        (Prims.of_int (2))
-                                       (Prims.of_int (411))
+                                       (Prims.of_int (437))
                                        (Prims.of_int (31)))))
                               (Obj.magic
                                  (FStar_Tactics_V2_Builtins.log_issues issues))
@@ -4098,17 +4154,17 @@ let (check_subtyping :
                                                    (Obj.magic
                                                       (FStar_Range.mk_range
                                                          "Pulse.Checker.Pure.fst"
-                                                         (Prims.of_int (408))
+                                                         (Prims.of_int (434))
                                                          (Prims.of_int (6))
-                                                         (Prims.of_int (411))
+                                                         (Prims.of_int (437))
                                                          (Prims.of_int (31)))))
                                                 (FStar_Sealed.seal
                                                    (Obj.magic
                                                       (FStar_Range.mk_range
                                                          "Pulse.Checker.Pure.fst"
-                                                         (Prims.of_int (407))
+                                                         (Prims.of_int (433))
                                                          (Prims.of_int (4))
-                                                         (Prims.of_int (411))
+                                                         (Prims.of_int (437))
                                                          (Prims.of_int (31)))))
                                                 (Obj.magic
                                                    (FStar_Tactics_Effect.tac_bind
@@ -4116,17 +4172,17 @@ let (check_subtyping :
                                                          (Obj.magic
                                                             (FStar_Range.mk_range
                                                                "Pulse.Checker.Pure.fst"
-                                                               (Prims.of_int (411))
+                                                               (Prims.of_int (437))
                                                                (Prims.of_int (9))
-                                                               (Prims.of_int (411))
+                                                               (Prims.of_int (437))
                                                                (Prims.of_int (30)))))
                                                       (FStar_Sealed.seal
                                                          (Obj.magic
                                                             (FStar_Range.mk_range
                                                                "Pulse.Checker.Pure.fst"
-                                                               (Prims.of_int (408))
+                                                               (Prims.of_int (434))
                                                                (Prims.of_int (6))
-                                                               (Prims.of_int (411))
+                                                               (Prims.of_int (437))
                                                                (Prims.of_int (31)))))
                                                       (Obj.magic
                                                          (Pulse_Syntax_Printer.term_to_string
@@ -4140,18 +4196,18 @@ let (check_subtyping :
                                                                     Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (408))
+                                                                    (Prims.of_int (434))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (411))
+                                                                    (Prims.of_int (437))
                                                                     (Prims.of_int (31)))))
                                                                  (FStar_Sealed.seal
                                                                     (
                                                                     Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (408))
+                                                                    (Prims.of_int (434))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (411))
+                                                                    (Prims.of_int (437))
                                                                     (Prims.of_int (31)))))
                                                                  (Obj.magic
                                                                     (
@@ -4160,9 +4216,9 @@ let (check_subtyping :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (410))
+                                                                    (Prims.of_int (436))
                                                                     (Prims.of_int (9))
-                                                                    (Prims.of_int (410))
+                                                                    (Prims.of_int (436))
                                                                     (Prims.of_int (30)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -4221,13 +4277,13 @@ let (check_equiv :
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                   (Prims.of_int (416)) (Prims.of_int (4))
-                   (Prims.of_int (416)) (Prims.of_int (80)))))
+                   (Prims.of_int (442)) (Prims.of_int (4))
+                   (Prims.of_int (442)) (Prims.of_int (80)))))
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                   (Prims.of_int (414)) (Prims.of_int (25))
-                   (Prims.of_int (418)) (Prims.of_int (5)))))
+                   (Prims.of_int (440)) (Prims.of_int (25))
+                   (Prims.of_int (444)) (Prims.of_int (5)))))
           (Obj.magic
              (Pulse_Typing_Util.check_equiv_now (Pulse_Typing.elab_env g)
                 (Pulse_Elaborate_Pure.elab_term t1)
@@ -4241,13 +4297,13 @@ let (check_equiv :
                          (FStar_Sealed.seal
                             (Obj.magic
                                (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                                  (Prims.of_int (417)) (Prims.of_int (2))
-                                  (Prims.of_int (417)) (Prims.of_int (21)))))
+                                  (Prims.of_int (443)) (Prims.of_int (2))
+                                  (Prims.of_int (443)) (Prims.of_int (21)))))
                          (FStar_Sealed.seal
                             (Obj.magic
                                (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                                  (Prims.of_int (415)) (Prims.of_int (6))
-                                  (Prims.of_int (415)) (Prims.of_int (9)))))
+                                  (Prims.of_int (441)) (Prims.of_int (6))
+                                  (Prims.of_int (441)) (Prims.of_int (9)))))
                          (Obj.magic
                             (FStar_Tactics_V2_Builtins.log_issues issues))
                          (fun uu___1 ->


### PR DESCRIPTION
* Checking the annotation on a Pulse function would produce an F* term without ranges; add the source ranges to the elaborated arrow.

* In Pulse.Checker.Pure, if a callback to the typechecker already reports an error issue with a range, then do not report another error blaming the entire term used in the callback. Instead, just call T.fail (with an error message), which adds an error stub to the top of the Pulse function, rather than masking the more precise original error report. 