### PR TITLE
Use size_t arg for index in TLArray, similarly to regular arrays

### DIFF
--- a/lib/steel/Steel.TLArray.fst
+++ b/lib/steel/Steel.TLArray.fst
@@ -6,4 +6,4 @@ let v x = G.hide x
 let length x = L.length x
 
 let create l = l
-let get x i = L.index x (U32.v i)
+let get x i = L.index x (US.v i)

--- a/lib/steel/Steel.TLArray.fsti
+++ b/lib/steel/Steel.TLArray.fsti
@@ -2,7 +2,7 @@ module Steel.TLArray
 
 module G = FStar.Ghost
 module L = FStar.List.Tot
-module U32 = FStar.UInt32
+module US = FStar.SizeT
 
 noextract
 val t (a:Type0) : Type0
@@ -21,9 +21,9 @@ val create (#a:Type0) (l: list a) :
          length x == normalize_term (List.Tot.length l))
 
 noextract
-val get (#a:Type0) (x: t a) (i:U32.t{U32.v i < length x}) :
+val get (#a:Type0) (x: t a) (i:US.t{US.v i < length x}) :
   Pure a
     (requires True)
     (ensures fun y ->
-      U32.v i < L.length (v x) /\
-      y == L.index (v x) (U32.v i))
+      US.v i < L.length (v x) /\
+      y == L.index (v x) (US.v i))

--- a/share/steel/tests/krml/SteelTLArray.fst
+++ b/share/steel/tests/krml/SteelTLArray.fst
@@ -11,6 +11,6 @@ let l = [0uy; 1uy]
 let x = create l
 
 let main () : SteelT Int32.t emp (fun _ -> emp) =
-  let i = get x 0ul in
-  let j = get x 1ul in
+  let i = get x 0sz in
+  let j = get x 1sz in
   if i = j then return 1l else return 0l


### PR DESCRIPTION
Steel.TLArray provides a module for top-level, const arrays.
While other array modules now use a size_t when indexing, TLArray still used the old approach, based on UInt32 indices. This PR fixes this.