### PR TITLE
Nik type directed stapp

### DIFF
--- a/lib/steel/pulse/Pulse.Checker.Base.fst
+++ b/lib/steel/pulse/Pulse.Checker.Base.fst
@@ -561,10 +561,12 @@ let rec is_stateful_arrow (g:env) (c:option comp) (args:list T.argv) (out:list T
 
           | (arg, qual)::args' -> ( //check that this arg qual matches the binder and recurse accordingly
             match b.qual, qual with
+            | T.Q_Meta _, T.Q_Implicit
             | T.Q_Implicit, T.Q_Implicit 
             | T.Q_Explicit, T.Q_Explicit ->  //consume this argument
               is_stateful_arrow g (readback_comp_res_as_comp c) args' ((arg, qual)::out)
 
+            | T.Q_Meta _, T.Q_Explicit
             | T.Q_Implicit, T.Q_Explicit -> 
               //don't consume this argument
               is_stateful_arrow g (readback_comp_res_as_comp c) args out

--- a/lib/steel/pulse/Pulse.Checker.Base.fsti
+++ b/lib/steel/pulse/Pulse.Checker.Base.fsti
@@ -142,3 +142,6 @@ val checker_result_for_st_typing (#g:env) (#ctxt:vprop) (#post_hint:post_hint_op
   (d:st_typing_in_ctxt g ctxt post_hint)
   (ppname:ppname)
   : T.Tac (checker_result_t g ctxt post_hint)
+
+val is_stateful_application (g:env) (e:term) 
+  : T.Tac (option st_term)

--- a/lib/steel/pulse/Pulse.Checker.Bind.fst
+++ b/lib/steel/pulse/Pulse.Checker.Bind.fst
@@ -69,6 +69,8 @@ let check_bind
 
     checker_result_for_st_typing d res_ppname
   )
+
+
 let check_tot_bind
   (g:env)
   (pre:term)
@@ -84,48 +86,54 @@ let check_tot_bind
   if None? post_hint
   then fail g (Some t.range) "check_tot_bind: post hint is not set, please add an annotation";
 
-  // let Tm_TotBind { head=e1; body=e2 } = t.term in
-  // let (| e1, eff1, t1, (| u1, _t1_typing |), e1_typing |) =
-  //   check_term_and_type g e1 in
+
   let Tm_TotBind { binder=b; head=e1; body=e2 } = t.term in
-  let (| e1, eff1, t1, (| u1, _t1_typing |) , e1_typing |) =
-    (* If there's an annotated type for e1 in the binder, we check it at
-    that type. Otherwise we just call check_term_and_type and infer. *)
-    let ty = b.binder_ty in
-    match ty.t with
-    | Tm_Unknown ->
-      check_term_and_type g e1
-    | _ ->
-      let (| ty, _, _ |) = check_tot_term g ty in //elaborate it first
-      let (| u1, ty_typing |) = check_universe g ty in
-      let (| e1, eff1, e1_typing |) = check_term_with_expected_type g e1 ty in
-      let ty_typing : universe_of g ty u1 = ty_typing in
-      let e1_typing : typing g e1 eff1 ty = e1_typing in
-      (| e1, eff1, ty, (| u1, ty_typing |), e1_typing |)
-        <: (t:term & eff:T.tot_or_ghost & ty:term & (u:universe & universe_of g ty u) & typing g t eff ty)
-        (* ^ Need this annotation *)
-  in
-  let t1 =
-    let b = {binder_ty=t1;binder_ppname=ppname_default} in
-    let eq_tm = mk_eq2 u1 t1 (null_bvar 0) e1 in
-    tm_refine b eq_tm in
+  match Pulse.Checker.Base.is_stateful_application g e1 with
+  | Some st_app -> (
+    let t = { t with term = Tm_Bind { binder=b; head=st_app; body=e2 } } in
+    check_bind g pre pre_typing post_hint res_ppname t check
+  )
 
-  // THIS IS WASTEFUL, CHECKING e1 MULTIPLE TIMES
-  let (| e1, e1_typing |) =
-    check_term_with_expected_type_and_effect g e1 eff1 t1 in
+  | None -> (
+    let (| e1, eff1, t1, (| u1, _t1_typing |) , e1_typing |) =
+      (* If there's an annotated type for e1 in the binder, we check it at
+      that type. Otherwise we just call check_term_and_type and infer. *)
+      let ty = b.binder_ty in
+      match ty.t with
+      | Tm_Unknown ->
+        check_term_and_type g e1
+      | _ ->
+        let (| ty, _, _ |) = check_tot_term g ty in //elaborate it first
+        let (| u1, ty_typing |) = check_universe g ty in
+        let (| e1, eff1, e1_typing |) = check_term_with_expected_type g e1 ty in
+        let ty_typing : universe_of g ty u1 = ty_typing in
+        let e1_typing : typing g e1 eff1 ty = e1_typing in
+        (| e1, eff1, ty, (| u1, ty_typing |), e1_typing |)
+          <: (t:term & eff:T.tot_or_ghost & ty:term & (u:universe & universe_of g ty u) & typing g t eff ty)
+          (* ^ Need this annotation *)
+    in
+    let t1 =
+      let b = {binder_ty=t1;binder_ppname=ppname_default} in
+      let eq_tm = mk_eq2 u1 t1 (null_bvar 0) e1 in
+      tm_refine b eq_tm in
 
-  let x = fresh g in
+    // THIS IS WASTEFUL, CHECKING e1 MULTIPLE TIMES
+    let (| e1, e1_typing |) =
+      check_term_with_expected_type_and_effect g e1 eff1 t1 in
 
-  let b = { b with binder_ty = t1 } in
-  let k = continuation_elaborator_with_let pre_typing b e1_typing (ppname_default, x) in
+    let x = fresh g in
 
-  let px = b.binder_ppname, x in
-  let g' = push_binding g x (fst px) t1 in
-  let pre_typing' : tot_typing g' pre tm_vprop =
-    Metatheory.tot_typing_weakening_single pre_typing x t1 in
-  let d =
-    let ppname = mk_ppname_no_range "_tbind_c" in
-    let r = check g' pre pre_typing' post_hint ppname (open_st_term_nv e2 px) in
-    apply_checker_result_k #_ #_ #(Some?.v post_hint) r ppname in
-  let d = k post_hint d in
-  checker_result_for_st_typing d res_ppname
+    let b = { b with binder_ty = t1 } in
+    let k = continuation_elaborator_with_let pre_typing b e1_typing (ppname_default, x) in
+
+    let px = b.binder_ppname, x in
+    let g' = push_binding g x (fst px) t1 in
+    let pre_typing' : tot_typing g' pre tm_vprop =
+      Metatheory.tot_typing_weakening_single pre_typing x t1 in
+    let d =
+      let ppname = mk_ppname_no_range "_tbind_c" in
+      let r = check g' pre pre_typing' post_hint ppname (open_st_term_nv e2 px) in
+      apply_checker_result_k #_ #_ #(Some?.v post_hint) r ppname in
+    let d = k post_hint d in
+    checker_result_for_st_typing d res_ppname
+  )

--- a/lib/steel/pulse/Pulse.Checker.Return.fsti
+++ b/lib/steel/pulse/Pulse.Checker.Return.fsti
@@ -13,4 +13,5 @@ val check
   (post_hint:post_hint_opt g)
   (res_ppname:ppname)
   (st:st_term { Tm_Return? st.term })
+  (check:check_t)
   : T.Tac (checker_result_t g ctxt post_hint)

--- a/lib/steel/pulse/Pulse.Checker.fst
+++ b/lib/steel/pulse/Pulse.Checker.fst
@@ -144,7 +144,7 @@ let rec check
     let g = push_context (P.tag_of_st_term t) t.range g in
     match t.term with
     | Tm_Return _ ->
-      Return.check g pre pre_typing post_hint res_ppname t
+      Return.check g pre pre_typing post_hint res_ppname t check
     
     | Tm_Abs _ -> T.fail "Tm_Abs check should not have been called in the checker"
 

--- a/lib/steel/pulse/Pulse.RuntimeUtils.fsti
+++ b/lib/steel/pulse/Pulse.RuntimeUtils.fsti
@@ -41,3 +41,4 @@ val deep_compress (t:T.term) : r:T.term { t == r }
 val deep_transform_to_unary_applications (t:T.term) : r:T.term { t == r }
 val map_seal (s:FStar.Sealed.sealed 't) (f: 't -> 'u) : FStar.Sealed.sealed 'u
 val float_one : FStar.Float.float
+val lax_check_term_with_unknown_universes (g:env) (t:T.term) : option T.term

--- a/share/steel/examples/pulse/Fibo32.fst
+++ b/share/steel/examples/pulse/Fibo32.fst
@@ -16,7 +16,7 @@ let rec fib_mono (n:nat) (m:nat { m <= n})
 
 open Pulse.Lib.BoundedIntegers
 
-#push-options "--z3rlimit_factor 4 --z3refresh --log_queries --query_stats"
+#push-options "--z3rlimit_factor 4"
 ```pulse
 fn fibo32 (k:U32.t) (_:squash(0ul < k /\ fits #U32.t (fib (v k))))
   requires emp

--- a/share/steel/examples/pulse/Recursion.fst
+++ b/share/steel/examples/pulse/Recursion.fst
@@ -8,8 +8,7 @@ fn rec test1
   requires emp
   ensures pure False
 {
-  let x = perform (fun () -> test1 ());
-  ()
+  test1 ()
 }
 ```
 
@@ -32,8 +31,7 @@ fn rec test2
   ensures emp
 {
   if (y > 0) {
-    perform (fun () -> test2 (y-1));
-    ()
+    test2 (y-1)
   }
 }
 ```
@@ -47,7 +45,7 @@ fn rec test3
   ensures emp
 {
   if (y > 0) {
-    perform (fun () -> test3 (z+1) (y-1));
+    test3 (z+1) (y-1)
   } else {
     z
   }
@@ -76,7 +74,7 @@ fn rec test_ghost_loop
   ensures emp
   decreases ()
 {
-  perform_ghost (fun () -> test_ghost_loop ())
+  test_ghost_loop ()
 }
 ```
 
@@ -91,7 +89,7 @@ fn rec test4
   if (y > 0) {
     let w = !r;
     r := w+1;
-    perform (fun () -> test4 r (v+1) (y-1));
+    test4 r (v+1) (y-1);
   }
 }
 ```
@@ -106,7 +104,7 @@ fn rec test5
   decreases z
 {
   if (z <> 0 && y <> 0) {
-    perform_ghost (fun () -> test5 (z-1) (y-1))
+    test5 (z-1) (y-1)
   }
 }
 ```
@@ -123,7 +121,7 @@ fn rec test5'
   decreases z
 {
   if (z <> 0 && y <> 0) {
-    perform_ghost (fun () -> test5' (z-1) (y-1))
+    test5' (z-1) (y-1)
   }
 }
 ```
@@ -134,7 +132,7 @@ fn rec test6
   requires emp
   ensures pure False
 {
-  let x = perform (fun () -> test6 () (y+1));
+  let x = test6 () (y+1);
   test5 10 10;
   ()
 }

--- a/share/steel/examples/pulse/bug-reports/BugHigherOrderApplication.fst
+++ b/share/steel/examples/pulse/bug-reports/BugHigherOrderApplication.fst
@@ -102,3 +102,53 @@ fn apply_id_t (f:id_t bool) (x:bool)
    res
 }
 ```
+
+noeq
+type record = {
+    first:bool;
+    second: (bool -> stt bool emp (fun _ -> emp));
+}
+
+```pulse
+fn projection (r:record)
+requires emp
+returns _:bool
+ensures emp
+{
+    let res = r.first;
+    res
+}
+```
+
+```pulse
+fn return (#a:Type0) (x:a)
+requires emp
+returns y:a
+ensures pure (x == y)
+{
+    x
+}
+```
+
+```pulse
+fn project_and_apply (r:record)
+requires emp
+returns _:bool
+ensures emp
+{
+    let f = return r.second; //need the return since otherwise Pulse adds an equality refinement to the type of x
+    f r.first
+}
+```
+
+assume val g :  (f:(bool -> stt bool emp (fun _ -> emp)){ f == f })
+[@@expect_failure] //this fails too, with unexpected head type in impure application
+```pulse
+fn apply_refined_function (b:bool)
+requires emp
+returns b:bool
+ensures emp
+{
+    g b
+}
+```

--- a/share/steel/examples/pulse/bug-reports/BugHigherOrderApplication.fst
+++ b/share/steel/examples/pulse/bug-reports/BugHigherOrderApplication.fst
@@ -1,0 +1,104 @@
+module BugHigherOrderApplication
+open Pulse.Lib.Pervasives
+
+```pulse
+fn apply (#a #b:Type0) (f: (x:a -> stt b emp (fun _ -> emp))) (x:a)
+    requires emp
+    returns y:b
+    ensures emp
+{
+    f x
+}
+```
+
+```pulse
+fn apply2 (#a #b:Type0) (f: (x:a -> stt b emp (fun _ -> emp))) (x:a)
+    requires emp
+    returns y:(b & b)
+    ensures emp
+{
+    let fst = f x;
+    let snd = f x;
+    Mktuple2 u#0 u#0 fst snd
+}
+```
+
+```pulse
+fn apply_with_imps (#a #b:Type0) (#p:(a -> vprop)) (#q:(a -> b -> vprop))
+                  (f: (x:a -> stt b (p x) (fun y -> q x y)))
+                  (x:a)
+    requires p x
+    returns y:b
+    ensures q x y
+{
+    f x;
+}
+```
+
+```pulse
+fn apply_with_imps_inst
+    (#a #b:Type0) (#p:(a -> nat -> vprop)) (#q:(a -> nat -> b -> vprop))
+    (f: (x:a -> #index:nat -> stt b (p x index) (fun y -> q x index y)))
+    (x:a)
+  requires p x 0
+  returns y:b
+  ensures q x 0 y
+{
+    f x;
+}
+```
+
+
+
+```pulse
+fn apply_with_imps_explicit 
+    (#a #b:Type0) (#p:(a -> nat -> vprop)) (#q:(a -> nat -> b -> vprop))
+    (f: (x:a -> #index:erased nat -> stt b (p x index) (fun y -> q x index y)))
+    (x:a) (#i:erased nat)
+  requires p x i
+  returns y:b
+  ensures q x i y
+{
+    f x #i;
+}
+```
+
+```pulse
+fn rec loop (x:int)
+    requires emp
+    returns y:int
+    ensures emp
+{
+    let res = loop x;
+    (res + 1)
+}
+```
+
+```pulse
+fn curry_stt
+    (#a #b #c:Type0)
+    (f: (a -> stt (b -> (stt c emp (fun _ -> emp))) emp (fun _ -> emp)))
+    (x:a) (y:b)
+  requires emp
+  returns _:c
+  ensures emp
+{
+    let g = f x;
+    g y
+}
+```
+
+let id_t (a:Type) = a -> stt a emp (fun _ -> emp)
+
+// Abbreviations don't work yet
+[@@expect_failure]
+```pulse
+fn apply_id_t (f:id_t bool) (x:bool)
+  requires emp
+  returns _:bool
+  ensures emp
+{
+   let res = f x;
+   res
+}
+```

--- a/share/steel/examples/pulse/bug-reports/BugHigherOrderApplication.fst
+++ b/share/steel/examples/pulse/bug-reports/BugHigherOrderApplication.fst
@@ -19,7 +19,7 @@ fn apply2 (#a #b:Type0) (f: (x:a -> stt b emp (fun _ -> emp))) (x:a)
 {
     let fst = f x;
     let snd = f x;
-    Mktuple2 u#0 u#0 fst snd
+    (fst, snd)
 }
 ```
 

--- a/share/steel/examples/pulse/lib/Pulse.Lib.LinkedList.fst
+++ b/share/steel/examples/pulse/lib/Pulse.Lib.LinkedList.fst
@@ -245,7 +245,7 @@ fn rec length (#t:Type0) (x:llist t)
         let node = !vl;
         with tail tl. assert (is_list #t tail tl);
         rewrite each tail as node.tail; 
-        let n = perform (fun () -> length #t node.tail tl);
+        let n = length #t node.tail tl;
         intro_is_list_cons x vl;
         (1 + n)
     }
@@ -304,7 +304,7 @@ fn rec append (#t:Type0) (x y:llist t)
                 intro_is_list_cons x np; 
             }
             Some _ -> {
-                perform (fun () -> append #t node.tail y #tl #'l2);
+                append #t node.tail y #tl #'l2;
                 intro_is_list_cons x np;
             }
         }

--- a/src/ocaml/plugin/Pulse_RuntimeUtils.ml
+++ b/src/ocaml/plugin/Pulse_RuntimeUtils.ml
@@ -68,3 +68,38 @@ let deep_transform_to_unary_applications (t:S.term) =
 let deep_compress (t:S.term) = FStar_Syntax_Compress.deep_compress_uvars t
 let map_seal (t:'a) (f:'a -> 'b) : 'b = f t
 let float_one = FStar_Compiler_Util.float_of_string "1.0"
+module TcEnv = FStar_TypeChecker_Env
+module Free = FStar_Syntax_Free
+module BU = FStar_Compiler_Util
+let lax_check_term_with_unknown_universes (g:TcEnv.env) (e:S.term)
+  : S.term option
+  = let open FStar_Tactics_V2_Basic in
+    let issues, res =
+      FStar_Errors.catch_errors (fun _ ->
+        if no_uvars_in_g g &&
+          no_uvars_in_term e
+        then (
+          let g = TcEnv.set_range g e.pos in
+          let must_tot = false in
+          let g = {g with instantiate_imp=false; phase1=true; lax=true} in
+          let e, t, guard = g.typeof_tot_or_gtot_term g e must_tot in
+          let _ = FStar_TypeChecker_Rel.resolve_implicits g guard in
+          let uvs = BU.set_union (Free.uvars e) (Free.uvars t) in
+          if not (BU.set_is_empty uvs)
+          then None
+          else (
+            let univs = BU.set_union (Free.univs e) (Free.univs t) in
+            let univs = BU.set_elements univs in
+            List.iter (fun univ -> FStar_Syntax_Unionfind.univ_change univ S.U_unknown) univs;
+            let t = FStar_Syntax_Compress.deep_compress false true t in
+            Some t
+          )
+        )
+        else None
+      )
+    in
+    FStar_Errors.add_issues issues;
+    match res with
+    | None -> None
+    | Some None -> None
+    | Some (Some x) -> Some x  

--- a/src/ocaml/plugin/Pulse_RuntimeUtils.ml
+++ b/src/ocaml/plugin/Pulse_RuntimeUtils.ml
@@ -79,23 +79,28 @@ let lax_check_term_with_unknown_universes (g:TcEnv.env) (e:S.term)
         if no_uvars_in_g g &&
           no_uvars_in_term e
         then (
-          let g = TcEnv.set_range g e.pos in
-          let must_tot = false in
-          let g = {g with instantiate_imp=false; phase1=true; lax=true} in
-          let e, t, guard = g.typeof_tot_or_gtot_term g e must_tot in
-          let _ = FStar_TypeChecker_Rel.resolve_implicits g guard in
-          let uvs = BU.set_union (Free.uvars e) (Free.uvars t) in
-          if not (BU.set_is_empty uvs)
-          then None
-          else (
-            let univs = BU.set_union (Free.univs e) (Free.univs t) in
-            let univs = BU.set_elements univs in
-            List.iter (fun univ -> FStar_Syntax_Unionfind.univ_change univ S.U_unknown) univs;
-            let t = FStar_Syntax_Compress.deep_compress false true t in
-            Some t
+          match e.n with
+          | S.Tm_fvar { fv_qual = Some _ } ->
+            (* record projectors etc. are pure *)
+            None 
+          | _ ->
+            let g = TcEnv.set_range g e.pos in
+            let must_tot = false in
+            let g = {g with instantiate_imp=false; phase1=true; lax=true} in
+            let e, t, guard = g.typeof_tot_or_gtot_term g e must_tot in
+            let _ = FStar_TypeChecker_Rel.resolve_implicits g guard in
+            let uvs = BU.set_union (Free.uvars e) (Free.uvars t) in
+            if not (BU.set_is_empty uvs)
+            then None
+            else (
+              let univs = BU.set_union (Free.univs e) (Free.univs t) in
+              let univs = BU.set_elements univs in
+              List.iter (fun univ -> FStar_Syntax_Unionfind.univ_change univ S.U_unknown) univs;
+              let t = FStar_Syntax_Compress.deep_compress false true t in
+              Some t
+            )
           )
-        )
-        else None
+          else None
       )
     in
     FStar_Errors.add_issues issues;

--- a/src/ocaml/plugin/generated/PulseDesugar.ml
+++ b/src/ocaml/plugin/generated/PulseDesugar.ml
@@ -421,50 +421,6 @@ let (resolve_lid : env_t -> FStar_Ident.lident -> FStar_Ident.lident err) =
                    "Name %s resolved unexpectedly to %s" uu___4 uu___5 in
                let uu___4 = FStar_Ident.range_of_lid lid in
                fail uu___3 uu___4)
-let (pulse_arrow_formals :
-  FStar_Syntax_Syntax.term ->
-    FStar_Syntax_Syntax.binder Prims.list FStar_Pervasives_Native.option)
-  =
-  fun t ->
-    let uu___ = FStar_Syntax_Util.arrow_formals_comp_ln t in
-    match uu___ with
-    | (formals, comp) ->
-        let uu___1 = FStar_Syntax_Util.is_total_comp comp in
-        if uu___1
-        then
-          let res = FStar_Syntax_Util.comp_result comp in
-          let uu___2 = FStar_Syntax_Util.head_and_args_full res in
-          (match uu___2 with
-           | (head, uu___3) ->
-               let uu___4 =
-                 let uu___5 = FStar_Syntax_Subst.compress head in
-                 uu___5.FStar_Syntax_Syntax.n in
-               (match uu___4 with
-                | FStar_Syntax_Syntax.Tm_fvar fv ->
-                    let uu___5 =
-                      FStar_Compiler_List.existsML
-                        (FStar_Syntax_Syntax.fv_eq_lid fv)
-                        [stt_lid; stt_ghost_lid; stt_atomic_lid] in
-                    if uu___5
-                    then FStar_Pervasives_Native.Some formals
-                    else FStar_Pervasives_Native.None
-                | FStar_Syntax_Syntax.Tm_uinst
-                    ({
-                       FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar fv;
-                       FStar_Syntax_Syntax.pos = uu___5;
-                       FStar_Syntax_Syntax.vars = uu___6;
-                       FStar_Syntax_Syntax.hash_code = uu___7;_},
-                     uu___8)
-                    ->
-                    let uu___9 =
-                      FStar_Compiler_List.existsML
-                        (FStar_Syntax_Syntax.fv_eq_lid fv)
-                        [stt_lid; stt_ghost_lid; stt_atomic_lid] in
-                    if uu___9
-                    then FStar_Pervasives_Native.Some formals
-                    else FStar_Pervasives_Native.None
-                | uu___5 -> FStar_Pervasives_Native.None))
-        else FStar_Pervasives_Native.None
 let (ret : FStar_Syntax_Syntax.term -> PulseSyntaxWrapper.st_term) =
   fun s ->
     let uu___ = as_term s in
@@ -485,53 +441,6 @@ let (__proj__Return__item___0 :
 let (st_term_of_admit_or_return :
   admit_or_return_t -> PulseSyntaxWrapper.st_term) =
   fun t -> match t with | STTerm t1 -> t1 | Return t1 -> ret t1
-let (type_is_stt_fun :
-  env_t ->
-    FStar_Syntax_Syntax.term ->
-      FStar_Syntax_Syntax.arg Prims.list -> Prims.bool)
-  =
-  fun env ->
-    fun t ->
-      fun args ->
-        let uu___ = pulse_arrow_formals t in
-        match uu___ with
-        | FStar_Pervasives_Native.None -> false
-        | FStar_Pervasives_Native.Some formals ->
-            let is_binder_implicit b =
-              match b.FStar_Syntax_Syntax.binder_qual with
-              | FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.Implicit
-                  uu___1) -> true
-              | FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.Meta
-                  uu___1) -> true
-              | uu___1 -> false in
-            let is_arg_implicit aq =
-              match FStar_Pervasives_Native.snd aq with
-              | FStar_Pervasives_Native.Some
-                  { FStar_Syntax_Syntax.aqual_implicit = b;
-                    FStar_Syntax_Syntax.aqual_attributes = uu___1;_}
-                  -> b
-              | uu___1 -> false in
-            let rec uninst_formals formals1 args1 =
-              match (formals1, args1) with
-              | (uu___1, []) -> FStar_Pervasives_Native.Some formals1
-              | ([], uu___1) -> FStar_Pervasives_Native.None
-              | (f::formals2, a::args2) ->
-                  if is_binder_implicit f
-                  then
-                    (if is_arg_implicit a
-                     then uninst_formals formals2 args2
-                     else uninst_formals formals2 (a :: args2))
-                  else
-                    if is_arg_implicit a
-                    then FStar_Pervasives_Native.None
-                    else uninst_formals formals2 args2 in
-            let uu___1 = uninst_formals formals args in
-            (match uu___1 with
-             | FStar_Pervasives_Native.None -> false
-             | FStar_Pervasives_Native.Some formals1 ->
-                 let uu___2 =
-                   FStar_Compiler_List.for_all is_binder_implicit formals1 in
-                 if uu___2 then true else false)
 let (admit_or_return :
   env_t -> FStar_Syntax_Syntax.term -> admit_or_return_t) =
   fun env ->

--- a/src/ocaml/plugin/generated/PulseDesugar.ml
+++ b/src/ocaml/plugin/generated/PulseDesugar.ml
@@ -469,21 +469,21 @@ let (ret : FStar_Syntax_Syntax.term -> PulseSyntaxWrapper.st_term) =
   fun s ->
     let uu___ = as_term s in
     PulseSyntaxWrapper.tm_return uu___ s.FStar_Syntax_Syntax.pos
-type stapp_or_return_t =
+type admit_or_return_t =
   | STTerm of PulseSyntaxWrapper.st_term 
   | Return of FStar_Syntax_Syntax.term 
-let (uu___is_STTerm : stapp_or_return_t -> Prims.bool) =
+let (uu___is_STTerm : admit_or_return_t -> Prims.bool) =
   fun projectee -> match projectee with | STTerm _0 -> true | uu___ -> false
 let (__proj__STTerm__item___0 :
-  stapp_or_return_t -> PulseSyntaxWrapper.st_term) =
+  admit_or_return_t -> PulseSyntaxWrapper.st_term) =
   fun projectee -> match projectee with | STTerm _0 -> _0
-let (uu___is_Return : stapp_or_return_t -> Prims.bool) =
+let (uu___is_Return : admit_or_return_t -> Prims.bool) =
   fun projectee -> match projectee with | Return _0 -> true | uu___ -> false
 let (__proj__Return__item___0 :
-  stapp_or_return_t -> FStar_Syntax_Syntax.term) =
+  admit_or_return_t -> FStar_Syntax_Syntax.term) =
   fun projectee -> match projectee with | Return _0 -> _0
-let (st_term_of_stapp_or_return :
-  stapp_or_return_t -> PulseSyntaxWrapper.st_term) =
+let (st_term_of_admit_or_return :
+  admit_or_return_t -> PulseSyntaxWrapper.st_term) =
   fun t -> match t with | STTerm t1 -> t1 | Return t1 -> ret t1
 let (type_is_stt_fun :
   env_t ->
@@ -532,28 +532,8 @@ let (type_is_stt_fun :
                  let uu___2 =
                    FStar_Compiler_List.for_all is_binder_implicit formals1 in
                  if uu___2 then true else false)
-let (mk_st_app :
-  FStar_Compiler_Range_Type.range ->
-    FStar_Syntax_Syntax.term ->
-      (FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax *
-        FStar_Syntax_Syntax.arg_qualifier FStar_Pervasives_Native.option)
-        Prims.list -> PulseSyntaxWrapper.st_term)
-  =
-  fun rng ->
-    fun head ->
-      fun args ->
-        let head1 =
-          let uu___ = FStar_Compiler_List.init args in
-          FStar_Syntax_Syntax.mk_Tm_app head uu___ rng in
-        let uu___ = FStar_Compiler_List.last args in
-        match uu___ with
-        | (last, q) ->
-            let uu___1 =
-              PulseSyntaxWrapper.tm_expr head1 head1.FStar_Syntax_Syntax.pos in
-            let uu___2 = as_term last in
-            PulseSyntaxWrapper.tm_st_app uu___1 q uu___2 rng
-let (stapp_or_return :
-  env_t -> FStar_Syntax_Syntax.term -> stapp_or_return_t) =
+let (admit_or_return :
+  env_t -> FStar_Syntax_Syntax.term -> admit_or_return_t) =
   fun env ->
     fun s ->
       let r = s.FStar_Syntax_Syntax.pos in
@@ -566,18 +546,7 @@ let (stapp_or_return :
                if uu___1
                then
                  let uu___2 = PulseSyntaxWrapper.tm_admit r in STTerm uu___2
-               else
-                 (let uu___3 =
-                    FStar_TypeChecker_Env.try_lookup_lid env.tcenv
-                      (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-                  match uu___3 with
-                  | FStar_Pervasives_Native.None -> Return s
-                  | FStar_Pervasives_Native.Some ((uu___4, t), uu___5) ->
-                      let uu___6 = type_is_stt_fun env t args in
-                      if uu___6
-                      then
-                        let uu___7 = mk_st_app r head args in STTerm uu___7
-                      else Return s)
+               else Return s
            | uu___1 -> Return s)
 let (prepend_ctx_issue :
   FStar_Pprint.document -> FStar_Errors.issue -> FStar_Errors.issue) =
@@ -859,8 +828,8 @@ let rec (desugar_stmt :
           op_let_Question uu___
             (fun tm ->
                let uu___1 =
-                 let uu___2 = stapp_or_return env tm in
-                 st_term_of_stapp_or_return uu___2 in
+                 let uu___2 = admit_or_return env tm in
+                 st_term_of_admit_or_return uu___2 in
                return uu___1)
       | PulseSugar.Assignment
           { PulseSugar.lhs = lhs; PulseSugar.value = value;_} ->
@@ -1208,7 +1177,7 @@ and (desugar_bind :
                                           PulseSyntaxWrapper.mk_binder
                                             lb.PulseSugar.id annot in
                                         let t =
-                                          let uu___5 = stapp_or_return env s1 in
+                                          let uu___5 = admit_or_return env s1 in
                                           match uu___5 with
                                           | STTerm s11 -> mk_bind b s11 s21 r
                                           | Return s11 ->

--- a/src/ocaml/plugin/generated/Pulse_Checker.ml
+++ b/src/ocaml/plugin/generated/Pulse_Checker.ml
@@ -504,7 +504,7 @@ let rec (check : Pulse_Checker_Base.check_t) =
                                                  (Obj.repr
                                                     (Pulse_Checker_Return.check
                                                        g1 pre () post_hint
-                                                       res_ppname t))
+                                                       res_ppname t check))
                                            | Pulse_Syntax_Base.Tm_Abs uu___1
                                                ->
                                                Obj.magic

--- a/src/ocaml/plugin/generated/Pulse_Checker_Base.ml
+++ b/src/ocaml/plugin/generated/Pulse_Checker_Base.ml
@@ -2635,139 +2635,146 @@ let (checker_result_for_st_typing :
                                                         uu___1))) uu___1)))
                                   uu___1))) uu___)
 let (readback_comp_res_as_comp :
-  FStar_Reflection_Types.comp ->
+  FStar_Tactics_NamedView.comp ->
     Pulse_Syntax_Base.comp FStar_Pervasives_Native.option)
   =
   fun c ->
-    match FStar_Reflection_V2_Builtins.inspect_comp c with
+    match c with
     | FStar_Reflection_V2_Data.C_Total t ->
         (match Pulse_Readback.readback_comp t with
          | FStar_Pervasives_Native.None -> FStar_Pervasives_Native.None
          | FStar_Pervasives_Native.Some c1 -> FStar_Pervasives_Native.Some c1)
     | uu___ -> FStar_Pervasives_Native.None
 let rec (is_stateful_arrow :
-  Pulse_Syntax_Base.comp FStar_Pervasives_Native.option ->
-    FStar_Reflection_V2_Data.argv Prims.list ->
+  Pulse_Typing_Env.env ->
+    Pulse_Syntax_Base.comp FStar_Pervasives_Native.option ->
       FStar_Reflection_V2_Data.argv Prims.list ->
-        ((FStar_Reflection_V2_Data.argv Prims.list *
-           FStar_Reflection_V2_Data.argv) FStar_Pervasives_Native.option,
-          unit) FStar_Tactics_Effect.tac_repr)
+        FStar_Reflection_V2_Data.argv Prims.list ->
+          ((FStar_Reflection_V2_Data.argv Prims.list *
+             FStar_Reflection_V2_Data.argv) FStar_Pervasives_Native.option,
+            unit) FStar_Tactics_Effect.tac_repr)
   =
-  fun uu___2 ->
-    fun uu___1 ->
-      fun uu___ ->
-        (fun c ->
-           fun args ->
-             fun out ->
-               match c with
-               | FStar_Pervasives_Native.None ->
-                   Obj.magic
-                     (Obj.repr
-                        (FStar_Tactics_Effect.lift_div_tac
-                           (fun uu___ -> FStar_Pervasives_Native.None)))
-               | FStar_Pervasives_Native.Some (Pulse_Syntax_Base.C_ST uu___)
-                   ->
-                   Obj.magic
-                     (Obj.repr
-                        (FStar_Tactics_Effect.lift_div_tac
-                           (fun uu___1 ->
-                              match (args, out) with
-                              | ([], hd::tl) ->
-                                  FStar_Pervasives_Native.Some
-                                    ((FStar_List_Tot_Base.rev tl), hd)
-                              | uu___2 -> FStar_Pervasives_Native.None)))
-               | FStar_Pervasives_Native.Some (Pulse_Syntax_Base.C_STGhost
-                   (uu___, uu___1)) ->
-                   Obj.magic
-                     (Obj.repr
-                        (FStar_Tactics_Effect.lift_div_tac
-                           (fun uu___2 ->
-                              match (args, out) with
-                              | ([], hd::tl) ->
-                                  FStar_Pervasives_Native.Some
-                                    ((FStar_List_Tot_Base.rev tl), hd)
-                              | uu___3 -> FStar_Pervasives_Native.None)))
-               | FStar_Pervasives_Native.Some (Pulse_Syntax_Base.C_STAtomic
-                   (uu___, uu___1)) ->
-                   Obj.magic
-                     (Obj.repr
-                        (FStar_Tactics_Effect.lift_div_tac
-                           (fun uu___2 ->
-                              match (args, out) with
-                              | ([], hd::tl) ->
-                                  FStar_Pervasives_Native.Some
-                                    ((FStar_List_Tot_Base.rev tl), hd)
-                              | uu___3 -> FStar_Pervasives_Native.None)))
-               | FStar_Pervasives_Native.Some (Pulse_Syntax_Base.C_Tot c_res)
-                   ->
-                   Obj.magic
-                     (Obj.repr
-                        (if
-                           Prims.op_Negation
-                             (Pulse_Syntax_Base.uu___is_Tm_FStar
-                                c_res.Pulse_Syntax_Base.t)
-                         then
-                           Obj.repr
-                             (FStar_Tactics_Effect.lift_div_tac
-                                (fun uu___ -> FStar_Pervasives_Native.None))
-                         else
-                           Obj.repr
-                             (FStar_Tactics_Effect.tac_bind
-                                (FStar_Sealed.seal
-                                   (Obj.magic
-                                      (FStar_Range.mk_range
-                                         "Pulse.Checker.Base.fst"
-                                         (Prims.of_int (550))
-                                         (Prims.of_int (29))
-                                         (Prims.of_int (550))
-                                         (Prims.of_int (36)))))
-                                (FStar_Sealed.seal
-                                   (Obj.magic
-                                      (FStar_Range.mk_range
-                                         "Pulse.Checker.Base.fst"
-                                         (Prims.of_int (549))
-                                         (Prims.of_int (11))
-                                         (Prims.of_int (577))
-                                         (Prims.of_int (7)))))
-                                (FStar_Tactics_Effect.lift_div_tac
-                                   (fun uu___1 -> c_res.Pulse_Syntax_Base.t))
-                                (fun uu___1 ->
-                                   (fun uu___1 ->
-                                      match uu___1 with
-                                      | Pulse_Syntax_Base.Tm_FStar c_res1 ->
-                                          Obj.magic
-                                            (FStar_Tactics_Effect.tac_bind
-                                               (FStar_Sealed.seal
-                                                  (Obj.magic
-                                                     (FStar_Range.mk_range
-                                                        "Pulse.Checker.Base.fst"
-                                                        (Prims.of_int (551))
-                                                        (Prims.of_int (17))
-                                                        (Prims.of_int (551))
-                                                        (Prims.of_int (35)))))
-                                               (FStar_Sealed.seal
-                                                  (Obj.magic
-                                                     (FStar_Range.mk_range
-                                                        "Pulse.Checker.Base.fst"
-                                                        (Prims.of_int (552))
-                                                        (Prims.of_int (8))
-                                                        (Prims.of_int (576))
-                                                        (Prims.of_int (19)))))
-                                               (FStar_Tactics_Effect.lift_div_tac
-                                                  (fun uu___2 ->
-                                                     FStar_Reflection_V2_Builtins.inspect_ln
-                                                       c_res1))
-                                               (fun uu___2 ->
-                                                  (fun ht ->
-                                                     match ht with
-                                                     | FStar_Reflection_V2_Data.Tv_Arrow
-                                                         (b, c1) ->
-                                                         Obj.magic
-                                                           (Obj.repr
-                                                              (match args
-                                                               with
-                                                               | [] ->
-                                                                   FStar_Tactics_Effect.tac_bind
+  fun uu___3 ->
+    fun uu___2 ->
+      fun uu___1 ->
+        fun uu___ ->
+          (fun g ->
+             fun c ->
+               fun args ->
+                 fun out ->
+                   match c with
+                   | FStar_Pervasives_Native.None ->
+                       Obj.magic
+                         (Obj.repr
+                            (FStar_Tactics_Effect.lift_div_tac
+                               (fun uu___ -> FStar_Pervasives_Native.None)))
+                   | FStar_Pervasives_Native.Some (Pulse_Syntax_Base.C_ST
+                       uu___) ->
+                       Obj.magic
+                         (Obj.repr
+                            (FStar_Tactics_Effect.lift_div_tac
+                               (fun uu___1 ->
+                                  match (args, out) with
+                                  | ([], hd::tl) ->
+                                      FStar_Pervasives_Native.Some
+                                        ((FStar_List_Tot_Base.rev tl), hd)
+                                  | uu___2 -> FStar_Pervasives_Native.None)))
+                   | FStar_Pervasives_Native.Some
+                       (Pulse_Syntax_Base.C_STGhost (uu___, uu___1)) ->
+                       Obj.magic
+                         (Obj.repr
+                            (FStar_Tactics_Effect.lift_div_tac
+                               (fun uu___2 ->
+                                  match (args, out) with
+                                  | ([], hd::tl) ->
+                                      FStar_Pervasives_Native.Some
+                                        ((FStar_List_Tot_Base.rev tl), hd)
+                                  | uu___3 -> FStar_Pervasives_Native.None)))
+                   | FStar_Pervasives_Native.Some
+                       (Pulse_Syntax_Base.C_STAtomic (uu___, uu___1)) ->
+                       Obj.magic
+                         (Obj.repr
+                            (FStar_Tactics_Effect.lift_div_tac
+                               (fun uu___2 ->
+                                  match (args, out) with
+                                  | ([], hd::tl) ->
+                                      FStar_Pervasives_Native.Some
+                                        ((FStar_List_Tot_Base.rev tl), hd)
+                                  | uu___3 -> FStar_Pervasives_Native.None)))
+                   | FStar_Pervasives_Native.Some (Pulse_Syntax_Base.C_Tot
+                       c_res) ->
+                       Obj.magic
+                         (Obj.repr
+                            (if
+                               Prims.op_Negation
+                                 (Pulse_Syntax_Base.uu___is_Tm_FStar
+                                    c_res.Pulse_Syntax_Base.t)
+                             then
+                               Obj.repr
+                                 (FStar_Tactics_Effect.lift_div_tac
+                                    (fun uu___ ->
+                                       FStar_Pervasives_Native.None))
+                             else
+                               Obj.repr
+                                 (FStar_Tactics_Effect.tac_bind
+                                    (FStar_Sealed.seal
+                                       (Obj.magic
+                                          (FStar_Range.mk_range
+                                             "Pulse.Checker.Base.fst"
+                                             (Prims.of_int (550))
+                                             (Prims.of_int (29))
+                                             (Prims.of_int (550))
+                                             (Prims.of_int (36)))))
+                                    (FStar_Sealed.seal
+                                       (Obj.magic
+                                          (FStar_Range.mk_range
+                                             "Pulse.Checker.Base.fst"
+                                             (Prims.of_int (549))
+                                             (Prims.of_int (11))
+                                             (Prims.of_int (586))
+                                             (Prims.of_int (7)))))
+                                    (FStar_Tactics_Effect.lift_div_tac
+                                       (fun uu___1 ->
+                                          c_res.Pulse_Syntax_Base.t))
+                                    (fun uu___1 ->
+                                       (fun uu___1 ->
+                                          match uu___1 with
+                                          | Pulse_Syntax_Base.Tm_FStar c_res1
+                                              ->
+                                              Obj.magic
+                                                (FStar_Tactics_Effect.tac_bind
+                                                   (FStar_Sealed.seal
+                                                      (Obj.magic
+                                                         (FStar_Range.mk_range
+                                                            "Pulse.Checker.Base.fst"
+                                                            (Prims.of_int (551))
+                                                            (Prims.of_int (17))
+                                                            (Prims.of_int (551))
+                                                            (Prims.of_int (32)))))
+                                                   (FStar_Sealed.seal
+                                                      (Obj.magic
+                                                         (FStar_Range.mk_range
+                                                            "Pulse.Checker.Base.fst"
+                                                            (Prims.of_int (552))
+                                                            (Prims.of_int (8))
+                                                            (Prims.of_int (576))
+                                                            (Prims.of_int (14)))))
+                                                   (Obj.magic
+                                                      (FStar_Tactics_NamedView.inspect
+                                                         c_res1))
+                                                   (fun uu___2 ->
+                                                      (fun ht ->
+                                                         match ht with
+                                                         | FStar_Tactics_NamedView.Tv_Arrow
+                                                             (b, c1) ->
+                                                             Obj.magic
+                                                               (Obj.repr
+                                                                  (match args
+                                                                   with
+                                                                   | 
+                                                                   [] ->
+                                                                    Obj.repr
+                                                                    (FStar_Tactics_Effect.tac_bind
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
@@ -2810,8 +2817,10 @@ let rec (is_stateful_arrow :
                                                                     Obj.magic
                                                                     (Obj.repr
                                                                     (is_stateful_arrow
+                                                                    g
                                                                     (readback_comp_res_as_comp
-                                                                    c2) []
+                                                                    (FStar_Reflection_V2_Builtins.inspect_comp
+                                                                    c2)) []
                                                                     out))
                                                                     else
                                                                     Obj.magic
@@ -2820,91 +2829,66 @@ let rec (is_stateful_arrow :
                                                                     (fun
                                                                     uu___4 ->
                                                                     FStar_Pervasives_Native.None))))
-                                                                    uu___2)
-                                                               | (arg, qual)::args'
-                                                                   ->
-                                                                   FStar_Tactics_Effect.tac_bind
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Base.fst"
-                                                                    (Prims.of_int (563))
-                                                                    (Prims.of_int (20))
-                                                                    (Prims.of_int (563))
-                                                                    (Prims.of_int (38)))))
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Base.fst"
-                                                                    (Prims.of_int (564))
-                                                                    (Prims.of_int (12))
-                                                                    (Prims.of_int (573))
-                                                                    (Prims.of_int (23)))))
-                                                                    (FStar_Tactics_Effect.lift_div_tac
-                                                                    (fun
-                                                                    uu___2 ->
-                                                                    FStar_Reflection_V2_Builtins.inspect_binder
-                                                                    b))
-                                                                    (fun
-                                                                    uu___2 ->
-                                                                    (fun b1
+                                                                    uu___2))
+                                                                   | 
+                                                                   (arg,
+                                                                    qual)::args'
                                                                     ->
-                                                                    match 
-                                                                    ((b1.FStar_Reflection_V2_Data.qual),
+                                                                    Obj.repr
+                                                                    (match 
+                                                                    ((b.FStar_Tactics_NamedView.qual),
                                                                     qual)
                                                                     with
                                                                     | 
                                                                     (FStar_Reflection_V2_Data.Q_Implicit,
                                                                     FStar_Reflection_V2_Data.Q_Implicit)
                                                                     ->
-                                                                    Obj.magic
-                                                                    (Obj.repr
+                                                                    Obj.repr
                                                                     (is_stateful_arrow
+                                                                    g
                                                                     (readback_comp_res_as_comp
                                                                     c1) args'
                                                                     ((arg,
                                                                     qual) ::
-                                                                    out)))
+                                                                    out))
                                                                     | 
                                                                     (FStar_Reflection_V2_Data.Q_Explicit,
                                                                     FStar_Reflection_V2_Data.Q_Explicit)
                                                                     ->
-                                                                    Obj.magic
-                                                                    (Obj.repr
+                                                                    Obj.repr
                                                                     (is_stateful_arrow
+                                                                    g
                                                                     (readback_comp_res_as_comp
                                                                     c1) args'
                                                                     ((arg,
                                                                     qual) ::
-                                                                    out)))
+                                                                    out))
                                                                     | 
                                                                     (FStar_Reflection_V2_Data.Q_Implicit,
                                                                     FStar_Reflection_V2_Data.Q_Explicit)
                                                                     ->
-                                                                    Obj.magic
-                                                                    (Obj.repr
+                                                                    Obj.repr
                                                                     (is_stateful_arrow
+                                                                    g
                                                                     (readback_comp_res_as_comp
                                                                     c1) args
-                                                                    out))
+                                                                    out)
                                                                     | 
                                                                     uu___2 ->
-                                                                    Obj.magic
-                                                                    (Obj.repr
+                                                                    Obj.repr
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
                                                                     uu___3 ->
+                                                                    FStar_Pervasives_Native.None)))))
+                                                         | uu___2 ->
+                                                             Obj.magic
+                                                               (Obj.repr
+                                                                  (FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___3 ->
                                                                     FStar_Pervasives_Native.None))))
-                                                                    uu___2)))
-                                                     | uu___2 ->
-                                                         Obj.magic
-                                                           (Obj.repr
-                                                              (FStar_Tactics_Effect.lift_div_tac
-                                                                 (fun uu___3
-                                                                    ->
-                                                                    FStar_Pervasives_Native.None))))
-                                                    uu___2))) uu___1)))))
-          uu___2 uu___1 uu___
+                                                        uu___2))) uu___1)))))
+            uu___3 uu___2 uu___1 uu___
 let (is_stateful_application :
   Pulse_Typing_Env.env ->
     Pulse_Syntax_Base.term ->
@@ -2923,13 +2907,13 @@ let (is_stateful_application :
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Checker.Base.fst"
-                                (Prims.of_int (585)) (Prims.of_int (23))
-                                (Prims.of_int (585)) (Prims.of_int (49)))))
+                                (Prims.of_int (594)) (Prims.of_int (23))
+                                (Prims.of_int (594)) (Prims.of_int (49)))))
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Checker.Base.fst"
-                                (Prims.of_int (584)) (Prims.of_int (28))
-                                (Prims.of_int (608)) (Prims.of_int (5)))))
+                                (Prims.of_int (593)) (Prims.of_int (28))
+                                (Prims.of_int (617)) (Prims.of_int (5)))))
                        (FStar_Tactics_Effect.lift_div_tac
                           (fun uu___ ->
                              FStar_Reflection_V2_Derived.collect_app_ln
@@ -2955,17 +2939,17 @@ let (is_stateful_application :
                                                  (Obj.magic
                                                     (FStar_Range.mk_range
                                                        "Pulse.Checker.Base.fst"
-                                                       (Prims.of_int (591))
+                                                       (Prims.of_int (600))
                                                        (Prims.of_int (21))
-                                                       (Prims.of_int (591))
+                                                       (Prims.of_int (600))
                                                        (Prims.of_int (53)))))
                                               (FStar_Sealed.seal
                                                  (Obj.magic
                                                     (FStar_Range.mk_range
                                                        "Pulse.Checker.Base.fst"
-                                                       (Prims.of_int (592))
+                                                       (Prims.of_int (601))
                                                        (Prims.of_int (8))
-                                                       (Prims.of_int (607))
+                                                       (Prims.of_int (616))
                                                        (Prims.of_int (21)))))
                                               (FStar_Tactics_Effect.lift_div_tac
                                                  (fun uu___1 ->
@@ -2981,20 +2965,21 @@ let (is_stateful_application :
                                                             (Obj.magic
                                                                (FStar_Range.mk_range
                                                                   "Pulse.Checker.Base.fst"
-                                                                  (Prims.of_int (592))
+                                                                  (Prims.of_int (601))
                                                                   (Prims.of_int (14))
-                                                                  (Prims.of_int (592))
-                                                                  (Prims.of_int (61)))))
+                                                                  (Prims.of_int (601))
+                                                                  (Prims.of_int (63)))))
                                                          (FStar_Sealed.seal
                                                             (Obj.magic
                                                                (FStar_Range.mk_range
                                                                   "Pulse.Checker.Base.fst"
-                                                                  (Prims.of_int (592))
+                                                                  (Prims.of_int (601))
                                                                   (Prims.of_int (8))
-                                                                  (Prims.of_int (607))
+                                                                  (Prims.of_int (616))
                                                                   (Prims.of_int (21)))))
                                                          (Obj.magic
                                                             (is_stateful_arrow
+                                                               g
                                                                (FStar_Pervasives_Native.Some
                                                                   (Pulse_Syntax_Base.C_Tot
                                                                     head_t))

--- a/src/ocaml/plugin/generated/Pulse_Checker_Base.ml
+++ b/src/ocaml/plugin/generated/Pulse_Checker_Base.ml
@@ -2634,3 +2634,421 @@ let (checker_result_for_st_typing :
                                                                     () ()))))))
                                                         uu___1))) uu___1)))
                                   uu___1))) uu___)
+let (readback_comp_res_as_comp :
+  FStar_Reflection_Types.comp ->
+    Pulse_Syntax_Base.comp FStar_Pervasives_Native.option)
+  =
+  fun c ->
+    match FStar_Reflection_V2_Builtins.inspect_comp c with
+    | FStar_Reflection_V2_Data.C_Total t ->
+        (match Pulse_Readback.readback_comp t with
+         | FStar_Pervasives_Native.None -> FStar_Pervasives_Native.None
+         | FStar_Pervasives_Native.Some c1 -> FStar_Pervasives_Native.Some c1)
+    | uu___ -> FStar_Pervasives_Native.None
+let rec (is_stateful_arrow :
+  Pulse_Syntax_Base.comp FStar_Pervasives_Native.option ->
+    FStar_Reflection_V2_Data.argv Prims.list ->
+      FStar_Reflection_V2_Data.argv Prims.list ->
+        ((FStar_Reflection_V2_Data.argv Prims.list *
+           FStar_Reflection_V2_Data.argv) FStar_Pervasives_Native.option,
+          unit) FStar_Tactics_Effect.tac_repr)
+  =
+  fun uu___2 ->
+    fun uu___1 ->
+      fun uu___ ->
+        (fun c ->
+           fun args ->
+             fun out ->
+               match c with
+               | FStar_Pervasives_Native.None ->
+                   Obj.magic
+                     (Obj.repr
+                        (FStar_Tactics_Effect.lift_div_tac
+                           (fun uu___ -> FStar_Pervasives_Native.None)))
+               | FStar_Pervasives_Native.Some (Pulse_Syntax_Base.C_ST uu___)
+                   ->
+                   Obj.magic
+                     (Obj.repr
+                        (FStar_Tactics_Effect.lift_div_tac
+                           (fun uu___1 ->
+                              match (args, out) with
+                              | ([], hd::tl) ->
+                                  FStar_Pervasives_Native.Some
+                                    ((FStar_List_Tot_Base.rev tl), hd)
+                              | uu___2 -> FStar_Pervasives_Native.None)))
+               | FStar_Pervasives_Native.Some (Pulse_Syntax_Base.C_STGhost
+                   (uu___, uu___1)) ->
+                   Obj.magic
+                     (Obj.repr
+                        (FStar_Tactics_Effect.lift_div_tac
+                           (fun uu___2 ->
+                              match (args, out) with
+                              | ([], hd::tl) ->
+                                  FStar_Pervasives_Native.Some
+                                    ((FStar_List_Tot_Base.rev tl), hd)
+                              | uu___3 -> FStar_Pervasives_Native.None)))
+               | FStar_Pervasives_Native.Some (Pulse_Syntax_Base.C_STAtomic
+                   (uu___, uu___1)) ->
+                   Obj.magic
+                     (Obj.repr
+                        (FStar_Tactics_Effect.lift_div_tac
+                           (fun uu___2 ->
+                              match (args, out) with
+                              | ([], hd::tl) ->
+                                  FStar_Pervasives_Native.Some
+                                    ((FStar_List_Tot_Base.rev tl), hd)
+                              | uu___3 -> FStar_Pervasives_Native.None)))
+               | FStar_Pervasives_Native.Some (Pulse_Syntax_Base.C_Tot c_res)
+                   ->
+                   Obj.magic
+                     (Obj.repr
+                        (if
+                           Prims.op_Negation
+                             (Pulse_Syntax_Base.uu___is_Tm_FStar
+                                c_res.Pulse_Syntax_Base.t)
+                         then
+                           Obj.repr
+                             (FStar_Tactics_Effect.lift_div_tac
+                                (fun uu___ -> FStar_Pervasives_Native.None))
+                         else
+                           Obj.repr
+                             (FStar_Tactics_Effect.tac_bind
+                                (FStar_Sealed.seal
+                                   (Obj.magic
+                                      (FStar_Range.mk_range
+                                         "Pulse.Checker.Base.fst"
+                                         (Prims.of_int (550))
+                                         (Prims.of_int (29))
+                                         (Prims.of_int (550))
+                                         (Prims.of_int (36)))))
+                                (FStar_Sealed.seal
+                                   (Obj.magic
+                                      (FStar_Range.mk_range
+                                         "Pulse.Checker.Base.fst"
+                                         (Prims.of_int (549))
+                                         (Prims.of_int (11))
+                                         (Prims.of_int (577))
+                                         (Prims.of_int (7)))))
+                                (FStar_Tactics_Effect.lift_div_tac
+                                   (fun uu___1 -> c_res.Pulse_Syntax_Base.t))
+                                (fun uu___1 ->
+                                   (fun uu___1 ->
+                                      match uu___1 with
+                                      | Pulse_Syntax_Base.Tm_FStar c_res1 ->
+                                          Obj.magic
+                                            (FStar_Tactics_Effect.tac_bind
+                                               (FStar_Sealed.seal
+                                                  (Obj.magic
+                                                     (FStar_Range.mk_range
+                                                        "Pulse.Checker.Base.fst"
+                                                        (Prims.of_int (551))
+                                                        (Prims.of_int (17))
+                                                        (Prims.of_int (551))
+                                                        (Prims.of_int (35)))))
+                                               (FStar_Sealed.seal
+                                                  (Obj.magic
+                                                     (FStar_Range.mk_range
+                                                        "Pulse.Checker.Base.fst"
+                                                        (Prims.of_int (552))
+                                                        (Prims.of_int (8))
+                                                        (Prims.of_int (576))
+                                                        (Prims.of_int (19)))))
+                                               (FStar_Tactics_Effect.lift_div_tac
+                                                  (fun uu___2 ->
+                                                     FStar_Reflection_V2_Builtins.inspect_ln
+                                                       c_res1))
+                                               (fun uu___2 ->
+                                                  (fun ht ->
+                                                     match ht with
+                                                     | FStar_Reflection_V2_Data.Tv_Arrow
+                                                         (b, c1) ->
+                                                         Obj.magic
+                                                           (Obj.repr
+                                                              (match args
+                                                               with
+                                                               | [] ->
+                                                                   FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Base.fst"
+                                                                    (Prims.of_int (556))
+                                                                    (Prims.of_int (24))
+                                                                    (Prims.of_int (556))
+                                                                    (Prims.of_int (49)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Base.fst"
+                                                                    (Prims.of_int (555))
+                                                                    (Prims.of_int (18))
+                                                                    (Prims.of_int (560))
+                                                                    (Prims.of_int (11)))))
+                                                                    (FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___2 ->
+                                                                    FStar_Reflection_V2_Derived.collect_arr_ln_bs
+                                                                    c_res1))
+                                                                    (fun
+                                                                    uu___2 ->
+                                                                    (fun
+                                                                    uu___2 ->
+                                                                    match uu___2
+                                                                    with
+                                                                    | 
+                                                                    (bs, c2)
+                                                                    ->
+                                                                    if
+                                                                    FStar_List_Tot_Base.for_all
+                                                                    (fun b1
+                                                                    ->
+                                                                    FStar_Reflection_V2_Data.uu___is_Q_Implicit
+                                                                    (FStar_Reflection_V2_Builtins.inspect_binder
+                                                                    b1).FStar_Reflection_V2_Data.qual)
+                                                                    bs
+                                                                    then
+                                                                    Obj.magic
+                                                                    (Obj.repr
+                                                                    (is_stateful_arrow
+                                                                    (readback_comp_res_as_comp
+                                                                    c2) []
+                                                                    out))
+                                                                    else
+                                                                    Obj.magic
+                                                                    (Obj.repr
+                                                                    (FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___4 ->
+                                                                    FStar_Pervasives_Native.None))))
+                                                                    uu___2)
+                                                               | (arg, qual)::args'
+                                                                   ->
+                                                                   FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Base.fst"
+                                                                    (Prims.of_int (563))
+                                                                    (Prims.of_int (20))
+                                                                    (Prims.of_int (563))
+                                                                    (Prims.of_int (38)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Base.fst"
+                                                                    (Prims.of_int (564))
+                                                                    (Prims.of_int (12))
+                                                                    (Prims.of_int (573))
+                                                                    (Prims.of_int (23)))))
+                                                                    (FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___2 ->
+                                                                    FStar_Reflection_V2_Builtins.inspect_binder
+                                                                    b))
+                                                                    (fun
+                                                                    uu___2 ->
+                                                                    (fun b1
+                                                                    ->
+                                                                    match 
+                                                                    ((b1.FStar_Reflection_V2_Data.qual),
+                                                                    qual)
+                                                                    with
+                                                                    | 
+                                                                    (FStar_Reflection_V2_Data.Q_Implicit,
+                                                                    FStar_Reflection_V2_Data.Q_Implicit)
+                                                                    ->
+                                                                    Obj.magic
+                                                                    (Obj.repr
+                                                                    (is_stateful_arrow
+                                                                    (readback_comp_res_as_comp
+                                                                    c1) args'
+                                                                    ((arg,
+                                                                    qual) ::
+                                                                    out)))
+                                                                    | 
+                                                                    (FStar_Reflection_V2_Data.Q_Explicit,
+                                                                    FStar_Reflection_V2_Data.Q_Explicit)
+                                                                    ->
+                                                                    Obj.magic
+                                                                    (Obj.repr
+                                                                    (is_stateful_arrow
+                                                                    (readback_comp_res_as_comp
+                                                                    c1) args'
+                                                                    ((arg,
+                                                                    qual) ::
+                                                                    out)))
+                                                                    | 
+                                                                    (FStar_Reflection_V2_Data.Q_Implicit,
+                                                                    FStar_Reflection_V2_Data.Q_Explicit)
+                                                                    ->
+                                                                    Obj.magic
+                                                                    (Obj.repr
+                                                                    (is_stateful_arrow
+                                                                    (readback_comp_res_as_comp
+                                                                    c1) args
+                                                                    out))
+                                                                    | 
+                                                                    uu___2 ->
+                                                                    Obj.magic
+                                                                    (Obj.repr
+                                                                    (FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___3 ->
+                                                                    FStar_Pervasives_Native.None))))
+                                                                    uu___2)))
+                                                     | uu___2 ->
+                                                         Obj.magic
+                                                           (Obj.repr
+                                                              (FStar_Tactics_Effect.lift_div_tac
+                                                                 (fun uu___3
+                                                                    ->
+                                                                    FStar_Pervasives_Native.None))))
+                                                    uu___2))) uu___1)))))
+          uu___2 uu___1 uu___
+let (is_stateful_application :
+  Pulse_Typing_Env.env ->
+    Pulse_Syntax_Base.term ->
+      (Pulse_Syntax_Base.st_term FStar_Pervasives_Native.option, unit)
+        FStar_Tactics_Effect.tac_repr)
+  =
+  fun uu___1 ->
+    fun uu___ ->
+      (fun g ->
+         fun e ->
+           match e.Pulse_Syntax_Base.t with
+           | Pulse_Syntax_Base.Tm_FStar host_term ->
+               Obj.magic
+                 (Obj.repr
+                    (FStar_Tactics_Effect.tac_bind
+                       (FStar_Sealed.seal
+                          (Obj.magic
+                             (FStar_Range.mk_range "Pulse.Checker.Base.fst"
+                                (Prims.of_int (584)) (Prims.of_int (23))
+                                (Prims.of_int (584)) (Prims.of_int (49)))))
+                       (FStar_Sealed.seal
+                          (Obj.magic
+                             (FStar_Range.mk_range "Pulse.Checker.Base.fst"
+                                (Prims.of_int (583)) (Prims.of_int (28))
+                                (Prims.of_int (603)) (Prims.of_int (5)))))
+                       (FStar_Tactics_Effect.lift_div_tac
+                          (fun uu___ ->
+                             FStar_Reflection_V2_Derived.collect_app_ln
+                               host_term))
+                       (fun uu___ ->
+                          (fun uu___ ->
+                             match uu___ with
+                             | (head, args) ->
+                                 Obj.magic
+                                   (FStar_Tactics_Effect.tac_bind
+                                      (FStar_Sealed.seal
+                                         (Obj.magic
+                                            (FStar_Range.mk_range
+                                               "Pulse.Checker.Base.fst"
+                                               (Prims.of_int (586))
+                                               (Prims.of_int (28))
+                                               (Prims.of_int (586))
+                                               (Prims.of_int (107)))))
+                                      (FStar_Sealed.seal
+                                         (Obj.magic
+                                            (FStar_Range.mk_range
+                                               "Pulse.Checker.Base.fst"
+                                               (Prims.of_int (585))
+                                               (Prims.of_int (35))
+                                               (Prims.of_int (602))
+                                               (Prims.of_int (19)))))
+                                      (Obj.magic
+                                         (Pulse_Checker_Pure.core_check_tot_term
+                                            g
+                                            (Pulse_Syntax_Base.tm_fstar head
+                                               (FStar_Reflection_V2_Builtins.range_of_term
+                                                  head))))
+                                      (fun uu___1 ->
+                                         (fun uu___1 ->
+                                            match uu___1 with
+                                            | Prims.Mkdtuple2
+                                                (head_t, uu___2) ->
+                                                Obj.magic
+                                                  (FStar_Tactics_Effect.tac_bind
+                                                     (FStar_Sealed.seal
+                                                        (Obj.magic
+                                                           (FStar_Range.mk_range
+                                                              "Pulse.Checker.Base.fst"
+                                                              (Prims.of_int (587))
+                                                              (Prims.of_int (12))
+                                                              (Prims.of_int (587))
+                                                              (Prims.of_int (59)))))
+                                                     (FStar_Sealed.seal
+                                                        (Obj.magic
+                                                           (FStar_Range.mk_range
+                                                              "Pulse.Checker.Base.fst"
+                                                              (Prims.of_int (587))
+                                                              (Prims.of_int (6))
+                                                              (Prims.of_int (602))
+                                                              (Prims.of_int (19)))))
+                                                     (Obj.magic
+                                                        (is_stateful_arrow
+                                                           (FStar_Pervasives_Native.Some
+                                                              (Pulse_Syntax_Base.C_Tot
+                                                                 head_t))
+                                                           args []))
+                                                     (fun uu___3 ->
+                                                        FStar_Tactics_Effect.lift_div_tac
+                                                          (fun uu___4 ->
+                                                             match uu___3
+                                                             with
+                                                             | FStar_Pervasives_Native.None
+                                                                 ->
+                                                                 FStar_Pervasives_Native.None
+                                                             | FStar_Pervasives_Native.Some
+                                                                 (applied_args,
+                                                                  (last_arg,
+                                                                   aqual))
+                                                                 ->
+                                                                 FStar_Pervasives_Native.Some
+                                                                   {
+                                                                    Pulse_Syntax_Base.term1
+                                                                    =
+                                                                    (Pulse_Syntax_Base.Tm_STApp
+                                                                    {
+                                                                    Pulse_Syntax_Base.head
+                                                                    =
+                                                                    (Pulse_Syntax_Base.tm_fstar
+                                                                    (FStar_Reflection_V2_Derived.mk_app
+                                                                    head
+                                                                    applied_args)
+                                                                    (FStar_Reflection_V2_Builtins.range_of_term
+                                                                    (FStar_Reflection_V2_Derived.mk_app
+                                                                    head
+                                                                    applied_args)));
+                                                                    Pulse_Syntax_Base.arg_qual
+                                                                    =
+                                                                    ((match aqual
+                                                                    with
+                                                                    | FStar_Reflection_V2_Data.Q_Implicit
+                                                                    ->
+                                                                    FStar_Pervasives_Native.Some
+                                                                    Pulse_Syntax_Base.Implicit
+                                                                    | uu___5
+                                                                    ->
+                                                                    FStar_Pervasives_Native.None));
+                                                                    Pulse_Syntax_Base.arg
+                                                                    =
+                                                                    (Pulse_Syntax_Base.tm_fstar
+                                                                    last_arg
+                                                                    (FStar_Reflection_V2_Builtins.range_of_term
+                                                                    last_arg))
+                                                                    });
+                                                                    Pulse_Syntax_Base.range2
+                                                                    =
+                                                                    (e.Pulse_Syntax_Base.range1);
+                                                                    Pulse_Syntax_Base.effect_tag
+                                                                    =
+                                                                    Pulse_Syntax_Base.default_effect_hint
+                                                                   }))))
+                                           uu___1))) uu___)))
+           | uu___ ->
+               Obj.magic
+                 (Obj.repr
+                    (FStar_Tactics_Effect.lift_div_tac
+                       (fun uu___1 -> FStar_Pervasives_Native.None)))) uu___1
+        uu___

--- a/src/ocaml/plugin/generated/Pulse_Checker_Base.ml
+++ b/src/ocaml/plugin/generated/Pulse_Checker_Base.ml
@@ -2923,13 +2923,13 @@ let (is_stateful_application :
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Checker.Base.fst"
-                                (Prims.of_int (584)) (Prims.of_int (23))
-                                (Prims.of_int (584)) (Prims.of_int (49)))))
+                                (Prims.of_int (585)) (Prims.of_int (23))
+                                (Prims.of_int (585)) (Prims.of_int (49)))))
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Checker.Base.fst"
-                                (Prims.of_int (583)) (Prims.of_int (28))
-                                (Prims.of_int (603)) (Prims.of_int (5)))))
+                                (Prims.of_int (584)) (Prims.of_int (28))
+                                (Prims.of_int (608)) (Prims.of_int (5)))))
                        (FStar_Tactics_Effect.lift_div_tac
                           (fun uu___ ->
                              FStar_Reflection_V2_Derived.collect_app_ln
@@ -2938,74 +2938,82 @@ let (is_stateful_application :
                           (fun uu___ ->
                              match uu___ with
                              | (head, args) ->
-                                 Obj.magic
-                                   (FStar_Tactics_Effect.tac_bind
-                                      (FStar_Sealed.seal
-                                         (Obj.magic
-                                            (FStar_Range.mk_range
-                                               "Pulse.Checker.Base.fst"
-                                               (Prims.of_int (586))
-                                               (Prims.of_int (28))
-                                               (Prims.of_int (586))
-                                               (Prims.of_int (107)))))
-                                      (FStar_Sealed.seal
-                                         (Obj.magic
-                                            (FStar_Range.mk_range
-                                               "Pulse.Checker.Base.fst"
-                                               (Prims.of_int (585))
-                                               (Prims.of_int (35))
-                                               (Prims.of_int (602))
-                                               (Prims.of_int (19)))))
-                                      (Obj.magic
-                                         (Pulse_Checker_Pure.core_check_tot_term
-                                            g
-                                            (Pulse_Syntax_Base.tm_fstar head
-                                               (FStar_Reflection_V2_Builtins.range_of_term
-                                                  head))))
-                                      (fun uu___1 ->
-                                         (fun uu___1 ->
-                                            match uu___1 with
-                                            | Prims.Mkdtuple2
-                                                (head_t, uu___2) ->
-                                                Obj.magic
-                                                  (FStar_Tactics_Effect.tac_bind
-                                                     (FStar_Sealed.seal
-                                                        (Obj.magic
-                                                           (FStar_Range.mk_range
-                                                              "Pulse.Checker.Base.fst"
-                                                              (Prims.of_int (587))
-                                                              (Prims.of_int (12))
-                                                              (Prims.of_int (587))
-                                                              (Prims.of_int (59)))))
-                                                     (FStar_Sealed.seal
-                                                        (Obj.magic
-                                                           (FStar_Range.mk_range
-                                                              "Pulse.Checker.Base.fst"
-                                                              (Prims.of_int (587))
-                                                              (Prims.of_int (6))
-                                                              (Prims.of_int (602))
-                                                              (Prims.of_int (19)))))
-                                                     (Obj.magic
-                                                        (is_stateful_arrow
-                                                           (FStar_Pervasives_Native.Some
-                                                              (Pulse_Syntax_Base.C_Tot
-                                                                 head_t))
-                                                           args []))
-                                                     (fun uu___3 ->
-                                                        FStar_Tactics_Effect.lift_div_tac
-                                                          (fun uu___4 ->
-                                                             match uu___3
-                                                             with
-                                                             | FStar_Pervasives_Native.None
-                                                                 ->
-                                                                 FStar_Pervasives_Native.None
-                                                             | FStar_Pervasives_Native.Some
-                                                                 (applied_args,
-                                                                  (last_arg,
-                                                                   aqual))
-                                                                 ->
-                                                                 FStar_Pervasives_Native.Some
-                                                                   {
+                                 (match Pulse_RuntimeUtils.lax_check_term_with_unknown_universes
+                                          (Pulse_Typing.elab_env g) head
+                                  with
+                                  | FStar_Pervasives_Native.None ->
+                                      Obj.magic
+                                        (Obj.repr
+                                           (FStar_Tactics_Effect.lift_div_tac
+                                              (fun uu___1 ->
+                                                 FStar_Pervasives_Native.None)))
+                                  | FStar_Pervasives_Native.Some ht ->
+                                      Obj.magic
+                                        (Obj.repr
+                                           (FStar_Tactics_Effect.tac_bind
+                                              (FStar_Sealed.seal
+                                                 (Obj.magic
+                                                    (FStar_Range.mk_range
+                                                       "Pulse.Checker.Base.fst"
+                                                       (Prims.of_int (591))
+                                                       (Prims.of_int (21))
+                                                       (Prims.of_int (591))
+                                                       (Prims.of_int (53)))))
+                                              (FStar_Sealed.seal
+                                                 (Obj.magic
+                                                    (FStar_Range.mk_range
+                                                       "Pulse.Checker.Base.fst"
+                                                       (Prims.of_int (592))
+                                                       (Prims.of_int (8))
+                                                       (Prims.of_int (607))
+                                                       (Prims.of_int (21)))))
+                                              (FStar_Tactics_Effect.lift_div_tac
+                                                 (fun uu___1 ->
+                                                    Pulse_Syntax_Base.tm_fstar
+                                                      ht
+                                                      (FStar_Reflection_V2_Builtins.range_of_term
+                                                         ht)))
+                                              (fun uu___1 ->
+                                                 (fun head_t ->
+                                                    Obj.magic
+                                                      (FStar_Tactics_Effect.tac_bind
+                                                         (FStar_Sealed.seal
+                                                            (Obj.magic
+                                                               (FStar_Range.mk_range
+                                                                  "Pulse.Checker.Base.fst"
+                                                                  (Prims.of_int (592))
+                                                                  (Prims.of_int (14))
+                                                                  (Prims.of_int (592))
+                                                                  (Prims.of_int (61)))))
+                                                         (FStar_Sealed.seal
+                                                            (Obj.magic
+                                                               (FStar_Range.mk_range
+                                                                  "Pulse.Checker.Base.fst"
+                                                                  (Prims.of_int (592))
+                                                                  (Prims.of_int (8))
+                                                                  (Prims.of_int (607))
+                                                                  (Prims.of_int (21)))))
+                                                         (Obj.magic
+                                                            (is_stateful_arrow
+                                                               (FStar_Pervasives_Native.Some
+                                                                  (Pulse_Syntax_Base.C_Tot
+                                                                    head_t))
+                                                               args []))
+                                                         (fun uu___1 ->
+                                                            FStar_Tactics_Effect.lift_div_tac
+                                                              (fun uu___2 ->
+                                                                 match uu___1
+                                                                 with
+                                                                 | FStar_Pervasives_Native.None
+                                                                    ->
+                                                                    FStar_Pervasives_Native.None
+                                                                 | FStar_Pervasives_Native.Some
+                                                                    (applied_args,
+                                                                    (last_arg,
+                                                                    aqual))
+                                                                    ->
+                                                                    FStar_Pervasives_Native.Some
+                                                                    {
                                                                     Pulse_Syntax_Base.term1
                                                                     =
                                                                     (Pulse_Syntax_Base.Tm_STApp
@@ -3028,7 +3036,7 @@ let (is_stateful_application :
                                                                     ->
                                                                     FStar_Pervasives_Native.Some
                                                                     Pulse_Syntax_Base.Implicit
-                                                                    | uu___5
+                                                                    | uu___3
                                                                     ->
                                                                     FStar_Pervasives_Native.None));
                                                                     Pulse_Syntax_Base.arg
@@ -3044,8 +3052,8 @@ let (is_stateful_application :
                                                                     Pulse_Syntax_Base.effect_tag
                                                                     =
                                                                     Pulse_Syntax_Base.default_effect_hint
-                                                                   }))))
-                                           uu___1))) uu___)))
+                                                                    }))))
+                                                   uu___1))))) uu___)))
            | uu___ ->
                Obj.magic
                  (Obj.repr

--- a/src/ocaml/plugin/generated/Pulse_Checker_Base.ml
+++ b/src/ocaml/plugin/generated/Pulse_Checker_Base.ml
@@ -2731,7 +2731,7 @@ let rec (is_stateful_arrow :
                                              "Pulse.Checker.Base.fst"
                                              (Prims.of_int (549))
                                              (Prims.of_int (11))
-                                             (Prims.of_int (586))
+                                             (Prims.of_int (588))
                                              (Prims.of_int (7)))))
                                     (FStar_Tactics_Effect.lift_div_tac
                                        (fun uu___1 ->
@@ -2757,7 +2757,7 @@ let rec (is_stateful_arrow :
                                                             "Pulse.Checker.Base.fst"
                                                             (Prims.of_int (552))
                                                             (Prims.of_int (8))
-                                                            (Prims.of_int (576))
+                                                            (Prims.of_int (578))
                                                             (Prims.of_int (14)))))
                                                    (Obj.magic
                                                       (FStar_Tactics_NamedView.inspect
@@ -2840,6 +2840,19 @@ let rec (is_stateful_arrow :
                                                                     qual)
                                                                     with
                                                                     | 
+                                                                    (FStar_Reflection_V2_Data.Q_Meta
+                                                                    uu___2,
+                                                                    FStar_Reflection_V2_Data.Q_Implicit)
+                                                                    ->
+                                                                    Obj.repr
+                                                                    (is_stateful_arrow
+                                                                    g
+                                                                    (readback_comp_res_as_comp
+                                                                    c1) args'
+                                                                    ((arg,
+                                                                    qual) ::
+                                                                    out))
+                                                                    | 
                                                                     (FStar_Reflection_V2_Data.Q_Implicit,
                                                                     FStar_Reflection_V2_Data.Q_Implicit)
                                                                     ->
@@ -2863,6 +2876,17 @@ let rec (is_stateful_arrow :
                                                                     ((arg,
                                                                     qual) ::
                                                                     out))
+                                                                    | 
+                                                                    (FStar_Reflection_V2_Data.Q_Meta
+                                                                    uu___2,
+                                                                    FStar_Reflection_V2_Data.Q_Explicit)
+                                                                    ->
+                                                                    Obj.repr
+                                                                    (is_stateful_arrow
+                                                                    g
+                                                                    (readback_comp_res_as_comp
+                                                                    c1) args
+                                                                    out)
                                                                     | 
                                                                     (FStar_Reflection_V2_Data.Q_Implicit,
                                                                     FStar_Reflection_V2_Data.Q_Explicit)
@@ -2907,13 +2931,13 @@ let (is_stateful_application :
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Checker.Base.fst"
-                                (Prims.of_int (594)) (Prims.of_int (23))
-                                (Prims.of_int (594)) (Prims.of_int (49)))))
+                                (Prims.of_int (596)) (Prims.of_int (23))
+                                (Prims.of_int (596)) (Prims.of_int (49)))))
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Checker.Base.fst"
-                                (Prims.of_int (593)) (Prims.of_int (28))
-                                (Prims.of_int (617)) (Prims.of_int (5)))))
+                                (Prims.of_int (595)) (Prims.of_int (28))
+                                (Prims.of_int (619)) (Prims.of_int (5)))))
                        (FStar_Tactics_Effect.lift_div_tac
                           (fun uu___ ->
                              FStar_Reflection_V2_Derived.collect_app_ln
@@ -2939,17 +2963,17 @@ let (is_stateful_application :
                                                  (Obj.magic
                                                     (FStar_Range.mk_range
                                                        "Pulse.Checker.Base.fst"
-                                                       (Prims.of_int (600))
+                                                       (Prims.of_int (602))
                                                        (Prims.of_int (21))
-                                                       (Prims.of_int (600))
+                                                       (Prims.of_int (602))
                                                        (Prims.of_int (53)))))
                                               (FStar_Sealed.seal
                                                  (Obj.magic
                                                     (FStar_Range.mk_range
                                                        "Pulse.Checker.Base.fst"
-                                                       (Prims.of_int (601))
+                                                       (Prims.of_int (603))
                                                        (Prims.of_int (8))
-                                                       (Prims.of_int (616))
+                                                       (Prims.of_int (618))
                                                        (Prims.of_int (21)))))
                                               (FStar_Tactics_Effect.lift_div_tac
                                                  (fun uu___1 ->
@@ -2965,17 +2989,17 @@ let (is_stateful_application :
                                                             (Obj.magic
                                                                (FStar_Range.mk_range
                                                                   "Pulse.Checker.Base.fst"
-                                                                  (Prims.of_int (601))
+                                                                  (Prims.of_int (603))
                                                                   (Prims.of_int (14))
-                                                                  (Prims.of_int (601))
+                                                                  (Prims.of_int (603))
                                                                   (Prims.of_int (63)))))
                                                          (FStar_Sealed.seal
                                                             (Obj.magic
                                                                (FStar_Range.mk_range
                                                                   "Pulse.Checker.Base.fst"
-                                                                  (Prims.of_int (601))
+                                                                  (Prims.of_int (603))
                                                                   (Prims.of_int (8))
-                                                                  (Prims.of_int (616))
+                                                                  (Prims.of_int (618))
                                                                   (Prims.of_int (21)))))
                                                          (Obj.magic
                                                             (is_stateful_arrow

--- a/src/ocaml/plugin/generated/Pulse_Checker_Bind.ml
+++ b/src/ocaml/plugin/generated/Pulse_Checker_Bind.ml
@@ -644,13 +644,13 @@ let (check_tot_bind :
                   (FStar_Sealed.seal
                      (Obj.magic
                         (FStar_Range.mk_range "Pulse.Checker.Bind.fst"
-                           (Prims.of_int (82)) (Prims.of_int (10))
-                           (Prims.of_int (82)) (Prims.of_int (66)))))
+                           (Prims.of_int (84)) (Prims.of_int (10))
+                           (Prims.of_int (84)) (Prims.of_int (66)))))
                   (FStar_Sealed.seal
                      (Obj.magic
                         (FStar_Range.mk_range "Pulse.Checker.Bind.fst"
-                           (Prims.of_int (84)) (Prims.of_int (2))
-                           (Prims.of_int (131)) (Prims.of_int (43)))))
+                           (Prims.of_int (86)) (Prims.of_int (2))
+                           (Prims.of_int (139)) (Prims.of_int (3)))))
                   (FStar_Tactics_Effect.lift_div_tac
                      (fun uu___ ->
                         Pulse_Typing_Env.push_context g "check_tot_bind"
@@ -663,15 +663,14 @@ let (check_tot_bind :
                                 (Obj.magic
                                    (FStar_Range.mk_range
                                       "Pulse.Checker.Bind.fst"
-                                      (Prims.of_int (84)) (Prims.of_int (2))
-                                      (Prims.of_int (85)) (Prims.of_int (93)))))
+                                      (Prims.of_int (86)) (Prims.of_int (2))
+                                      (Prims.of_int (87)) (Prims.of_int (93)))))
                              (FStar_Sealed.seal
                                 (Obj.magic
                                    (FStar_Range.mk_range
                                       "Pulse.Checker.Bind.fst"
-                                      (Prims.of_int (85)) (Prims.of_int (94))
-                                      (Prims.of_int (131))
-                                      (Prims.of_int (43)))))
+                                      (Prims.of_int (87)) (Prims.of_int (94))
+                                      (Prims.of_int (139)) (Prims.of_int (3)))))
                              (if
                                 FStar_Pervasives_Native.uu___is_None
                                   post_hint
@@ -703,10 +702,10 @@ let (check_tot_bind :
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.Checker.Bind.fst"
-                                                 (Prims.of_int (85))
+                                                 (Prims.of_int (87))
                                                  (Prims.of_int (94))
-                                                 (Prims.of_int (131))
-                                                 (Prims.of_int (43)))))
+                                                 (Prims.of_int (139))
+                                                 (Prims.of_int (3)))))
                                         (FStar_Tactics_Effect.lift_div_tac
                                            (fun uu___1 ->
                                               t.Pulse_Syntax_Base.term1))
@@ -729,84 +728,166 @@ let (check_tot_bind :
                                                              (FStar_Range.mk_range
                                                                 "Pulse.Checker.Bind.fst"
                                                                 (Prims.of_int (91))
-                                                                (Prims.of_int (60))
-                                                                (Prims.of_int (105))
-                                                                (Prims.of_int (106)))))
+                                                                (Prims.of_int (8))
+                                                                (Prims.of_int (91))
+                                                                (Prims.of_int (55)))))
                                                        (FStar_Sealed.seal
                                                           (Obj.magic
                                                              (FStar_Range.mk_range
                                                                 "Pulse.Checker.Bind.fst"
-                                                                (Prims.of_int (90))
-                                                                (Prims.of_int (59))
-                                                                (Prims.of_int (131))
-                                                                (Prims.of_int (43)))))
+                                                                (Prims.of_int (91))
+                                                                (Prims.of_int (2))
+                                                                (Prims.of_int (139))
+                                                                (Prims.of_int (3)))))
                                                        (Obj.magic
-                                                          (FStar_Tactics_Effect.tac_bind
-                                                             (FStar_Sealed.seal
-                                                                (Obj.magic
-                                                                   (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (94))
-                                                                    (Prims.of_int (13))
-                                                                    (Prims.of_int (94))
-                                                                    (Prims.of_int (24)))))
-                                                             (FStar_Sealed.seal
-                                                                (Obj.magic
-                                                                   (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (95))
-                                                                    (Prims.of_int (4))
-                                                                    (Prims.of_int (105))
-                                                                    (Prims.of_int (106)))))
-                                                             (FStar_Tactics_Effect.lift_div_tac
-                                                                (fun uu___2
-                                                                   ->
-                                                                   b.Pulse_Syntax_Base.binder_ty))
-                                                             (fun uu___2 ->
-                                                                (fun ty ->
-                                                                   match 
-                                                                    ty.Pulse_Syntax_Base.t
-                                                                   with
-                                                                   | 
-                                                                   Pulse_Syntax_Base.Tm_Unknown
-                                                                    ->
-                                                                    Obj.magic
-                                                                    (Pulse_Checker_Pure.check_term_and_type
-                                                                    g1 e1)
-                                                                   | 
-                                                                   uu___2 ->
-                                                                    Obj.magic
-                                                                    (FStar_Tactics_Effect.tac_bind
+                                                          (Pulse_Checker_Base.is_stateful_application
+                                                             g1 e1))
+                                                       (fun uu___2 ->
+                                                          (fun uu___2 ->
+                                                             match uu___2
+                                                             with
+                                                             | FStar_Pervasives_Native.Some
+                                                                 st_app ->
+                                                                 Obj.magic
+                                                                   (FStar_Tactics_Effect.tac_bind
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (99))
-                                                                    (Prims.of_int (27))
-                                                                    (Prims.of_int (99))
-                                                                    (Prims.of_int (46)))))
+                                                                    (Prims.of_int (93))
+                                                                    (Prims.of_int (14))
+                                                                    (Prims.of_int (93))
+                                                                    (Prims.of_int (70)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Bind.fst"
+                                                                    (Prims.of_int (94))
+                                                                    (Prims.of_int (4))
+                                                                    (Prims.of_int (94))
+                                                                    (Prims.of_int (60)))))
+                                                                    (FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___3 ->
+                                                                    {
+                                                                    Pulse_Syntax_Base.term1
+                                                                    =
+                                                                    (Pulse_Syntax_Base.Tm_Bind
+                                                                    {
+                                                                    Pulse_Syntax_Base.binder
+                                                                    = b;
+                                                                    Pulse_Syntax_Base.head1
+                                                                    = st_app;
+                                                                    Pulse_Syntax_Base.body1
+                                                                    = e2
+                                                                    });
+                                                                    Pulse_Syntax_Base.range2
+                                                                    =
+                                                                    (t.Pulse_Syntax_Base.range2);
+                                                                    Pulse_Syntax_Base.effect_tag
+                                                                    =
+                                                                    (t.Pulse_Syntax_Base.effect_tag)
+                                                                    }))
+                                                                    (fun
+                                                                    uu___3 ->
+                                                                    (fun t1
+                                                                    ->
+                                                                    Obj.magic
+                                                                    (check_bind
+                                                                    g1 pre ()
+                                                                    post_hint
+                                                                    res_ppname
+                                                                    t1 check))
+                                                                    uu___3))
+                                                             | FStar_Pervasives_Native.None
+                                                                 ->
+                                                                 Obj.magic
+                                                                   (FStar_Tactics_Effect.tac_bind
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
                                                                     (Prims.of_int (98))
-                                                                    (Prims.of_int (10))
+                                                                    (Prims.of_int (62))
+                                                                    (Prims.of_int (112))
+                                                                    (Prims.of_int (108)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Bind.fst"
+                                                                    (Prims.of_int (97))
+                                                                    (Prims.of_int (12))
+                                                                    (Prims.of_int (139))
+                                                                    (Prims.of_int (3)))))
+                                                                    (Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Bind.fst"
+                                                                    (Prims.of_int (101))
+                                                                    (Prims.of_int (15))
+                                                                    (Prims.of_int (101))
+                                                                    (Prims.of_int (26)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Bind.fst"
+                                                                    (Prims.of_int (102))
+                                                                    (Prims.of_int (6))
+                                                                    (Prims.of_int (112))
+                                                                    (Prims.of_int (108)))))
+                                                                    (FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___3 ->
+                                                                    b.Pulse_Syntax_Base.binder_ty))
+                                                                    (fun
+                                                                    uu___3 ->
+                                                                    (fun ty
+                                                                    ->
+                                                                    match 
+                                                                    ty.Pulse_Syntax_Base.t
+                                                                    with
+                                                                    | 
+                                                                    Pulse_Syntax_Base.Tm_Unknown
+                                                                    ->
+                                                                    Obj.magic
+                                                                    (Pulse_Checker_Pure.check_term_and_type
+                                                                    g1 e1)
+                                                                    | 
+                                                                    uu___3 ->
+                                                                    Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Bind.fst"
+                                                                    (Prims.of_int (106))
+                                                                    (Prims.of_int (29))
+                                                                    (Prims.of_int (106))
+                                                                    (Prims.of_int (48)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Bind.fst"
                                                                     (Prims.of_int (105))
-                                                                    (Prims.of_int (106)))))
+                                                                    (Prims.of_int (12))
+                                                                    (Prims.of_int (112))
+                                                                    (Prims.of_int (108)))))
                                                                     (Obj.magic
                                                                     (Pulse_Checker_Pure.check_tot_term
                                                                     g1 ty))
                                                                     (fun
-                                                                    uu___3 ->
+                                                                    uu___4 ->
                                                                     (fun
-                                                                    uu___3 ->
-                                                                    match uu___3
+                                                                    uu___4 ->
+                                                                    match uu___4
                                                                     with
                                                                     | 
                                                                     FStar_Pervasives.Mkdtuple3
                                                                     (ty1,
-                                                                    uu___4,
-                                                                    uu___5)
+                                                                    uu___5,
+                                                                    uu___6)
                                                                     ->
                                                                     Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -814,26 +895,26 @@ let (check_tot_bind :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (100))
-                                                                    (Prims.of_int (32))
-                                                                    (Prims.of_int (100))
-                                                                    (Prims.of_int (51)))))
+                                                                    (Prims.of_int (107))
+                                                                    (Prims.of_int (34))
+                                                                    (Prims.of_int (107))
+                                                                    (Prims.of_int (53)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (99))
-                                                                    (Prims.of_int (49))
-                                                                    (Prims.of_int (105))
-                                                                    (Prims.of_int (106)))))
+                                                                    (Prims.of_int (106))
+                                                                    (Prims.of_int (51))
+                                                                    (Prims.of_int (112))
+                                                                    (Prims.of_int (108)))))
                                                                     (Obj.magic
                                                                     (Pulse_Checker_Pure.check_universe
                                                                     g1 ty1))
                                                                     (fun
-                                                                    uu___6 ->
+                                                                    uu___7 ->
                                                                     (fun
-                                                                    uu___6 ->
-                                                                    match uu___6
+                                                                    uu___7 ->
+                                                                    match uu___7
                                                                     with
                                                                     | 
                                                                     Prims.Mkdtuple2
@@ -846,27 +927,27 @@ let (check_tot_bind :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (101))
-                                                                    (Prims.of_int (38))
-                                                                    (Prims.of_int (101))
-                                                                    (Prims.of_int (75)))))
+                                                                    (Prims.of_int (108))
+                                                                    (Prims.of_int (40))
+                                                                    (Prims.of_int (108))
+                                                                    (Prims.of_int (77)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (100))
-                                                                    (Prims.of_int (54))
-                                                                    (Prims.of_int (105))
-                                                                    (Prims.of_int (106)))))
+                                                                    (Prims.of_int (107))
+                                                                    (Prims.of_int (56))
+                                                                    (Prims.of_int (112))
+                                                                    (Prims.of_int (108)))))
                                                                     (Obj.magic
                                                                     (Pulse_Checker_Pure.check_term_with_expected_type
                                                                     g1 e1 ty1))
                                                                     (fun
-                                                                    uu___7 ->
+                                                                    uu___8 ->
                                                                     FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
-                                                                    uu___8 ->
-                                                                    match uu___7
+                                                                    uu___9 ->
+                                                                    match uu___8
                                                                     with
                                                                     | 
                                                                     FStar_Pervasives.Mkdtuple3
@@ -881,42 +962,45 @@ let (check_tot_bind :
                                                                     (Prims.Mkdtuple2
                                                                     (u1, ())),
                                                                     ())))))
-                                                                    uu___6)))
+                                                                    uu___7)))
+                                                                    uu___4)))
                                                                     uu___3)))
-                                                                  uu___2)))
-                                                       (fun uu___2 ->
-                                                          (fun uu___2 ->
-                                                             match uu___2
-                                                             with
-                                                             | FStar_Pervasives.Mkdtuple5
-                                                                 (e11, eff1,
-                                                                  t1,
-                                                                  Prims.Mkdtuple2
-                                                                  (u1,
-                                                                   _t1_typing),
-                                                                  e1_typing)
-                                                                 ->
-                                                                 Obj.magic
-                                                                   (FStar_Tactics_Effect.tac_bind
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (108))
-                                                                    (Prims.of_int (10))
-                                                                    (Prims.of_int (111))
-                                                                    (Prims.of_int (21)))))
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (111))
-                                                                    (Prims.of_int (24))
-                                                                    (Prims.of_int (131))
-                                                                    (Prims.of_int (43)))))
-                                                                    (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
                                                                     uu___3 ->
+                                                                    (fun
+                                                                    uu___3 ->
+                                                                    match uu___3
+                                                                    with
+                                                                    | 
+                                                                    FStar_Pervasives.Mkdtuple5
+                                                                    (e11,
+                                                                    eff1, t1,
+                                                                    Prims.Mkdtuple2
+                                                                    (u1,
+                                                                    _t1_typing),
+                                                                    e1_typing)
+                                                                    ->
+                                                                    Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Bind.fst"
+                                                                    (Prims.of_int (115))
+                                                                    (Prims.of_int (12))
+                                                                    (Prims.of_int (118))
+                                                                    (Prims.of_int (23)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Bind.fst"
+                                                                    (Prims.of_int (118))
+                                                                    (Prims.of_int (26))
+                                                                    (Prims.of_int (138))
+                                                                    (Prims.of_int (45)))))
+                                                                    (FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___4 ->
                                                                     Pulse_Syntax_Pure.tm_refine
                                                                     {
                                                                     Pulse_Syntax_Base.binder_ty
@@ -931,7 +1015,7 @@ let (check_tot_bind :
                                                                     Prims.int_zero)
                                                                     e11)))
                                                                     (fun
-                                                                    uu___3 ->
+                                                                    uu___4 ->
                                                                     (fun t11
                                                                     ->
                                                                     Obj.magic
@@ -940,27 +1024,27 @@ let (check_tot_bind :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (115))
-                                                                    (Prims.of_int (4))
-                                                                    (Prims.of_int (115))
-                                                                    (Prims.of_int (57)))))
+                                                                    (Prims.of_int (122))
+                                                                    (Prims.of_int (6))
+                                                                    (Prims.of_int (122))
+                                                                    (Prims.of_int (59)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (111))
-                                                                    (Prims.of_int (24))
-                                                                    (Prims.of_int (131))
-                                                                    (Prims.of_int (43)))))
+                                                                    (Prims.of_int (118))
+                                                                    (Prims.of_int (26))
+                                                                    (Prims.of_int (138))
+                                                                    (Prims.of_int (45)))))
                                                                     (Obj.magic
                                                                     (Pulse_Checker_Pure.check_term_with_expected_type_and_effect
                                                                     g1 e11
                                                                     eff1 t11))
                                                                     (fun
-                                                                    uu___3 ->
+                                                                    uu___4 ->
                                                                     (fun
-                                                                    uu___3 ->
-                                                                    match uu___3
+                                                                    uu___4 ->
+                                                                    match uu___4
                                                                     with
                                                                     | 
                                                                     Prims.Mkdtuple2
@@ -973,25 +1057,25 @@ let (check_tot_bind :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (117))
-                                                                    (Prims.of_int (10))
-                                                                    (Prims.of_int (117))
-                                                                    (Prims.of_int (17)))))
+                                                                    (Prims.of_int (124))
+                                                                    (Prims.of_int (12))
+                                                                    (Prims.of_int (124))
+                                                                    (Prims.of_int (19)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (117))
-                                                                    (Prims.of_int (20))
-                                                                    (Prims.of_int (131))
-                                                                    (Prims.of_int (43)))))
+                                                                    (Prims.of_int (124))
+                                                                    (Prims.of_int (22))
+                                                                    (Prims.of_int (138))
+                                                                    (Prims.of_int (45)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
-                                                                    uu___4 ->
+                                                                    uu___5 ->
                                                                     Pulse_Typing_Env.fresh
                                                                     g1))
                                                                     (fun
-                                                                    uu___4 ->
+                                                                    uu___5 ->
                                                                     (fun x ->
                                                                     Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -999,21 +1083,21 @@ let (check_tot_bind :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (119))
-                                                                    (Prims.of_int (12))
-                                                                    (Prims.of_int (119))
-                                                                    (Prims.of_int (33)))))
+                                                                    (Prims.of_int (126))
+                                                                    (Prims.of_int (14))
+                                                                    (Prims.of_int (126))
+                                                                    (Prims.of_int (35)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (119))
-                                                                    (Prims.of_int (38))
-                                                                    (Prims.of_int (131))
-                                                                    (Prims.of_int (43)))))
+                                                                    (Prims.of_int (126))
+                                                                    (Prims.of_int (40))
+                                                                    (Prims.of_int (138))
+                                                                    (Prims.of_int (45)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
-                                                                    uu___4 ->
+                                                                    uu___5 ->
                                                                     {
                                                                     Pulse_Syntax_Base.binder_ty
                                                                     = t11;
@@ -1022,7 +1106,7 @@ let (check_tot_bind :
                                                                     (b.Pulse_Syntax_Base.binder_ppname)
                                                                     }))
                                                                     (fun
-                                                                    uu___4 ->
+                                                                    uu___5 ->
                                                                     (fun b1
                                                                     ->
                                                                     Obj.magic
@@ -1031,18 +1115,18 @@ let (check_tot_bind :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (120))
-                                                                    (Prims.of_int (10))
-                                                                    (Prims.of_int (120))
-                                                                    (Prims.of_int (85)))))
+                                                                    (Prims.of_int (127))
+                                                                    (Prims.of_int (12))
+                                                                    (Prims.of_int (127))
+                                                                    (Prims.of_int (87)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (120))
-                                                                    (Prims.of_int (88))
-                                                                    (Prims.of_int (131))
-                                                                    (Prims.of_int (43)))))
+                                                                    (Prims.of_int (127))
+                                                                    (Prims.of_int (90))
+                                                                    (Prims.of_int (138))
+                                                                    (Prims.of_int (45)))))
                                                                     (Obj.magic
                                                                     (Pulse_Checker_Base.continuation_elaborator_with_let
                                                                     g pre ()
@@ -1051,7 +1135,7 @@ let (check_tot_bind :
                                                                     (Pulse_Syntax_Base.ppname_default,
                                                                     x)))
                                                                     (fun
-                                                                    uu___4 ->
+                                                                    uu___5 ->
                                                                     (fun k ->
                                                                     Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1059,25 +1143,25 @@ let (check_tot_bind :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (122))
-                                                                    (Prims.of_int (11))
-                                                                    (Prims.of_int (122))
-                                                                    (Prims.of_int (29)))))
+                                                                    (Prims.of_int (129))
+                                                                    (Prims.of_int (13))
+                                                                    (Prims.of_int (129))
+                                                                    (Prims.of_int (31)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (122))
-                                                                    (Prims.of_int (32))
-                                                                    (Prims.of_int (131))
-                                                                    (Prims.of_int (43)))))
+                                                                    (Prims.of_int (129))
+                                                                    (Prims.of_int (34))
+                                                                    (Prims.of_int (138))
+                                                                    (Prims.of_int (45)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
-                                                                    uu___4 ->
+                                                                    uu___5 ->
                                                                     ((b1.Pulse_Syntax_Base.binder_ppname),
                                                                     x)))
                                                                     (fun
-                                                                    uu___4 ->
+                                                                    uu___5 ->
                                                                     (fun px
                                                                     ->
                                                                     Obj.magic
@@ -1086,27 +1170,27 @@ let (check_tot_bind :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (123))
-                                                                    (Prims.of_int (11))
-                                                                    (Prims.of_int (123))
-                                                                    (Prims.of_int (39)))))
+                                                                    (Prims.of_int (130))
+                                                                    (Prims.of_int (13))
+                                                                    (Prims.of_int (130))
+                                                                    (Prims.of_int (41)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (123))
-                                                                    (Prims.of_int (42))
-                                                                    (Prims.of_int (131))
-                                                                    (Prims.of_int (43)))))
+                                                                    (Prims.of_int (130))
+                                                                    (Prims.of_int (44))
+                                                                    (Prims.of_int (138))
+                                                                    (Prims.of_int (45)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
-                                                                    uu___4 ->
+                                                                    uu___5 ->
                                                                     Pulse_Typing_Env.push_binding
                                                                     g1 x
                                                                     (FStar_Pervasives_Native.fst
                                                                     px) t11))
                                                                     (fun
-                                                                    uu___4 ->
+                                                                    uu___5 ->
                                                                     (fun g'
                                                                     ->
                                                                     Obj.magic
@@ -1115,24 +1199,24 @@ let (check_tot_bind :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (125))
-                                                                    (Prims.of_int (4))
-                                                                    (Prims.of_int (125))
-                                                                    (Prims.of_int (58)))))
+                                                                    (Prims.of_int (132))
+                                                                    (Prims.of_int (6))
+                                                                    (Prims.of_int (132))
+                                                                    (Prims.of_int (60)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (125))
-                                                                    (Prims.of_int (61))
-                                                                    (Prims.of_int (131))
-                                                                    (Prims.of_int (43)))))
+                                                                    (Prims.of_int (132))
+                                                                    (Prims.of_int (63))
+                                                                    (Prims.of_int (138))
+                                                                    (Prims.of_int (45)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
-                                                                    uu___4 ->
+                                                                    uu___5 ->
                                                                     ()))
                                                                     (fun
-                                                                    uu___4 ->
+                                                                    uu___5 ->
                                                                     (fun
                                                                     pre_typing'
                                                                     ->
@@ -1142,43 +1226,43 @@ let (check_tot_bind :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (126))
-                                                                    (Prims.of_int (9))
-                                                                    (Prims.of_int (129))
-                                                                    (Prims.of_int (62)))))
+                                                                    (Prims.of_int (133))
+                                                                    (Prims.of_int (11))
+                                                                    (Prims.of_int (136))
+                                                                    (Prims.of_int (64)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (129))
-                                                                    (Prims.of_int (65))
-                                                                    (Prims.of_int (131))
-                                                                    (Prims.of_int (43)))))
+                                                                    (Prims.of_int (136))
+                                                                    (Prims.of_int (67))
+                                                                    (Prims.of_int (138))
+                                                                    (Prims.of_int (45)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (127))
-                                                                    (Prims.of_int (17))
-                                                                    (Prims.of_int (127))
-                                                                    (Prims.of_int (46)))))
+                                                                    (Prims.of_int (134))
+                                                                    (Prims.of_int (19))
+                                                                    (Prims.of_int (134))
+                                                                    (Prims.of_int (48)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (127))
-                                                                    (Prims.of_int (49))
-                                                                    (Prims.of_int (129))
-                                                                    (Prims.of_int (62)))))
+                                                                    (Prims.of_int (134))
+                                                                    (Prims.of_int (51))
+                                                                    (Prims.of_int (136))
+                                                                    (Prims.of_int (64)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
-                                                                    uu___4 ->
+                                                                    uu___5 ->
                                                                     Pulse_Syntax_Base.mk_ppname_no_range
                                                                     "_tbind_c"))
                                                                     (fun
-                                                                    uu___4 ->
+                                                                    uu___5 ->
                                                                     (fun
                                                                     ppname ->
                                                                     Obj.magic
@@ -1187,18 +1271,18 @@ let (check_tot_bind :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (128))
-                                                                    (Prims.of_int (12))
-                                                                    (Prims.of_int (128))
-                                                                    (Prims.of_int (77)))))
+                                                                    (Prims.of_int (135))
+                                                                    (Prims.of_int (14))
+                                                                    (Prims.of_int (135))
+                                                                    (Prims.of_int (79)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (129))
-                                                                    (Prims.of_int (4))
-                                                                    (Prims.of_int (129))
-                                                                    (Prims.of_int (62)))))
+                                                                    (Prims.of_int (136))
+                                                                    (Prims.of_int (6))
+                                                                    (Prims.of_int (136))
+                                                                    (Prims.of_int (64)))))
                                                                     (Obj.magic
                                                                     (check g'
                                                                     pre ()
@@ -1207,7 +1291,7 @@ let (check_tot_bind :
                                                                     (Pulse_Syntax_Naming.open_st_term_nv
                                                                     e2 px)))
                                                                     (fun
-                                                                    uu___4 ->
+                                                                    uu___5 ->
                                                                     (fun r ->
                                                                     Obj.magic
                                                                     (Pulse_Checker_Base.apply_checker_result_k
@@ -1215,10 +1299,10 @@ let (check_tot_bind :
                                                                     (FStar_Pervasives_Native.__proj__Some__item__v
                                                                     post_hint)
                                                                     r ppname))
-                                                                    uu___4)))
-                                                                    uu___4)))
+                                                                    uu___5)))
+                                                                    uu___5)))
                                                                     (fun
-                                                                    uu___4 ->
+                                                                    uu___5 ->
                                                                     (fun d ->
                                                                     Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1226,24 +1310,24 @@ let (check_tot_bind :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (130))
-                                                                    (Prims.of_int (10))
-                                                                    (Prims.of_int (130))
-                                                                    (Prims.of_int (23)))))
+                                                                    (Prims.of_int (137))
+                                                                    (Prims.of_int (12))
+                                                                    (Prims.of_int (137))
+                                                                    (Prims.of_int (25)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (131))
-                                                                    (Prims.of_int (2))
-                                                                    (Prims.of_int (131))
-                                                                    (Prims.of_int (43)))))
+                                                                    (Prims.of_int (138))
+                                                                    (Prims.of_int (4))
+                                                                    (Prims.of_int (138))
+                                                                    (Prims.of_int (45)))))
                                                                     (Obj.magic
                                                                     (k
                                                                     post_hint
                                                                     d))
                                                                     (fun
-                                                                    uu___4 ->
+                                                                    uu___5 ->
                                                                     (fun d1
                                                                     ->
                                                                     Obj.magic
@@ -1252,15 +1336,16 @@ let (check_tot_bind :
                                                                     post_hint
                                                                     d1
                                                                     res_ppname))
+                                                                    uu___5)))
+                                                                    uu___5)))
+                                                                    uu___5)))
+                                                                    uu___5)))
+                                                                    uu___5)))
+                                                                    uu___5)))
+                                                                    uu___5)))
+                                                                    uu___5)))
                                                                     uu___4)))
                                                                     uu___4)))
-                                                                    uu___4)))
-                                                                    uu___4)))
-                                                                    uu___4)))
-                                                                    uu___4)))
-                                                                    uu___4)))
-                                                                    uu___4)))
-                                                                    uu___3)))
                                                                     uu___3)))
                                                             uu___2))) uu___1)))
                                   uu___))) uu___)

--- a/src/ocaml/plugin/generated/Pulse_Checker_Return.ml
+++ b/src/ocaml/plugin/generated/Pulse_Checker_Return.ml
@@ -505,8 +505,9 @@ let (check :
         unit Pulse_Typing.post_hint_opt ->
           Pulse_Syntax_Base.ppname ->
             Pulse_Syntax_Base.st_term ->
-              ((unit, unit, unit) Pulse_Checker_Base.checker_result_t, 
-                unit) FStar_Tactics_Effect.tac_repr)
+              Pulse_Checker_Base.check_t ->
+                ((unit, unit, unit) Pulse_Checker_Base.checker_result_t,
+                  unit) FStar_Tactics_Effect.tac_repr)
   =
   fun g ->
     fun ctxt ->
@@ -514,49 +515,130 @@ let (check :
         fun post_hint ->
           fun res_ppname ->
             fun st ->
-              match (post_hint, (st.Pulse_Syntax_Base.term1)) with
-              | (FStar_Pervasives_Native.Some
-                 { Pulse_Typing.g = uu___;
-                   Pulse_Typing.ctag_hint = FStar_Pervasives_Native.Some ct;
-                   Pulse_Typing.ret_ty = uu___1; Pulse_Typing.u = uu___2;
-                   Pulse_Typing.ty_typing = uu___3;
-                   Pulse_Typing.post = uu___4;
-                   Pulse_Typing.post_typing = uu___5;_},
-                 Pulse_Syntax_Base.Tm_Return f) ->
-                  if ct = f.Pulse_Syntax_Base.ctag
-                  then check_core g ctxt () post_hint res_ppname st
-                  else
-                    FStar_Tactics_Effect.tac_bind
-                      (FStar_Sealed.seal
-                         (Obj.magic
-                            (FStar_Range.mk_range "Pulse.Checker.Return.fst"
-                               (Prims.of_int (78)) (Prims.of_int (22))
-                               (Prims.of_int (78)) (Prims.of_int (65)))))
-                      (FStar_Sealed.seal
-                         (Obj.magic
-                            (FStar_Range.mk_range "Pulse.Checker.Return.fst"
-                               (Prims.of_int (79)) (Prims.of_int (11))
-                               (Prims.of_int (79)) (Prims.of_int (64)))))
-                      (FStar_Tactics_Effect.lift_div_tac
-                         (fun uu___7 ->
-                            {
-                              Pulse_Syntax_Base.term1 =
-                                (Pulse_Syntax_Base.Tm_Return
-                                   {
-                                     Pulse_Syntax_Base.ctag = ct;
-                                     Pulse_Syntax_Base.insert_eq =
-                                       (f.Pulse_Syntax_Base.insert_eq);
-                                     Pulse_Syntax_Base.term =
-                                       (f.Pulse_Syntax_Base.term)
-                                   });
-                              Pulse_Syntax_Base.range2 =
-                                (st.Pulse_Syntax_Base.range2);
-                              Pulse_Syntax_Base.effect_tag =
-                                (st.Pulse_Syntax_Base.effect_tag)
-                            }))
-                      (fun uu___7 ->
-                         (fun st1 ->
+              fun check1 ->
+                FStar_Tactics_Effect.tac_bind
+                  (FStar_Sealed.seal
+                     (Obj.magic
+                        (FStar_Range.mk_range "Pulse.Checker.Return.fst"
+                           (Prims.of_int (75)) (Prims.of_int (22))
+                           (Prims.of_int (75)) (Prims.of_int (29)))))
+                  (FStar_Sealed.seal
+                     (Obj.magic
+                        (FStar_Range.mk_range "Pulse.Checker.Return.fst"
+                           (Prims.of_int (75)) (Prims.of_int (3))
+                           (Prims.of_int (89)) (Prims.of_int (5)))))
+                  (FStar_Tactics_Effect.lift_div_tac
+                     (fun uu___ -> st.Pulse_Syntax_Base.term1))
+                  (fun uu___ ->
+                     (fun uu___ ->
+                        match uu___ with
+                        | Pulse_Syntax_Base.Tm_Return f ->
                             Obj.magic
-                              (check_core g ctxt () post_hint res_ppname st1))
-                           uu___7)
-              | uu___ -> check_core g ctxt () post_hint res_ppname st
+                              (FStar_Tactics_Effect.tac_bind
+                                 (FStar_Sealed.seal
+                                    (Obj.magic
+                                       (FStar_Range.mk_range
+                                          "Pulse.Checker.Return.fst"
+                                          (Prims.of_int (76))
+                                          (Prims.of_int (10))
+                                          (Prims.of_int (76))
+                                          (Prims.of_int (61)))))
+                                 (FStar_Sealed.seal
+                                    (Obj.magic
+                                       (FStar_Range.mk_range
+                                          "Pulse.Checker.Return.fst"
+                                          (Prims.of_int (76))
+                                          (Prims.of_int (4))
+                                          (Prims.of_int (89))
+                                          (Prims.of_int (5)))))
+                                 (Obj.magic
+                                    (Pulse_Checker_Base.is_stateful_application
+                                       g f.Pulse_Syntax_Base.term))
+                                 (fun uu___1 ->
+                                    (fun uu___1 ->
+                                       match uu___1 with
+                                       | FStar_Pervasives_Native.Some st_app
+                                           ->
+                                           Obj.magic
+                                             (check1 g ctxt () post_hint
+                                                res_ppname st_app)
+                                       | FStar_Pervasives_Native.None ->
+                                           (match post_hint with
+                                            | FStar_Pervasives_Native.Some
+                                                { Pulse_Typing.g = uu___2;
+                                                  Pulse_Typing.ctag_hint =
+                                                    FStar_Pervasives_Native.Some
+                                                    ct;
+                                                  Pulse_Typing.ret_ty =
+                                                    uu___3;
+                                                  Pulse_Typing.u = uu___4;
+                                                  Pulse_Typing.ty_typing =
+                                                    uu___5;
+                                                  Pulse_Typing.post = uu___6;
+                                                  Pulse_Typing.post_typing =
+                                                    uu___7;_}
+                                                ->
+                                                if
+                                                  ct =
+                                                    f.Pulse_Syntax_Base.ctag
+                                                then
+                                                  Obj.magic
+                                                    (check_core g ctxt ()
+                                                       post_hint res_ppname
+                                                       st)
+                                                else
+                                                  Obj.magic
+                                                    (FStar_Tactics_Effect.tac_bind
+                                                       (FStar_Sealed.seal
+                                                          (Obj.magic
+                                                             (FStar_Range.mk_range
+                                                                "Pulse.Checker.Return.fst"
+                                                                (Prims.of_int (85))
+                                                                (Prims.of_int (24))
+                                                                (Prims.of_int (85))
+                                                                (Prims.of_int (67)))))
+                                                       (FStar_Sealed.seal
+                                                          (Obj.magic
+                                                             (FStar_Range.mk_range
+                                                                "Pulse.Checker.Return.fst"
+                                                                (Prims.of_int (86))
+                                                                (Prims.of_int (13))
+                                                                (Prims.of_int (86))
+                                                                (Prims.of_int (66)))))
+                                                       (FStar_Tactics_Effect.lift_div_tac
+                                                          (fun uu___9 ->
+                                                             {
+                                                               Pulse_Syntax_Base.term1
+                                                                 =
+                                                                 (Pulse_Syntax_Base.Tm_Return
+                                                                    {
+                                                                    Pulse_Syntax_Base.ctag
+                                                                    = ct;
+                                                                    Pulse_Syntax_Base.insert_eq
+                                                                    =
+                                                                    (f.Pulse_Syntax_Base.insert_eq);
+                                                                    Pulse_Syntax_Base.term
+                                                                    =
+                                                                    (f.Pulse_Syntax_Base.term)
+                                                                    });
+                                                               Pulse_Syntax_Base.range2
+                                                                 =
+                                                                 (st.Pulse_Syntax_Base.range2);
+                                                               Pulse_Syntax_Base.effect_tag
+                                                                 =
+                                                                 (st.Pulse_Syntax_Base.effect_tag)
+                                                             }))
+                                                       (fun uu___9 ->
+                                                          (fun st1 ->
+                                                             Obj.magic
+                                                               (check_core g
+                                                                  ctxt ()
+                                                                  post_hint
+                                                                  res_ppname
+                                                                  st1))
+                                                            uu___9))
+                                            | uu___2 ->
+                                                Obj.magic
+                                                  (check_core g ctxt ()
+                                                     post_hint res_ppname st)))
+                                      uu___1))) uu___)

--- a/src/syntax_extension/SyntaxExtension.fst.config.json
+++ b/src/syntax_extension/SyntaxExtension.fst.config.json
@@ -1,0 +1,24 @@
+{
+  "fstar_exe": "fstar.exe",
+  "options": [
+    "--lax",
+    "--MLish",
+    "--cache_dir",
+    "${FSTAR_HOME}/src/.cache.boot"
+  ],
+  "include_dirs": [
+    ".",
+    "${FSTAR_HOME}/src/basic",
+    "${FSTAR_HOME}/src/extraction",
+    "${FSTAR_HOME}/src/fstar",
+    "${FSTAR_HOME}/src/parser",
+    "${FSTAR_HOME}/src/prettyprint",
+    "${FSTAR_HOME}/src/reflection",
+    "${FSTAR_HOME}/src/smtencoding",
+    "${FSTAR_HOME}/src/syntax",
+    "${FSTAR_HOME}/src/tactics",
+    "${FSTAR_HOME}/src/tosyntax",
+    "${FSTAR_HOME}/src/typechecker",
+    "${FSTAR_HOME}/src/tests"
+  ]
+}


### PR DESCRIPTION
Instead of syntactic resolving stateful applications during desugaring, we now resolve it in a type-directed way, looking at the type of the head of an application node.

This means you no longer have to do awful things like `perform (fun _ -> f x)` to apply an argument `f` to `x`.

More examples in BugHigherOrderApplication. 

I made use of an OCaml-based callback into the typechecker, modeled after RTB.instantiate_implicits but more permissive, to sniff the type of the head of an application, even though looking up the type may result in unresolved universe instantiations. Universes don't matter to decide if an application is effectful or not.

Resolves part 3 of #54