### PR TITLE
Remove restriction on logical implicits ordering

### DIFF
--- a/lib/steel/pulse/Pulse.Checker.Pure.fsti
+++ b/lib/steel/pulse/Pulse.Checker.Pure.fsti
@@ -17,6 +17,9 @@ let push_context (ctx:string) (r:range) (g:env) : (g':env { g == g' })
 val instantiate_term_implicits (g:env) (t:term)
   : T.Tac (term & term)
 
+val instantiate_term_implicits_uvs (g:env) (t:term)
+  : T.Tac (uvs:env { disjoint g uvs } & term & term)  // uvs
+
 val check_universe (g:env) (t:term)
   : T.Tac (u:universe & universe_of g t u)
 

--- a/pulse2rust/src/Pulse2Rust.Rust.Syntax.fst
+++ b/pulse2rust/src/Pulse2Rust.Rust.Syntax.fst
@@ -90,7 +90,7 @@ let mk_pat_ident (path:string) : pat =
   Pat_ident { pat_name = path; by_ref = false; is_mut = false }
 
 let mk_pat_ts (pat_ts_path:string) (pat_ts_elems:list pat) : pat =
-  if List.Tot.length pat_ts_elems = 0
+  if L.length pat_ts_elems = 0
   then Pat_ident { pat_name = pat_ts_path; by_ref = false; is_mut = false }
   else Pat_tuple_struct { pat_ts_path; pat_ts_elems}
 

--- a/pulse2rust/src/Pulse2Rust.Rust.Syntax.fst
+++ b/pulse2rust/src/Pulse2Rust.Rust.Syntax.fst
@@ -144,4 +144,16 @@ let mk_local_stmt (name:string) (is_mut:bool) (init:expr) =
 let mk_fn (fn_sig:fn_signature) (fn_body:list stmt) =
   { fn_sig; fn_body; }
 
+let mk_item_struct (name:string) (generics:list string) (fields:list (string & typ))
+  : item =
+
+  Item_struct {
+    item_struct_name = name;
+    item_struct_generics = L.map Generic_type_param generics;
+    item_struct_fields = L.map (fun (f, t) -> {
+      field_typ_name = f;
+      field_typ_typ = t;
+    }) fields;
+  }
+
 let mk_file (file_name:string) (file_items:list item) : file = { file_name; file_items }

--- a/pulse2rust/src/Pulse2Rust.Rust.Syntax.fsti
+++ b/pulse2rust/src/Pulse2Rust.Rust.Syntax.fsti
@@ -190,8 +190,20 @@ type fn = {
   fn_body : list stmt;
 }
 
+type field_typ = {
+  field_typ_name : string;
+  field_typ_typ : typ;
+}
+
+type item_struct = {
+  item_struct_name : string;
+  item_struct_generics : list generic_param;
+  item_struct_fields : list field_typ;
+}
+
 type item =
   | Item_fn of fn
+  | Item_struct of item_struct
 
 type file = {
   file_name : string;
@@ -236,4 +248,8 @@ val mk_scalar_fn_arg (name:string) (t:typ) : fn_arg
 val mk_ref_fn_arg (name:string) (is_mut:bool) (t:typ) : fn_arg
 val mk_fn_signature (fn_name:string) (fn_generics:list string) (fn_args:list fn_arg) (fn_ret_t:typ) : fn_signature
 val mk_fn (fn_sig:fn_signature) (fn_body:list stmt) : fn
+
+val mk_item_struct (name:string) (generics:list string) (fields:list (string & typ))
+  : item
+
 val mk_file (name:string) (items:list item) : file

--- a/pulse2rust/src/Pulse2Rust.fst
+++ b/pulse2rust/src/Pulse2Rust.fst
@@ -511,6 +511,16 @@ let extract_top_level_lb (g:env) (lbs:S.mlletbinding) : fn & env =
     push_fv g lb.mllb_name fn_sig
   end
 
+// let extract_struct_defn (g:env) (d:S.mlmodule1) : item & env =
+//   match d with
+//   | S.MLM_Ty [ d ] ->
+//     let Some (S.MLTD_Record fts) = d.tydecl_defn in
+//     mk_item_struct
+//       d.tydecl_name
+//       d.tydecl_parameters
+//       (List.map (fun (f, t) -> f, extract_mlty g t) fts),
+//     g  // TODO: add it to env if needed later
+
 let extract_one (file:string) : unit =
   let (gamma, decls)  : (list UEnv.binding & S.mlmodule) =
     match load_value_from_file file with
@@ -527,6 +537,9 @@ let extract_one (file:string) : unit =
       items@[Item_fn f],
       g
     | S.MLM_Loc _ -> items, g
+    // | S.MLM_Ty [ {tydecl_defn = Some (S.MLTD_Record _)} ] ->
+    //   let item, g = extract_struct_defn g d in
+    //   items@[item], g
     | _ -> fail_nyi (format1 "top level decl %s" (S.mlmodule1_to_string d))
   ) ([], empty_env ()) decls in
   

--- a/pulse2rust/src/ocaml/generated/Pulse2Rust_Rust_Syntax.ml
+++ b/pulse2rust/src/ocaml/generated/Pulse2Rust_Rust_Syntax.ml
@@ -525,11 +525,52 @@ let (__proj__Mkfn__item__fn_sig : fn -> fn_signature) =
   fun projectee -> match projectee with | { fn_sig; fn_body;_} -> fn_sig
 let (__proj__Mkfn__item__fn_body : fn -> stmt Prims.list) =
   fun projectee -> match projectee with | { fn_sig; fn_body;_} -> fn_body
+type field_typ = {
+  field_typ_name: Prims.string ;
+  field_typ_typ: typ }
+let (__proj__Mkfield_typ__item__field_typ_name : field_typ -> Prims.string) =
+  fun projectee ->
+    match projectee with
+    | { field_typ_name; field_typ_typ;_} -> field_typ_name
+let (__proj__Mkfield_typ__item__field_typ_typ : field_typ -> typ) =
+  fun projectee ->
+    match projectee with
+    | { field_typ_name; field_typ_typ;_} -> field_typ_typ
+type item_struct =
+  {
+  item_struct_name: Prims.string ;
+  item_struct_generics: generic_param Prims.list ;
+  item_struct_fields: field_typ Prims.list }
+let (__proj__Mkitem_struct__item__item_struct_name :
+  item_struct -> Prims.string) =
+  fun projectee ->
+    match projectee with
+    | { item_struct_name; item_struct_generics; item_struct_fields;_} ->
+        item_struct_name
+let (__proj__Mkitem_struct__item__item_struct_generics :
+  item_struct -> generic_param Prims.list) =
+  fun projectee ->
+    match projectee with
+    | { item_struct_name; item_struct_generics; item_struct_fields;_} ->
+        item_struct_generics
+let (__proj__Mkitem_struct__item__item_struct_fields :
+  item_struct -> field_typ Prims.list) =
+  fun projectee ->
+    match projectee with
+    | { item_struct_name; item_struct_generics; item_struct_fields;_} ->
+        item_struct_fields
 type item =
   | Item_fn of fn 
-let (uu___is_Item_fn : item -> Prims.bool) = fun projectee -> true
+  | Item_struct of item_struct 
+let (uu___is_Item_fn : item -> Prims.bool) =
+  fun projectee -> match projectee with | Item_fn _0 -> true | uu___ -> false
 let (__proj__Item_fn__item___0 : item -> fn) =
   fun projectee -> match projectee with | Item_fn _0 -> _0
+let (uu___is_Item_struct : item -> Prims.bool) =
+  fun projectee ->
+    match projectee with | Item_struct _0 -> true | uu___ -> false
+let (__proj__Item_struct__item___0 : item -> item_struct) =
+  fun projectee -> match projectee with | Item_struct _0 -> _0
 type file = {
   file_name: Prims.string ;
   file_items: item Prims.list }
@@ -630,7 +671,7 @@ let (mk_pat_ident : Prims.string -> pat) =
 let (mk_pat_ts : Prims.string -> pat Prims.list -> pat) =
   fun pat_ts_path ->
     fun pat_ts_elems ->
-      if (FStar_List_Tot_Base.length pat_ts_elems) = Prims.int_zero
+      if (FStar_Compiler_List.length pat_ts_elems) = Prims.int_zero
       then
         Pat_ident { pat_name = pat_ts_path; by_ref = false; is_mut = false }
       else Pat_tuple_struct { pat_ts_path; pat_ts_elems }
@@ -697,5 +738,28 @@ let (mk_local_stmt : Prims.string -> Prims.bool -> expr -> stmt) =
           }
 let (mk_fn : fn_signature -> stmt Prims.list -> fn) =
   fun fn_sig -> fun fn_body -> { fn_sig; fn_body }
+let (mk_item_struct :
+  Prims.string ->
+    Prims.string Prims.list -> (Prims.string * typ) Prims.list -> item)
+  =
+  fun name ->
+    fun generics ->
+      fun fields ->
+        let uu___ =
+          let uu___1 =
+            FStar_Compiler_List.map (fun uu___2 -> Generic_type_param uu___2)
+              generics in
+          let uu___2 =
+            FStar_Compiler_List.map
+              (fun uu___3 ->
+                 match uu___3 with
+                 | (f, t) -> { field_typ_name = f; field_typ_typ = t })
+              fields in
+          {
+            item_struct_name = name;
+            item_struct_generics = uu___1;
+            item_struct_fields = uu___2
+          } in
+        Item_struct uu___
 let (mk_file : Prims.string -> item Prims.list -> file) =
   fun file_name -> fun file_items -> { file_name; file_items }

--- a/share/steel/examples/pulse/ArrayTests.fst
+++ b/share/steel/examples/pulse/ArrayTests.fst
@@ -8,8 +8,7 @@ module R = Pulse.Lib.Reference
 #push-options "--using_facts_from '* -FStar.Tactics -FStar.Reflection'"
 
 ```pulse
-fn compare (#t:eqtype) (l:US.t) (a1 a2:A.larray t (US.v l))
-           (#p1 #p2:perm) (#s1 #s2:elseq t l)
+fn compare (#t:eqtype) (#p1 #p2:perm) (l:US.t) (#s1 #s2:elseq t l) (a1 a2:A.larray t (US.v l))
   requires (
     A.pts_to a1 #p1 s1 **
     A.pts_to a2 #p2 s2
@@ -90,7 +89,7 @@ fn array_of_zeroes (n:US.t)
 
 //this is not a recommended way to do this, since s is not erased, but it works
 ```pulse
-fn read_at_offset_0 (#t:Type0) (a:array t) (i:US.t) (#p:perm) (#s:Seq.seq t)
+fn read_at_offset_0 (#t:Type0) (#p:perm) (#s:Seq.seq t) (a:array t) (i:US.t)
    requires (A.pts_to a #p s **
              pure (US.v i < Seq.length s))
    returns x:t
@@ -107,7 +106,7 @@ fn read_at_offset_0 (#t:Type0) (a:array t) (i:US.t) (#p:perm) (#s:Seq.seq t)
 ```
 
 ```pulse
-fn read_at_offset_poly (#t:Type0) (a:array t) (i:US.t) (#p:perm) (#s:Ghost.erased (Seq.seq t))
+fn read_at_offset_poly (#t:Type0) (#p:perm) (#s:Ghost.erased (Seq.seq t)) (a:array t) (i:US.t)
    requires (A.pts_to a #p s **
              pure (US.v i < Seq.length s))
    returns x:t
@@ -141,10 +140,10 @@ fn read_at_offset (a:array U32.t) (i:US.t) (#p:perm) (#s:Ghost.erased (Seq.seq U
 assume
 val test_array_access
   (#t: Type)
+  (#p: perm)
   (a: A.array t)
   (i: US.t)
   (#s: Ghost.erased (Seq.seq t) {US.v i < A.length a \/ US.v i < Seq.length s})
-  (#p: perm)
 : stt t
     (requires
       A.pts_to a #p s)
@@ -155,7 +154,7 @@ val test_array_access
             res == Seq.index s (US.v i)))
 
 ```pulse
-fn read_at_offset_refine (a:array U32.t) (i:US.t) (#p:perm) (#s:Ghost.erased (Seq.seq U32.t))
+fn read_at_offset_refine (#p:perm) (#s:Ghost.erased (Seq.seq U32.t)) (a:array U32.t) (i:US.t) 
    requires (A.pts_to a #p s **
              pure (US.v i < A.length a \/ US.v i < Seq.length s))
    returns x:U32.t
@@ -174,7 +173,7 @@ fn read_at_offset_refine (a:array U32.t) (i:US.t) (#p:perm) (#s:Ghost.erased (Se
 
 
 ```pulse
-fn read_at_offset_refine_poly (#t:Type0) (a:array t) (i:US.t) (#p:perm) (#s:Ghost.erased (Seq.seq t))
+fn read_at_offset_refine_poly (#t:Type0) (#p:perm) (#s:Ghost.erased (Seq.seq t)) (a:array t) (i:US.t) 
    requires (A.pts_to a #p s **
              pure (US.v i < A.length a \/ US.v i < Seq.length s))
    returns x:t

--- a/share/steel/examples/pulse/CustomSyntax.fst
+++ b/share/steel/examples/pulse/CustomSyntax.fst
@@ -7,400 +7,387 @@ module U32 = FStar.UInt32
 assume val p : vprop
 assume val g : unit -> stt unit emp (fun _ -> p)
 
-// let folded_pts_to (r:ref U32.t) (n:erased U32.t) : vprop = pts_to r n
+let folded_pts_to (r:ref U32.t) (n:erased U32.t) : vprop = pts_to r n
 
-// ```pulse
-// fn unfold_test (r:ref U32.t) 
-//   requires folded_pts_to r 'n
-//   ensures folded_pts_to r 'n
-// {
-//   with n. unfold (folded_pts_to r n);
-//   with n. fold (folded_pts_to r n)
-// }
-// ```
+```pulse
+fn unfold_test (r:ref U32.t) 
+  requires folded_pts_to r 'n
+  ensures folded_pts_to r 'n
+{
+  with n. unfold (folded_pts_to r n);
+  with n. fold (folded_pts_to r n)
+}
+```
 
-// ```pulse
-// fn test_write_10 (x:ref U32.t)
-//    requires pts_to x 'n
-//    ensures  pts_to x 0ul
-// {
-//     x := 1ul;
-//     x := 0ul;
-// }
-// ```
+```pulse
+fn test_write_10 (x:ref U32.t)
+   requires pts_to x 'n
+   ensures  pts_to x 0ul
+{
+    x := 1ul;
+    x := 0ul;
+}
+```
 
-// ```pulse
-// fn test_read (r:ref U32.t)
-//    requires pts_to r #pm 'n
-//    returns x : U32.t
-//    ensures pts_to r #pm x
-// {
-//   !r
-// }
-// ```
+```pulse
+fn test_read (r:ref U32.t)
+   requires pts_to r #pm 'n
+   returns x : U32.t
+   ensures pts_to r #pm x
+{
+  !r
+}
+```
 
-// ```pulse
-// fn swap (r1 r2:ref U32.t)
-//   requires 
-//       pts_to r1 'n1 **
-//       pts_to r2 'n2
-//   ensures
-//       pts_to r1 'n2 **
-//       pts_to r2 'n1
-// {
-//   let x = !r1;
-//   let y = !r2;
-//   r1 := y;
-//   r2 := x
-// }
-// ```
-
-
-// ```pulse
-// fn call_swap2 (r1 r2:ref U32.t)
-//    requires
-//        pts_to r1 'n1 **
-//        pts_to r2 'n2
-//    ensures
-//        pts_to r1 'n1 **
-//        pts_to r2 'n2
-// {
-//    swap r1 r2;
-//    swap r1 r2
-// }
-// ```
+```pulse
+fn swap (r1 r2:ref U32.t)
+  requires 
+      pts_to r1 'n1 **
+      pts_to r2 'n2
+  ensures
+      pts_to r1 'n2 **
+      pts_to r2 'n1
+{
+  let x = !r1;
+  let y = !r2;
+  r1 := y;
+  r2 := x
+}
+```
 
 
-// ```pulse
-// fn swap_with_elim_pure (#n1 #n2:erased U32.t)
-//                        (r1 r2:ref U32.t)
-//    requires
-//       pts_to r1 n1 **
-//       pts_to r2 n2
-//    ensures
-//       pts_to r1 n2 **
-//       pts_to r2 n1
-// {
-//    let x = !r1;
-//    let y = !r2;
-//    r1 := y;
-//    r2 := x
-// }
-// ```
-
-// ```pulse
-// fn swap (#n1 #n2:erased U32.t) (r1 r2:ref U32.t)
-//    requires
-//       pts_to r1 n1 **
-//       pts_to r2 n2
-//    ensures
-//       pts_to r1 n2 **
-//       pts_to r2 n1
-// {
-//   swap_with_elim_pure r1 r2
-// }
-// ```
-
-// ```pulse
-// fn intro_pure_example (r:ref U32.t)
-//    requires 
-//      (pts_to r 'n1  **
-//       pure (reveal 'n1 == reveal 'n2))
-//    ensures 
-//      (pts_to r 'n2  **
-//       pure (reveal 'n2 == reveal 'n1))
-// {
-//   ()
-// }
-// ```
+```pulse
+fn call_swap2 (r1 r2:ref U32.t)
+   requires
+       pts_to r1 'n1 **
+       pts_to r2 'n2
+   ensures
+       pts_to r1 'n1 **
+       pts_to r2 'n2
+{
+   swap r1 r2;
+   swap r1 r2
+}
+```
 
 
-// ```pulse
-// fn if_example (r:ref U32.t)
-//               (n:(n:erased U32.t{U32.v (reveal n) == 1}))
-//               (b:bool)
-//    requires 
-//      pts_to r n
-//    ensures
-//      pts_to r (U32.add (reveal n) 2ul)
-// {
-//    let x = read_atomic r;
-//    if b
-//    {
-//      r := U32.add x 2ul
-//    }
-//    else
-//    {
-//      write_atomic r 3ul
-//    }
-// }
-// ```
+```pulse
+fn swap_with_elim_pure (#n1 #n2:erased U32.t)
+                       (r1 r2:ref U32.t)
+   requires
+      pts_to r1 n1 **
+      pts_to r2 n2
+   ensures
+      pts_to r1 n2 **
+      pts_to r2 n1
+{
+   let x = !r1;
+   let y = !r2;
+   r1 := y;
+   r2 := x
+}
+```
 
-// ```pulse
-// ghost
-// fn elim_intro_exists2 (r:ref U32.t)
-//    requires 
-//      exists n. pts_to r n
-//    ensures 
-//      exists n. pts_to r n
-// {
-//   introduce exists n. pts_to r n with _
-// }
-// ```
-
-// assume
-// val pred (b:bool) : vprop
-// assume
-// val read_pred (_:unit) (#b:erased bool)
-//     : stt bool (pred b) (fun r -> pred r)
-
-// ```pulse
-// fn while_test_alt (r:ref U32.t)
-//   requires 
-//     exists b n.
-//       (pts_to r n  **
-//        pred b)
-//   ensures 
-//     exists n. (pts_to r n  **
-//               pred false)
-// {
-//   while (read_pred ())
-//   invariant b . exists n. (pts_to r n  ** pred b)
-//   {
-//     ()
-//   }
-// }
-// ```
-
-// ```pulse
-// fn infer_read_ex (r:ref U32.t)
-//   requires
-//     exists n. pts_to r n
-//   ensures exists n. pts_to r n
-// {
-//   let x = !r;
-//   ()
-// }
-// ```
+```pulse
+fn intro_pure_example (r:ref U32.t)
+   requires 
+     (pts_to r 'n1  **
+      pure (reveal 'n1 == reveal 'n2))
+   ensures 
+     (pts_to r 'n2  **
+      pure (reveal 'n2 == reveal 'n1))
+{
+  ()
+}
+```
 
 
-// ```pulse
-// fn while_count2 (r:ref U32.t)
-//   requires exists (n:U32.t). (pts_to r n)
-//   ensures (pts_to r 10ul)
-// {
-//   open FStar.UInt32;
-//   while (let x = !r; (x <> 10ul))
-//   invariant b. 
-//     exists n. (pts_to r n  **
-//           pure (b == (n <> 10ul)))
-//   {
-//     let x = !r;
-//     if (x <^ 10ul)
-//     {
-//       r := x +^ 1ul
-//     }
-//     else
-//     {
-//       r := x -^ 1ul
-//     }
-//   }
-// }
-// ```
+```pulse
+fn if_example (r:ref U32.t)
+              (n:(n:erased U32.t{U32.v (reveal n) == 1}))
+              (b:bool)
+   requires 
+     pts_to r n
+   ensures
+     pts_to r (U32.add (reveal n) 2ul)
+{
+   let x = read_atomic r;
+   if b
+   {
+     r := U32.add x 2ul
+   }
+   else
+   {
+     write_atomic r 3ul
+   }
+}
+```
+
+```pulse
+ghost
+fn elim_intro_exists2 (r:ref U32.t)
+   requires 
+     exists n. pts_to r n
+   ensures 
+     exists n. pts_to r n
+{
+  introduce exists n. pts_to r n with _
+}
+```
+
+assume
+val pred (b:bool) : vprop
+assume
+val read_pred (_:unit) (#b:erased bool)
+    : stt bool (pred b) (fun r -> pred r)
+
+```pulse
+fn while_test_alt (r:ref U32.t)
+  requires 
+    exists b n.
+      (pts_to r n  **
+       pred b)
+  ensures 
+    exists n. (pts_to r n  **
+              pred false)
+{
+  while (read_pred ())
+  invariant b . exists n. (pts_to r n  ** pred b)
+  {
+    ()
+  }
+}
+```
+
+```pulse
+fn infer_read_ex (r:ref U32.t)
+  requires
+    exists n. pts_to r n
+  ensures exists n. pts_to r n
+{
+  let x = !r;
+  ()
+}
+```
 
 
-// ```pulse
-// fn test_par (r1 r2:ref U32.t)
-//   requires 
-//      pts_to r1 'n1  **
-//      pts_to r2 'n2
-//   ensures
-//      pts_to r1 1ul  **
-//      pts_to r2 1ul
-// {
-//   parallel
-//   requires (pts_to r1 'n1)
-//        and (pts_to r2 'n2)
-//   ensures  (pts_to r1 1ul)    
-//        and (pts_to r2 1ul)
-//   {
-//      r1 := 1ul
-//   }
-//   {
-//      r2 := 1ul
-//   };
-//   ()
-// }
-// ```
-
-// // A test for rewrite
-// let mpts_to (r:ref U32.t) (n:erased U32.t) : vprop = pts_to r n
-
-// ```pulse
-// fn rewrite_test (r:ref U32.t)
-//    requires (mpts_to r 'n)
-//    ensures  (mpts_to r 1ul)
-// {
-//   rewrite (mpts_to r 'n) 
-//        as (pts_to r 'n);
-//   r := 1ul;
-//   rewrite (pts_to r 1ul)
-//        as (mpts_to r 1ul)
-// }
-// ```
-
-// ```pulse
-// fn test_local (r:ref U32.t)
-//    requires (pts_to r 'n)
-//    ensures  (pts_to r 0ul)
-// {
-//   let mut x = 0ul;
-//   let y = Pulse.Lib.Reference.op_Bang x;
-//   r := y
-// }
-// ```
-
-// ```pulse
-// fn count_local (r:ref int) (n:int)
-//    requires (pts_to r (hide 0))
-//    ensures (pts_to r n)
-// {
-//   let mut i = 0;
-//   while
-//     (let m = !i; (m <> n))
-//   invariant b. exists m. 
-//     (pts_to i m  **
-//      pure (b == (m <> n)))
-//   {
-//     let m = !i;
-//     i := m + 1
-//   };
-//   let x = !i;
-//   r := x
-// }
-// ```
+```pulse
+fn while_count2 (r:ref U32.t)
+  requires exists (n:U32.t). (pts_to r n)
+  ensures (pts_to r 10ul)
+{
+  open FStar.UInt32;
+  while (let x = !r; (x <> 10ul))
+  invariant b. 
+    exists n. (pts_to r n  **
+          pure (b == (n <> 10ul)))
+  {
+    let x = !r;
+    if (x <^ 10ul)
+    {
+      r := x +^ 1ul
+    }
+    else
+    {
+      r := x -^ 1ul
+    }
+  }
+}
+```
 
 
-// let rec sum_spec (n:nat) : nat =
-//   if n = 0 then 0 else n + sum_spec (n - 1)
+```pulse
+fn test_par (r1 r2:ref U32.t)
+  requires 
+     pts_to r1 'n1  **
+     pts_to r2 'n2
+  ensures
+     pts_to r1 1ul  **
+     pts_to r2 1ul
+{
+  parallel
+  requires (pts_to r1 'n1)
+       and (pts_to r2 'n2)
+  ensures  (pts_to r1 1ul)    
+       and (pts_to r2 1ul)
+  {
+     r1 := 1ul
+  }
+  {
+     r2 := 1ul
+  };
+  ()
+}
+```
+
+// A test for rewrite
+let mpts_to (r:ref U32.t) (n:erased U32.t) : vprop = pts_to r n
+
+```pulse
+fn rewrite_test (r:ref U32.t)
+   requires (mpts_to r 'n)
+   ensures  (mpts_to r 1ul)
+{
+  rewrite (mpts_to r 'n) 
+       as (pts_to r 'n);
+  r := 1ul;
+  rewrite (pts_to r 1ul)
+       as (mpts_to r 1ul)
+}
+```
+
+```pulse
+fn test_local (r:ref U32.t)
+   requires (pts_to r 'n)
+   ensures  (pts_to r 0ul)
+{
+  let mut x = 0ul;
+  let y = Pulse.Lib.Reference.op_Bang x;
+  r := y
+}
+```
+
+```pulse
+fn count_local (r:ref int) (n:int)
+   requires (pts_to r (hide 0))
+   ensures (pts_to r n)
+{
+  let mut i = 0;
+  while
+    (let m = !i; (m <> n))
+  invariant b. exists m. 
+    (pts_to i m  **
+     pure (b == (m <> n)))
+  {
+    let m = !i;
+    i := m + 1
+  };
+  let x = !i;
+  r := x
+}
+```
+
+
+let rec sum_spec (n:nat) : nat =
+  if n = 0 then 0 else n + sum_spec (n - 1)
 
  
-// let zero : nat = 0
+let zero : nat = 0
 
-// ```pulse
-// fn sum (r:ref nat) (n:nat)
-//    requires exists i. (pts_to r i)
-//    ensures (pts_to r (sum_spec n))
-// {
-//    let mut i = zero;
-//    let mut sum = zero;
-//    introduce exists b m s. (
-//      pts_to i m  **
-//      pts_to sum s  **
-//      pure (s == sum_spec m /\
-//            b == (m <> n)))
-//    with (zero <> n);
+```pulse
+fn sum (r:ref nat) (n:nat)
+   requires exists i. (pts_to r i)
+   ensures (pts_to r (sum_spec n))
+{
+   let mut i = zero;
+   let mut sum = zero;
+   introduce exists b m s. (
+     pts_to i m  **
+     pts_to sum s  **
+     pure (s == sum_spec m /\
+           b == (m <> n)))
+   with (zero <> n);
         
-//    while (let m = !i; (m <> n))
-//    invariant b . exists m s. (
-//      pts_to i m  **
-//      pts_to sum s  **
-//      pure (s == sum_spec m /\
-//            b == (m <> n)))
-//    {
-//      let m = !i;
-//      let s = !sum;
-//      i := (m + 1);
-//      sum := s + m + 1;
-//      introduce exists b m s. (
-//        pts_to i m  **
-//        pts_to sum s  **
-//        pure (s == sum_spec m /\
-//              b == (m <> n)))
-//      with (m + 1 <> n)
-//    };
-//    let s = !sum;
-//    r := s;
-//    introduce exists m. (pts_to i m) 
-//    with _;
-//    introduce exists s. (pts_to sum s)
-//    with _
-// }
-// ```
+   while (let m = !i; (m <> n))
+   invariant b . exists m s. (
+     pts_to i m  **
+     pts_to sum s  **
+     pure (s == sum_spec m /\
+           b == (m <> n)))
+   {
+     let m = !i;
+     let s = !sum;
+     i := (m + 1);
+     sum := s + m + 1;
+     introduce exists b m s. (
+       pts_to i m  **
+       pts_to sum s  **
+       pure (s == sum_spec m /\
+             b == (m <> n)))
+     with (m + 1 <> n)
+   };
+   let s = !sum;
+   r := s;
+   introduce exists m. (pts_to i m) 
+   with _;
+   introduce exists s. (pts_to sum s)
+   with _
+}
+```
 
-// ```pulse
-// fn sum2 (r:ref nat) (n:nat)
-//    requires exists i. pts_to r i
-//    ensures pts_to r (sum_spec n)
-// {
-//    let mut i = zero;
-//    let mut sum = zero;
-//    while (let m = !i; (m <> n))
-//    invariant b . exists m s.
-//      pts_to i m  **
-//      pts_to sum s **
-//      pure (s == sum_spec m /\ b == (m <> n))
-//    {
-//      let m = !i;
-//      let s = !sum;
-//      i := (m + 1);
-//      sum := s + m + 1;
-//      ()
-//    };
-//    let s = !sum;
-//    r := s;
-//    ()
-// }
-// ```
+```pulse
+fn sum2 (r:ref nat) (n:nat)
+   requires exists i. pts_to r i
+   ensures pts_to r (sum_spec n)
+{
+   let mut i = zero;
+   let mut sum = zero;
+   while (let m = !i; (m <> n))
+   invariant b . exists m s.
+     pts_to i m  **
+     pts_to sum s **
+     pure (s == sum_spec m /\ b == (m <> n))
+   {
+     let m = !i;
+     let s = !sum;
+     i := (m + 1);
+     sum := s + m + 1;
+     ()
+   };
+   let s = !sum;
+   r := s;
+   ()
+}
+```
 
+```pulse
+fn if_then_else_in_specs (r:ref U32.t)
+  requires `@(if true
+              then pts_to r 0ul
+              else pts_to r 1ul)
+  ensures  `@(if true
+              then pts_to r 1ul
+              else pts_to r 0ul)
+{
+  // need this for typechecking !r on the next line,
+  //   with inference of implicits
+  rewrite `@(if true then pts_to r 0ul else pts_to r 1ul)
+       as (pts_to r 0ul);
+  let x = !r;
+  r := U32.add x 1ul
+}
+```
+
+```pulse
+fn test_tot_let (r:ref U32.t)
+  requires (pts_to r 0ul)
+  ensures  (pts_to r 2ul)
+{
+  let x = 1ul;
+  let y = 1ul;
+  r := U32.add x y
+}
+```
+
+// Ascriptions coming in the way
 // ```pulse
-// fn if_then_else_in_specs (r:ref U32.t)
-//   requires `@(if true
-//               then pts_to r 0ul
-//               else pts_to r 1ul)
-//   ensures  `@(if true
-//               then pts_to r 1ul
-//               else pts_to r 0ul)
+// fn if_then_else_in_specs2 (r:ref U32.t) (b:bool)
+//   requires (pts_to r (if b then 0ul else 1ul))
+//   ensures (pts_to r (if b then 1ul else 2ul))
 // {
-//   // need this for typechecking !r on the next line,
-//   //   with inference of implicits
-//   rewrite `@(if true then pts_to r 0ul else pts_to r 1ul)
-//        as (pts_to r 0ul);
 //   let x = !r;
 //   r := U32.add x 1ul
 // }
 // ```
 
-// ```pulse
-// fn test_tot_let (r:ref U32.t)
-//   requires (pts_to r 0ul)
-//   ensures  (pts_to r 2ul)
-// {
-//   let x = 1ul;
-//   let y = 1ul;
-//   r := U32.add x y
-// }
-// ```
 
-// // Ascriptions coming in the way
-// // ```pulse
-// // fn if_then_else_in_specs2 (r:ref U32.t) (b:bool)
-// //   requires (pts_to r (if b then 0ul else 1ul))
-// //   ensures (pts_to r (if b then 1ul else 2ul))
-// // {
-// //   let x = !r;
-// //   r := U32.add x 1ul
-// // }
-// // ```
-
-
-// ```pulse
-// fn incr (x:nat)
-//   requires emp
-//   returns r : (r:nat { r > x })
-//   ensures emp
-// {
-//   let y = x + 1;
-//   ( y <: r:nat { r > x } )
-// }
-// ```
+```pulse
+fn incr (x:nat)
+  requires emp
+  returns r : (r:nat { r > x })
+  ensures emp
+{
+  let y = x + 1;
+  ( y <: r:nat { r > x } )
+}
+```

--- a/share/steel/examples/pulse/CustomSyntax.fst
+++ b/share/steel/examples/pulse/CustomSyntax.fst
@@ -7,387 +7,400 @@ module U32 = FStar.UInt32
 assume val p : vprop
 assume val g : unit -> stt unit emp (fun _ -> p)
 
-let folded_pts_to (r:ref U32.t) (n:erased U32.t) : vprop = pts_to r n
+// let folded_pts_to (r:ref U32.t) (n:erased U32.t) : vprop = pts_to r n
 
-```pulse
-fn unfold_test (r:ref U32.t) 
-  requires folded_pts_to r 'n
-  ensures folded_pts_to r 'n
-{
-  with n. unfold (folded_pts_to r n);
-  with n. fold (folded_pts_to r n)
-}
-```
+// ```pulse
+// fn unfold_test (r:ref U32.t) 
+//   requires folded_pts_to r 'n
+//   ensures folded_pts_to r 'n
+// {
+//   with n. unfold (folded_pts_to r n);
+//   with n. fold (folded_pts_to r n)
+// }
+// ```
 
-```pulse
-fn test_write_10 (x:ref U32.t)
-   requires pts_to x 'n
-   ensures  pts_to x 0ul
-{
-    x := 1ul;
-    x := 0ul;
-}
-```
+// ```pulse
+// fn test_write_10 (x:ref U32.t)
+//    requires pts_to x 'n
+//    ensures  pts_to x 0ul
+// {
+//     x := 1ul;
+//     x := 0ul;
+// }
+// ```
 
-```pulse
-fn test_read (r:ref U32.t)
-   requires pts_to r #pm 'n
-   returns x : U32.t
-   ensures pts_to r #pm x
-{
-  !r
-}
-```
+// ```pulse
+// fn test_read (r:ref U32.t)
+//    requires pts_to r #pm 'n
+//    returns x : U32.t
+//    ensures pts_to r #pm x
+// {
+//   !r
+// }
+// ```
 
-```pulse
-fn swap (r1 r2:ref U32.t)
-  requires 
-      pts_to r1 'n1 **
-      pts_to r2 'n2
-  ensures
-      pts_to r1 'n2 **
-      pts_to r2 'n1
-{
-  let x = !r1;
-  let y = !r2;
-  r1 := y;
-  r2 := x
-}
-```
-
-
-```pulse
-fn call_swap2 (r1 r2:ref U32.t)
-   requires
-       pts_to r1 'n1 **
-       pts_to r2 'n2
-   ensures
-       pts_to r1 'n1 **
-       pts_to r2 'n2
-{
-   swap r1 r2;
-   swap r1 r2
-}
-```
+// ```pulse
+// fn swap (r1 r2:ref U32.t)
+//   requires 
+//       pts_to r1 'n1 **
+//       pts_to r2 'n2
+//   ensures
+//       pts_to r1 'n2 **
+//       pts_to r2 'n1
+// {
+//   let x = !r1;
+//   let y = !r2;
+//   r1 := y;
+//   r2 := x
+// }
+// ```
 
 
-```pulse
-fn swap_with_elim_pure (r1 r2:ref U32.t) 
-                       (#n1 #n2:erased U32.t)
-   requires
-      pts_to r1 n1 **
-      pts_to r2 n2
-   ensures
-      pts_to r1 n2 **
-      pts_to r2 n1
-{
-   let x = !r1;
-   let y = !r2;
-   r1 := y;
-   r2 := x
-}
-```
-
-```pulse
-fn intro_pure_example (r:ref U32.t)
-   requires 
-     (pts_to r 'n1  **
-      pure (reveal 'n1 == reveal 'n2))
-   ensures 
-     (pts_to r 'n2  **
-      pure (reveal 'n2 == reveal 'n1))
-{
-  ()
-}
-```
+// ```pulse
+// fn call_swap2 (r1 r2:ref U32.t)
+//    requires
+//        pts_to r1 'n1 **
+//        pts_to r2 'n2
+//    ensures
+//        pts_to r1 'n1 **
+//        pts_to r2 'n2
+// {
+//    swap r1 r2;
+//    swap r1 r2
+// }
+// ```
 
 
-```pulse
-fn if_example (r:ref U32.t)
-              (n:(n:erased U32.t{U32.v (reveal n) == 1}))
-              (b:bool)
-   requires 
-     pts_to r n
-   ensures
-     pts_to r (U32.add (reveal n) 2ul)
-{
-   let x = read_atomic r;
-   if b
-   {
-     r := U32.add x 2ul
-   }
-   else
-   {
-     write_atomic r 3ul
-   }
-}
-```
+// ```pulse
+// fn swap_with_elim_pure (#n1 #n2:erased U32.t)
+//                        (r1 r2:ref U32.t)
+//    requires
+//       pts_to r1 n1 **
+//       pts_to r2 n2
+//    ensures
+//       pts_to r1 n2 **
+//       pts_to r2 n1
+// {
+//    let x = !r1;
+//    let y = !r2;
+//    r1 := y;
+//    r2 := x
+// }
+// ```
 
-```pulse
-ghost
-fn elim_intro_exists2 (r:ref U32.t)
-   requires 
-     exists n. pts_to r n
-   ensures 
-     exists n. pts_to r n
-{
-  introduce exists n. pts_to r n with _
-}
-```
+// ```pulse
+// fn swap (#n1 #n2:erased U32.t) (r1 r2:ref U32.t)
+//    requires
+//       pts_to r1 n1 **
+//       pts_to r2 n2
+//    ensures
+//       pts_to r1 n2 **
+//       pts_to r2 n1
+// {
+//   swap_with_elim_pure r1 r2
+// }
+// ```
 
-assume
-val pred (b:bool) : vprop
-assume
-val read_pred (_:unit) (#b:erased bool)
-    : stt bool (pred b) (fun r -> pred r)
-
-```pulse
-fn while_test_alt (r:ref U32.t)
-  requires 
-    exists b n.
-      (pts_to r n  **
-       pred b)
-  ensures 
-    exists n. (pts_to r n  **
-              pred false)
-{
-  while (read_pred ())
-  invariant b . exists n. (pts_to r n  ** pred b)
-  {
-    ()
-  }
-}
-```
-
-```pulse
-fn infer_read_ex (r:ref U32.t)
-  requires
-    exists n. pts_to r n
-  ensures exists n. pts_to r n
-{
-  let x = !r;
-  ()
-}
-```
+// ```pulse
+// fn intro_pure_example (r:ref U32.t)
+//    requires 
+//      (pts_to r 'n1  **
+//       pure (reveal 'n1 == reveal 'n2))
+//    ensures 
+//      (pts_to r 'n2  **
+//       pure (reveal 'n2 == reveal 'n1))
+// {
+//   ()
+// }
+// ```
 
 
-```pulse
-fn while_count2 (r:ref U32.t)
-  requires exists (n:U32.t). (pts_to r n)
-  ensures (pts_to r 10ul)
-{
-  open FStar.UInt32;
-  while (let x = !r; (x <> 10ul))
-  invariant b. 
-    exists n. (pts_to r n  **
-          pure (b == (n <> 10ul)))
-  {
-    let x = !r;
-    if (x <^ 10ul)
-    {
-      r := x +^ 1ul
-    }
-    else
-    {
-      r := x -^ 1ul
-    }
-  }
-}
-```
+// ```pulse
+// fn if_example (r:ref U32.t)
+//               (n:(n:erased U32.t{U32.v (reveal n) == 1}))
+//               (b:bool)
+//    requires 
+//      pts_to r n
+//    ensures
+//      pts_to r (U32.add (reveal n) 2ul)
+// {
+//    let x = read_atomic r;
+//    if b
+//    {
+//      r := U32.add x 2ul
+//    }
+//    else
+//    {
+//      write_atomic r 3ul
+//    }
+// }
+// ```
+
+// ```pulse
+// ghost
+// fn elim_intro_exists2 (r:ref U32.t)
+//    requires 
+//      exists n. pts_to r n
+//    ensures 
+//      exists n. pts_to r n
+// {
+//   introduce exists n. pts_to r n with _
+// }
+// ```
+
+// assume
+// val pred (b:bool) : vprop
+// assume
+// val read_pred (_:unit) (#b:erased bool)
+//     : stt bool (pred b) (fun r -> pred r)
+
+// ```pulse
+// fn while_test_alt (r:ref U32.t)
+//   requires 
+//     exists b n.
+//       (pts_to r n  **
+//        pred b)
+//   ensures 
+//     exists n. (pts_to r n  **
+//               pred false)
+// {
+//   while (read_pred ())
+//   invariant b . exists n. (pts_to r n  ** pred b)
+//   {
+//     ()
+//   }
+// }
+// ```
+
+// ```pulse
+// fn infer_read_ex (r:ref U32.t)
+//   requires
+//     exists n. pts_to r n
+//   ensures exists n. pts_to r n
+// {
+//   let x = !r;
+//   ()
+// }
+// ```
 
 
-```pulse
-fn test_par (r1 r2:ref U32.t)
-  requires 
-     pts_to r1 'n1  **
-     pts_to r2 'n2
-  ensures
-     pts_to r1 1ul  **
-     pts_to r2 1ul
-{
-  parallel
-  requires (pts_to r1 'n1)
-       and (pts_to r2 'n2)
-  ensures  (pts_to r1 1ul)    
-       and (pts_to r2 1ul)
-  {
-     r1 := 1ul
-  }
-  {
-     r2 := 1ul
-  };
-  ()
-}
-```
-
-// A test for rewrite
-let mpts_to (r:ref U32.t) (n:erased U32.t) : vprop = pts_to r n
-
-```pulse
-fn rewrite_test (r:ref U32.t)
-   requires (mpts_to r 'n)
-   ensures  (mpts_to r 1ul)
-{
-  rewrite (mpts_to r 'n) 
-       as (pts_to r 'n);
-  r := 1ul;
-  rewrite (pts_to r 1ul)
-       as (mpts_to r 1ul)
-}
-```
-
-```pulse
-fn test_local (r:ref U32.t)
-   requires (pts_to r 'n)
-   ensures  (pts_to r 0ul)
-{
-  let mut x = 0ul;
-  let y = Pulse.Lib.Reference.op_Bang x;
-  r := y
-}
-```
-
-```pulse
-fn count_local (r:ref int) (n:int)
-   requires (pts_to r (hide 0))
-   ensures (pts_to r n)
-{
-  let mut i = 0;
-  while
-    (let m = !i; (m <> n))
-  invariant b. exists m. 
-    (pts_to i m  **
-     pure (b == (m <> n)))
-  {
-    let m = !i;
-    i := m + 1
-  };
-  let x = !i;
-  r := x
-}
-```
+// ```pulse
+// fn while_count2 (r:ref U32.t)
+//   requires exists (n:U32.t). (pts_to r n)
+//   ensures (pts_to r 10ul)
+// {
+//   open FStar.UInt32;
+//   while (let x = !r; (x <> 10ul))
+//   invariant b. 
+//     exists n. (pts_to r n  **
+//           pure (b == (n <> 10ul)))
+//   {
+//     let x = !r;
+//     if (x <^ 10ul)
+//     {
+//       r := x +^ 1ul
+//     }
+//     else
+//     {
+//       r := x -^ 1ul
+//     }
+//   }
+// }
+// ```
 
 
-let rec sum_spec (n:nat) : nat =
-  if n = 0 then 0 else n + sum_spec (n - 1)
+// ```pulse
+// fn test_par (r1 r2:ref U32.t)
+//   requires 
+//      pts_to r1 'n1  **
+//      pts_to r2 'n2
+//   ensures
+//      pts_to r1 1ul  **
+//      pts_to r2 1ul
+// {
+//   parallel
+//   requires (pts_to r1 'n1)
+//        and (pts_to r2 'n2)
+//   ensures  (pts_to r1 1ul)    
+//        and (pts_to r2 1ul)
+//   {
+//      r1 := 1ul
+//   }
+//   {
+//      r2 := 1ul
+//   };
+//   ()
+// }
+// ```
+
+// // A test for rewrite
+// let mpts_to (r:ref U32.t) (n:erased U32.t) : vprop = pts_to r n
+
+// ```pulse
+// fn rewrite_test (r:ref U32.t)
+//    requires (mpts_to r 'n)
+//    ensures  (mpts_to r 1ul)
+// {
+//   rewrite (mpts_to r 'n) 
+//        as (pts_to r 'n);
+//   r := 1ul;
+//   rewrite (pts_to r 1ul)
+//        as (mpts_to r 1ul)
+// }
+// ```
+
+// ```pulse
+// fn test_local (r:ref U32.t)
+//    requires (pts_to r 'n)
+//    ensures  (pts_to r 0ul)
+// {
+//   let mut x = 0ul;
+//   let y = Pulse.Lib.Reference.op_Bang x;
+//   r := y
+// }
+// ```
+
+// ```pulse
+// fn count_local (r:ref int) (n:int)
+//    requires (pts_to r (hide 0))
+//    ensures (pts_to r n)
+// {
+//   let mut i = 0;
+//   while
+//     (let m = !i; (m <> n))
+//   invariant b. exists m. 
+//     (pts_to i m  **
+//      pure (b == (m <> n)))
+//   {
+//     let m = !i;
+//     i := m + 1
+//   };
+//   let x = !i;
+//   r := x
+// }
+// ```
+
+
+// let rec sum_spec (n:nat) : nat =
+//   if n = 0 then 0 else n + sum_spec (n - 1)
 
  
-let zero : nat = 0
+// let zero : nat = 0
 
-```pulse
-fn sum (r:ref nat) (n:nat)
-   requires exists i. (pts_to r i)
-   ensures (pts_to r (sum_spec n))
-{
-   let mut i = zero;
-   let mut sum = zero;
-   introduce exists b m s. (
-     pts_to i m  **
-     pts_to sum s  **
-     pure (s == sum_spec m /\
-           b == (m <> n)))
-   with (zero <> n);
-        
-   while (let m = !i; (m <> n))
-   invariant b . exists m s. (
-     pts_to i m  **
-     pts_to sum s  **
-     pure (s == sum_spec m /\
-           b == (m <> n)))
-   {
-     let m = !i;
-     let s = !sum;
-     i := (m + 1);
-     sum := s + m + 1;
-     introduce exists b m s. (
-       pts_to i m  **
-       pts_to sum s  **
-       pure (s == sum_spec m /\
-             b == (m <> n)))
-     with (m + 1 <> n)
-   };
-   let s = !sum;
-   r := s;
-   introduce exists m. (pts_to i m) 
-   with _;
-   introduce exists s. (pts_to sum s)
-   with _
-}
-```
-
-```pulse
-fn sum2 (r:ref nat) (n:nat)
-   requires exists i. pts_to r i
-   ensures pts_to r (sum_spec n)
-{
-   let mut i = zero;
-   let mut sum = zero;
-   while (let m = !i; (m <> n))
-   invariant b . exists m s.
-     pts_to i m  **
-     pts_to sum s **
-     pure (s == sum_spec m /\ b == (m <> n))
-   {
-     let m = !i;
-     let s = !sum;
-     i := (m + 1);
-     sum := s + m + 1;
-     ()
-   };
-   let s = !sum;
-   r := s;
-   ()
-}
-```
-
-```pulse
-fn if_then_else_in_specs (r:ref U32.t)
-  requires `@(if true
-              then pts_to r 0ul
-              else pts_to r 1ul)
-  ensures  `@(if true
-              then pts_to r 1ul
-              else pts_to r 0ul)
-{
-  // need this for typechecking !r on the next line,
-  //   with inference of implicits
-  rewrite `@(if true then pts_to r 0ul else pts_to r 1ul)
-       as (pts_to r 0ul);
-  let x = !r;
-  r := U32.add x 1ul
-}
-```
-
-```pulse
-fn test_tot_let (r:ref U32.t)
-  requires (pts_to r 0ul)
-  ensures  (pts_to r 2ul)
-{
-  let x = 1ul;
-  let y = 1ul;
-  r := U32.add x y
-}
-```
-
-// Ascriptions coming in the way
 // ```pulse
-// fn if_then_else_in_specs2 (r:ref U32.t) (b:bool)
-//   requires (pts_to r (if b then 0ul else 1ul))
-//   ensures (pts_to r (if b then 1ul else 2ul))
+// fn sum (r:ref nat) (n:nat)
+//    requires exists i. (pts_to r i)
+//    ensures (pts_to r (sum_spec n))
 // {
+//    let mut i = zero;
+//    let mut sum = zero;
+//    introduce exists b m s. (
+//      pts_to i m  **
+//      pts_to sum s  **
+//      pure (s == sum_spec m /\
+//            b == (m <> n)))
+//    with (zero <> n);
+        
+//    while (let m = !i; (m <> n))
+//    invariant b . exists m s. (
+//      pts_to i m  **
+//      pts_to sum s  **
+//      pure (s == sum_spec m /\
+//            b == (m <> n)))
+//    {
+//      let m = !i;
+//      let s = !sum;
+//      i := (m + 1);
+//      sum := s + m + 1;
+//      introduce exists b m s. (
+//        pts_to i m  **
+//        pts_to sum s  **
+//        pure (s == sum_spec m /\
+//              b == (m <> n)))
+//      with (m + 1 <> n)
+//    };
+//    let s = !sum;
+//    r := s;
+//    introduce exists m. (pts_to i m) 
+//    with _;
+//    introduce exists s. (pts_to sum s)
+//    with _
+// }
+// ```
+
+// ```pulse
+// fn sum2 (r:ref nat) (n:nat)
+//    requires exists i. pts_to r i
+//    ensures pts_to r (sum_spec n)
+// {
+//    let mut i = zero;
+//    let mut sum = zero;
+//    while (let m = !i; (m <> n))
+//    invariant b . exists m s.
+//      pts_to i m  **
+//      pts_to sum s **
+//      pure (s == sum_spec m /\ b == (m <> n))
+//    {
+//      let m = !i;
+//      let s = !sum;
+//      i := (m + 1);
+//      sum := s + m + 1;
+//      ()
+//    };
+//    let s = !sum;
+//    r := s;
+//    ()
+// }
+// ```
+
+// ```pulse
+// fn if_then_else_in_specs (r:ref U32.t)
+//   requires `@(if true
+//               then pts_to r 0ul
+//               else pts_to r 1ul)
+//   ensures  `@(if true
+//               then pts_to r 1ul
+//               else pts_to r 0ul)
+// {
+//   // need this for typechecking !r on the next line,
+//   //   with inference of implicits
+//   rewrite `@(if true then pts_to r 0ul else pts_to r 1ul)
+//        as (pts_to r 0ul);
 //   let x = !r;
 //   r := U32.add x 1ul
 // }
 // ```
 
+// ```pulse
+// fn test_tot_let (r:ref U32.t)
+//   requires (pts_to r 0ul)
+//   ensures  (pts_to r 2ul)
+// {
+//   let x = 1ul;
+//   let y = 1ul;
+//   r := U32.add x y
+// }
+// ```
 
-```pulse
-fn incr (x:nat)
-  requires emp
-  returns r : (r:nat { r > x })
-  ensures emp
-{
-  let y = x + 1;
-  ( y <: r:nat { r > x } )
-}
-```
+// // Ascriptions coming in the way
+// // ```pulse
+// // fn if_then_else_in_specs2 (r:ref U32.t) (b:bool)
+// //   requires (pts_to r (if b then 0ul else 1ul))
+// //   ensures (pts_to r (if b then 1ul else 2ul))
+// // {
+// //   let x = !r;
+// //   r := U32.add x 1ul
+// // }
+// // ```
+
+
+// ```pulse
+// fn incr (x:nat)
+//   requires emp
+//   returns r : (r:nat { r > x })
+//   ensures emp
+// {
+//   let y = x + 1;
+//   ( y <: r:nat { r > x } )
+// }
+// ```

--- a/share/steel/examples/pulse/ZetaHashAccumulator.fst
+++ b/share/steel/examples/pulse/ZetaHashAccumulator.fst
@@ -204,7 +204,7 @@ let ha_val_core (core:ha_core) (h:hash_value_t)
 // ha_val_core using Pulse's primitive `fold` operation
 ```pulse
 ghost
-fn fold_ha_val_core (h:ha_core) (#acc:Seq.lseq U8.t 32)
+fn fold_ha_val_core (#acc:Seq.lseq U8.t 32) (h:ha_core)
   requires
    A.pts_to h.acc acc **
    pts_to h.ctr n
@@ -218,8 +218,7 @@ fn fold_ha_val_core (h:ha_core) (#acc:Seq.lseq U8.t 32)
 // This too is a bit of boilerplate. It use fold_ha_val_core, but also 
 // creates and returns a new ha_core value
 ```pulse
-fn package_core (acc:hash_value_buf) (ctr:ref U32.t) 
-                (#vacc:erased (Seq.lseq U8.t 32))
+fn package_core (#vacc:erased (Seq.lseq U8.t 32)) (acc:hash_value_buf) (ctr:ref U32.t)
   requires A.pts_to acc vacc **
            pts_to ctr 'vctr 
   returns h:ha_core
@@ -262,7 +261,7 @@ let ha_val (h:ha) (s:hash_value_t) =
 // But, this version is more convenient to use in a manual setting.
 ```pulse
 ghost
-fn fold_ha_val (h:ha) (#acc #s:Seq.lseq U8.t 32)
+fn fold_ha_val (#acc #s:Seq.lseq U8.t 32) (h:ha)
   requires
    A.pts_to h.core.acc acc **
    pts_to h.core.ctr n **
@@ -280,9 +279,10 @@ fn fold_ha_val (h:ha) (#acc #s:Seq.lseq U8.t 32)
 // Again, if we were to do generate this, then the first two conjuncts
 // and acc, ctr arguments would be replaced by ha_core/ha_val_core
 ```pulse
-fn package (acc:hash_value_buf) (ctr:ref U32.t) (tmp:hash_value_buf) (dummy:dummy_buf)
-           (#vacc:erased (Seq.lseq U8.t 32))
-           (#vtmp:erased (Seq.lseq U8.t 32))
+fn package
+  (#vacc:erased (Seq.lseq U8.t 32))
+  (#vtmp:erased (Seq.lseq U8.t 32))
+  (acc:hash_value_buf) (ctr:ref U32.t) (tmp:hash_value_buf) (dummy:dummy_buf)
   requires A.pts_to acc vacc **
            pts_to ctr 'vctr **
            A.pts_to tmp vtmp **
@@ -318,7 +318,7 @@ fn create (_:unit)
 
 // Free'ing an ha
 ```pulse
-fn reclaim (s:ha) (#h:hash_value_t) 
+fn reclaim (#h:hash_value_t) (s:ha)
     requires ha_val s h
     ensures emp
 {
@@ -347,8 +347,8 @@ fn reclaim (s:ha) (#h:hash_value_t)
 // I should try that again and open issues. 
 #push-options "--retry 2 --ext 'pulse:rvalues'" // GM: Part of this VC fails on batch mode, not on ide...
 ```pulse
-fn aggregate_raw_hashes (b1 b2: hash_value_buf)
-                        (#s1 #s2:e_raw_hash_value_t)
+fn aggregate_raw_hashes (#s1 #s2:e_raw_hash_value_t)
+                        (b1 b2: hash_value_buf)
   requires 
     A.pts_to b1 s1 **
     A.pts_to b2 s2

--- a/share/steel/examples/pulse/dice/dpe/DPE.Messages.Parse.fst
+++ b/share/steel/examples/pulse/dice/dpe/DPE.Messages.Parse.fst
@@ -23,7 +23,7 @@ let emp_inames_disjoint (t:inames)
 
 ```pulse
 ghost
-fn elim_implies (_:unit) (#p #q:vprop)
+fn elim_implies (#p #q:vprop) (_:unit)
    requires `@(p @==> q) ** p
    ensures q
 {
@@ -207,10 +207,10 @@ let parse_dpe_cmd_post
     )
 
 ```pulse
-fn parse_dpe_cmd (len:SZ.t)
-                      (input:A.larray U8.t (SZ.v len))
-                      (#s:erased (Seq.seq U8.t))
-                      (#p:perm)
+fn parse_dpe_cmd (#s:erased (Seq.seq U8.t))
+                 (#p:perm)
+                 (len:SZ.t)
+                 (input:A.larray U8.t (SZ.v len))
     requires
         A.pts_to input #p s
     returns res:option dpe_cmd

--- a/share/steel/examples/pulse/dice/dpe/DPE.fst
+++ b/share/steel/examples/pulse/dice/dpe/DPE.fst
@@ -810,8 +810,10 @@ fn init_l1_ctxt (deviceIDCSR_len: US.t) (aliasKeyCRT_len: US.t)
   success and None upon failure. 
 *)
 ```pulse
-fn initialize_context' (sid:sid_t) (uds:A.larray U8.t (US.v uds_len)) 
-                       (#p:perm) (#uds_bytes:Ghost.erased (Seq.seq U8.t))
+fn initialize_context'
+  (#p:perm) (#uds_bytes:Ghost.erased (Seq.seq U8.t))
+  (sid:sid_t) (uds:A.larray U8.t (US.v uds_len)) 
+                       
   requires A.pts_to uds #p uds_bytes
   returns _:option ctxt_hndl_t
   ensures A.pts_to uds #p uds_bytes

--- a/share/steel/examples/pulse/dice/dpe/DPE.fsti
+++ b/share/steel/examples/pulse/dice/dpe/DPE.fsti
@@ -27,10 +27,10 @@ val destroy_context (sid:sid_t) (ctxt_hndl:ctxt_hndl_t) : stt bool emp (fun _ ->
 
 val close_session (sid:sid_t) : stt bool emp (fun _ -> emp)
 
-val initialize_context (sid:sid_t) 
-                       (uds:A.larray U8.t (US.v uds_len))
-                       (#p:perm)
+val initialize_context (#p:perm)
                        (#uds_bytes:erased (Seq.seq U8.t))
+                       (sid:sid_t) 
+                       (uds:A.larray U8.t (US.v uds_len))         
   : stt (option ctxt_hndl_t) 
         (A.pts_to uds #p uds_bytes)
         (fun _ -> A.pts_to uds #p uds_bytes)

--- a/share/steel/examples/pulse/dice/l0/L0Core.fst
+++ b/share/steel/examples/pulse/dice/l0/L0Core.fst
@@ -13,12 +13,12 @@ open HACL
 
 ```pulse
 fn create_deviceIDCRI
+  (#pub_perm:perm)
+  (#pub #_buf:erased (Seq.seq U8.t))
   (deviceID_pub: A.larray U8.t (US.v v32us))
   (deviceIDCRI_len: US.t)
   (deviceIDCRI_buf: A.larray U8.t (US.v deviceIDCRI_len))
   (deviceIDCSR_ingredients: deviceIDCSR_ingredients_t)
-  (#pub_perm:perm)
-  (#pub #_buf:erased (Seq.seq U8.t))
   requires 
     A.pts_to deviceID_pub #pub_perm pub **
     A.pts_to deviceIDCRI_buf _buf **
@@ -60,14 +60,14 @@ fn create_deviceIDCRI
 // TODO: don't need full perm on all of these
 ```pulse
 fn sign_and_finalize_deviceIDCSR
+  (#priv_perm:perm)
+  (#priv #_cri_buf #_csr_buf:erased (Seq.seq U8.t))
   (deviceID_priv: A.larray U8.t (US.v v32us))
   (deviceIDCRI_len: US.t)
   (deviceIDCRI_buf: A.larray U8.t (US.v deviceIDCRI_len))
   (deviceIDCSR_len: US.t)
   (deviceIDCSR_buf: A.larray U8.t (US.v deviceIDCSR_len))
   (deviceIDCSR_ingredients: deviceIDCSR_ingredients_t)
-  (#priv_perm:perm)
-  (#priv #_cri_buf #_csr_buf:erased (Seq.seq U8.t))
   requires (
     A.pts_to deviceID_priv #priv_perm priv **
     A.pts_to deviceIDCRI_buf _cri_buf **
@@ -115,6 +115,8 @@ fn sign_and_finalize_deviceIDCSR
 
 ```pulse
 fn create_aliasKeyTBS
+  (#fwid_perm #authKey_perm #device_perm #aliasKey_perm:perm)
+  (#fwid0 #authKeyID0 #deviceID_pub0 #aliasKey_pub0 #_buf:erased (Seq.seq U8.t))
   (fwid: A.larray U8.t (US.v v32us))
   (authKeyID: A.array U8.t)
   (deviceID_pub: A.larray U8.t (US.v v32us))
@@ -122,8 +124,6 @@ fn create_aliasKeyTBS
   (aliasKeyTBS_len: US.t)
   (aliasKeyTBS_buf: A.larray U8.t (US.v aliasKeyTBS_len))
   (aliasKeyCRT_ingredients: aliasKeyCRT_ingredients_t)
-  (#fwid_perm #authKey_perm #device_perm #aliasKey_perm:perm)
-  (#fwid0 #authKeyID0 #deviceID_pub0 #aliasKey_pub0 #_buf:erased (Seq.seq U8.t))
   requires 
     A.pts_to fwid #fwid_perm fwid0 **
     A.pts_to authKeyID #authKey_perm authKeyID0 **
@@ -170,14 +170,14 @@ fn create_aliasKeyTBS
 
 ```pulse
 fn sign_and_finalize_aliasKeyCRT
+  (#priv_perm:perm)
+  (#priv #_tbs_buf #_crt_buf:erased (Seq.seq U8.t))
   (deviceID_priv: A.larray U8.t (US.v v32us))
   (aliasKeyTBS_len: US.t)
   (aliasKeyTBS_buf: A.larray U8.t (US.v aliasKeyTBS_len))
   (aliasKeyCRT_len: US.t)
   (aliasKeyCRT_buf: A.larray U8.t (US.v aliasKeyCRT_len))
   (aliasKeyCRT_ingredients: aliasKeyCRT_ingredients_t)
-  (#priv_perm:perm)
-  (#priv #_tbs_buf #_crt_buf:erased (Seq.seq U8.t))
   requires (
     A.pts_to deviceID_priv #priv_perm priv **
     A.pts_to aliasKeyTBS_buf _tbs_buf **

--- a/src/ocaml/plugin/generated/Pulse_Checker_Pure.ml
+++ b/src/ocaml/plugin/generated/Pulse_Checker_Pure.ml
@@ -2386,6 +2386,607 @@ let (instantiate_term_implicits :
                                                                     uu___3)))
                                                              uu___1))) uu___)))
                                    uu___))) uu___))) uu___)
+let (instantiate_term_implicits_uvs :
+  Pulse_Typing_Env.env ->
+    Pulse_Syntax_Base.term ->
+      ((Pulse_Typing_Env.env, Pulse_Syntax_Base.term, Pulse_Syntax_Base.term)
+         FStar_Pervasives.dtuple3,
+        unit) FStar_Tactics_Effect.tac_repr)
+  =
+  fun g ->
+    fun t0 ->
+      FStar_Tactics_Effect.tac_bind
+        (FStar_Sealed.seal
+           (Obj.magic
+              (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
+                 (Prims.of_int (186)) (Prims.of_int (10))
+                 (Prims.of_int (186)) (Prims.of_int (20)))))
+        (FStar_Sealed.seal
+           (Obj.magic
+              (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
+                 (Prims.of_int (186)) (Prims.of_int (23))
+                 (Prims.of_int (226)) (Prims.of_int (49)))))
+        (FStar_Tactics_Effect.lift_div_tac
+           (fun uu___ -> Pulse_Typing.elab_env g))
+        (fun uu___ ->
+           (fun f ->
+              Obj.magic
+                (FStar_Tactics_Effect.tac_bind
+                   (FStar_Sealed.seal
+                      (Obj.magic
+                         (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
+                            (Prims.of_int (187)) (Prims.of_int (11))
+                            (Prims.of_int (187)) (Prims.of_int (23)))))
+                   (FStar_Sealed.seal
+                      (Obj.magic
+                         (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
+                            (Prims.of_int (187)) (Prims.of_int (26))
+                            (Prims.of_int (226)) (Prims.of_int (49)))))
+                   (FStar_Tactics_Effect.lift_div_tac
+                      (fun uu___ -> Pulse_Elaborate_Pure.elab_term t0))
+                   (fun uu___ ->
+                      (fun rt ->
+                         Obj.magic
+                           (FStar_Tactics_Effect.tac_bind
+                              (FStar_Sealed.seal
+                                 (Obj.magic
+                                    (FStar_Range.mk_range
+                                       "Pulse.Checker.Pure.fst"
+                                       (Prims.of_int (188))
+                                       (Prims.of_int (10))
+                                       (Prims.of_int (188))
+                                       (Prims.of_int (75)))))
+                              (FStar_Sealed.seal
+                                 (Obj.magic
+                                    (FStar_Range.mk_range
+                                       "Pulse.Checker.Pure.fst"
+                                       (Prims.of_int (188))
+                                       (Prims.of_int (78))
+                                       (Prims.of_int (226))
+                                       (Prims.of_int (49)))))
+                              (Obj.magic
+                                 (FStar_Tactics_Effect.tac_bind
+                                    (FStar_Sealed.seal
+                                       (Obj.magic
+                                          (FStar_Range.mk_range
+                                             "Pulse.Checker.Pure.fst"
+                                             (Prims.of_int (188))
+                                             (Prims.of_int (29))
+                                             (Prims.of_int (188))
+                                             (Prims.of_int (75)))))
+                                    (FStar_Sealed.seal
+                                       (Obj.magic
+                                          (FStar_Range.mk_range
+                                             "Pulse.Checker.Pure.fst"
+                                             (Prims.of_int (188))
+                                             (Prims.of_int (10))
+                                             (Prims.of_int (188))
+                                             (Prims.of_int (75)))))
+                                    (Obj.magic
+                                       (Pulse_Typing_Env.get_range g
+                                          (FStar_Pervasives_Native.Some
+                                             (t0.Pulse_Syntax_Base.range1))))
+                                    (fun uu___ ->
+                                       FStar_Tactics_Effect.lift_div_tac
+                                         (fun uu___1 ->
+                                            Pulse_RuntimeUtils.env_set_range
+                                              f uu___))))
+                              (fun uu___ ->
+                                 (fun f1 ->
+                                    Obj.magic
+                                      (FStar_Tactics_Effect.tac_bind
+                                         (FStar_Sealed.seal
+                                            (Obj.magic
+                                               (FStar_Range.mk_range
+                                                  "Pulse.Checker.Pure.fst"
+                                                  (Prims.of_int (189))
+                                                  (Prims.of_int (21))
+                                                  (Prims.of_int (189))
+                                                  (Prims.of_int (74)))))
+                                         (FStar_Sealed.seal
+                                            (Obj.magic
+                                               (FStar_Range.mk_range
+                                                  "Pulse.Checker.Pure.fst"
+                                                  (Prims.of_int (188))
+                                                  (Prims.of_int (78))
+                                                  (Prims.of_int (226))
+                                                  (Prims.of_int (49)))))
+                                         (Obj.magic
+                                            (catch_all
+                                               (fun uu___ ->
+                                                  rtb_instantiate_implicits g
+                                                    f1 rt)))
+                                         (fun uu___ ->
+                                            (fun uu___ ->
+                                               match uu___ with
+                                               | (topt, issues) ->
+                                                   Obj.magic
+                                                     (FStar_Tactics_Effect.tac_bind
+                                                        (FStar_Sealed.seal
+                                                           (Obj.magic
+                                                              (FStar_Range.mk_range
+                                                                 "Pulse.Checker.Pure.fst"
+                                                                 (Prims.of_int (190))
+                                                                 (Prims.of_int (2))
+                                                                 (Prims.of_int (190))
+                                                                 (Prims.of_int (21)))))
+                                                        (FStar_Sealed.seal
+                                                           (Obj.magic
+                                                              (FStar_Range.mk_range
+                                                                 "Pulse.Checker.Pure.fst"
+                                                                 (Prims.of_int (191))
+                                                                 (Prims.of_int (2))
+                                                                 (Prims.of_int (226))
+                                                                 (Prims.of_int (49)))))
+                                                        (Obj.magic
+                                                           (FStar_Tactics_V2_Builtins.log_issues
+                                                              issues))
+                                                        (fun uu___1 ->
+                                                           (fun uu___1 ->
+                                                              match topt with
+                                                              | FStar_Pervasives_Native.None
+                                                                  ->
+                                                                  Obj.magic
+                                                                    (
+                                                                    FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Pure.fst"
+                                                                    (Prims.of_int (195))
+                                                                    (Prims.of_int (20))
+                                                                    (Prims.of_int (198))
+                                                                    (Prims.of_int (13)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Pure.fst"
+                                                                    (Prims.of_int (194))
+                                                                    (Prims.of_int (4))
+                                                                    (Prims.of_int (198))
+                                                                    (Prims.of_int (13)))))
+                                                                    (Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Pure.fst"
+                                                                    (Prims.of_int (196))
+                                                                    (Prims.of_int (14))
+                                                                    (Prims.of_int (197))
+                                                                    (Prims.of_int (31)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Pure.fst"
+                                                                    (Prims.of_int (195))
+                                                                    (Prims.of_int (20))
+                                                                    (Prims.of_int (198))
+                                                                    (Prims.of_int (13)))))
+                                                                    (Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Pure.fst"
+                                                                    (Prims.of_int (197))
+                                                                    (Prims.of_int (24))
+                                                                    (Prims.of_int (197))
+                                                                    (Prims.of_int (31)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Pure.fst"
+                                                                    (Prims.of_int (196))
+                                                                    (Prims.of_int (14))
+                                                                    (Prims.of_int (197))
+                                                                    (Prims.of_int (31)))))
+                                                                    (Obj.magic
+                                                                    (Pulse_PP.pp
+                                                                    Pulse_PP.uu___44
+                                                                    t0))
+                                                                    (fun
+                                                                    uu___2 ->
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___3 ->
+                                                                    FStar_Pprint.prefix
+                                                                    (Prims.of_int (4))
+                                                                    Prims.int_one
+                                                                    (Pulse_PP.text
+                                                                    "Could not infer implicit arguments in")
+                                                                    uu___2))))
+                                                                    (fun
+                                                                    uu___2 ->
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___3 ->
+                                                                    [uu___2]))))
+                                                                    (fun
+                                                                    uu___2 ->
+                                                                    (fun
+                                                                    uu___2 ->
+                                                                    Obj.magic
+                                                                    (maybe_fail_doc
+                                                                    issues g
+                                                                    t0.Pulse_Syntax_Base.range1
+                                                                    uu___2))
+                                                                    uu___2))
+                                                              | FStar_Pervasives_Native.Some
+                                                                  (namedvs,
+                                                                   t, ty)
+                                                                  ->
+                                                                  Obj.magic
+                                                                    (
+                                                                    FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Pure.fst"
+                                                                    (Prims.of_int (201))
+                                                                    (Prims.of_int (15))
+                                                                    (Prims.of_int (201))
+                                                                    (Prims.of_int (28)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Pure.fst"
+                                                                    (Prims.of_int (201))
+                                                                    (Prims.of_int (31))
+                                                                    (Prims.of_int (226))
+                                                                    (Prims.of_int (49)))))
+                                                                    (FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___2 ->
+                                                                    Pulse_Readback.readback_ty
+                                                                    t))
+                                                                    (fun
+                                                                    uu___2 ->
+                                                                    (fun
+                                                                    topt1 ->
+                                                                    Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Pure.fst"
+                                                                    (Prims.of_int (202))
+                                                                    (Prims.of_int (16))
+                                                                    (Prims.of_int (202))
+                                                                    (Prims.of_int (30)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Pure.fst"
+                                                                    (Prims.of_int (203))
+                                                                    (Prims.of_int (4))
+                                                                    (Prims.of_int (226))
+                                                                    (Prims.of_int (49)))))
+                                                                    (FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___2 ->
+                                                                    Pulse_Readback.readback_ty
+                                                                    ty))
+                                                                    (fun
+                                                                    uu___2 ->
+                                                                    (fun
+                                                                    tyopt ->
+                                                                    match 
+                                                                    (topt1,
+                                                                    tyopt)
+                                                                    with
+                                                                    | 
+                                                                    (FStar_Pervasives_Native.Some
+                                                                    t1,
+                                                                    FStar_Pervasives_Native.Some
+                                                                    ty1) ->
+                                                                    Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Pure.fst"
+                                                                    (Prims.of_int (209))
+                                                                    (Prims.of_int (8))
+                                                                    (Prims.of_int (221))
+                                                                    (Prims.of_int (80)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Pure.fst"
+                                                                    (Prims.of_int (204))
+                                                                    (Prims.of_int (24))
+                                                                    (Prims.of_int (222))
+                                                                    (Prims.of_int (22)))))
+                                                                    (Obj.magic
+                                                                    (FStar_Tactics_Util.fold_left
+                                                                    (fun
+                                                                    uu___2 ->
+                                                                    fun
+                                                                    uu___3 ->
+                                                                    match 
+                                                                    (uu___2,
+                                                                    uu___3)
+                                                                    with
+                                                                    | 
+                                                                    (FStar_Pervasives.Mkdtuple3
+                                                                    (uvs, t2,
+                                                                    ty2),
+                                                                    (namedv,
+                                                                    namedvt))
+                                                                    ->
+                                                                    FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Pure.fst"
+                                                                    (Prims.of_int (210))
+                                                                    (Prims.of_int (22))
+                                                                    (Prims.of_int (210))
+                                                                    (Prims.of_int (45)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Pure.fst"
+                                                                    (Prims.of_int (210))
+                                                                    (Prims.of_int (48))
+                                                                    (Prims.of_int (221))
+                                                                    (Prims.of_int (37)))))
+                                                                    (FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___4 ->
+                                                                    FStar_Reflection_V2_Builtins.inspect_namedv
+                                                                    namedv))
+                                                                    (fun
+                                                                    uu___4 ->
+                                                                    (fun
+                                                                    nview ->
+                                                                    Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Pure.fst"
+                                                                    (Prims.of_int (211))
+                                                                    (Prims.of_int (25))
+                                                                    (Prims.of_int (211))
+                                                                    (Prims.of_int (62)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Pure.fst"
+                                                                    (Prims.of_int (211))
+                                                                    (Prims.of_int (67))
+                                                                    (Prims.of_int (221))
+                                                                    (Prims.of_int (37)))))
+                                                                    (FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___4 ->
+                                                                    {
+                                                                    Pulse_Syntax_Base.name
+                                                                    =
+                                                                    (nview.FStar_Reflection_V2_Data.ppname);
+                                                                    Pulse_Syntax_Base.range
+                                                                    =
+                                                                    (t0.Pulse_Syntax_Base.range1)
+                                                                    }))
+                                                                    (fun
+                                                                    uu___4 ->
+                                                                    (fun
+                                                                    ppname ->
+                                                                    Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Pure.fst"
+                                                                    (Prims.of_int (212))
+                                                                    (Prims.of_int (19))
+                                                                    (Prims.of_int (212))
+                                                                    (Prims.of_int (38)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Pure.fst"
+                                                                    (Prims.of_int (213))
+                                                                    (Prims.of_int (10))
+                                                                    (Prims.of_int (221))
+                                                                    (Prims.of_int (37)))))
+                                                                    (FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___4 ->
+                                                                    Pulse_Readback.readback_ty
+                                                                    namedvt))
+                                                                    (fun
+                                                                    uu___4 ->
+                                                                    (fun xt
+                                                                    ->
+                                                                    if
+                                                                    FStar_Pervasives_Native.uu___is_None
+                                                                    xt
+                                                                    then
+                                                                    Obj.magic
+                                                                    (Obj.repr
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Pure.fst"
+                                                                    (Prims.of_int (214))
+                                                                    (Prims.of_int (38))
+                                                                    (Prims.of_int (214))
+                                                                    (Prims.of_int (64)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Pure.fst"
+                                                                    (Prims.of_int (214))
+                                                                    (Prims.of_int (15))
+                                                                    (Prims.of_int (214))
+                                                                    (Prims.of_int (64)))))
+                                                                    (Obj.magic
+                                                                    (readback_failure
+                                                                    namedvt))
+                                                                    (fun
+                                                                    uu___4 ->
+                                                                    (fun
+                                                                    uu___4 ->
+                                                                    Obj.magic
+                                                                    (Pulse_Typing_Env.fail
+                                                                    g
+                                                                    (FStar_Pervasives_Native.Some
+                                                                    (t0.Pulse_Syntax_Base.range1))
+                                                                    uu___4))
+                                                                    uu___4)))
+                                                                    else
+                                                                    Obj.magic
+                                                                    (Obj.repr
+                                                                    (FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___5 ->
+                                                                    match xt
+                                                                    with
+                                                                    | 
+                                                                    FStar_Pervasives_Native.Some
+                                                                    xt1 ->
+                                                                    FStar_Pervasives.Mkdtuple3
+                                                                    ((Pulse_Typing_Env.push_binding
+                                                                    uvs
+                                                                    (Pulse_Typing_Env.fresh
+                                                                    (Pulse_Typing_Env.push_env
+                                                                    g uvs))
+                                                                    ppname
+                                                                    xt1),
+                                                                    (Pulse_Syntax_Naming.subst_term
+                                                                    t2
+                                                                    [
+                                                                    Pulse_Syntax_Naming.NT
+                                                                    ((nview.FStar_Reflection_V2_Data.uniq),
+                                                                    (Pulse_Syntax_Pure.tm_var
+                                                                    {
+                                                                    Pulse_Syntax_Base.nm_index
+                                                                    =
+                                                                    (Pulse_Typing_Env.fresh
+                                                                    (Pulse_Typing_Env.push_env
+                                                                    g uvs));
+                                                                    Pulse_Syntax_Base.nm_ppname
+                                                                    = ppname
+                                                                    }))]),
+                                                                    (Pulse_Syntax_Naming.subst_term
+                                                                    ty2
+                                                                    [
+                                                                    Pulse_Syntax_Naming.NT
+                                                                    ((nview.FStar_Reflection_V2_Data.uniq),
+                                                                    (Pulse_Syntax_Pure.tm_var
+                                                                    {
+                                                                    Pulse_Syntax_Base.nm_index
+                                                                    =
+                                                                    (Pulse_Typing_Env.fresh
+                                                                    (Pulse_Typing_Env.push_env
+                                                                    g uvs));
+                                                                    Pulse_Syntax_Base.nm_ppname
+                                                                    = ppname
+                                                                    }))]))))))
+                                                                    uu___4)))
+                                                                    uu___4)))
+                                                                    uu___4))
+                                                                    (FStar_Pervasives.Mkdtuple3
+                                                                    ((Pulse_Typing_Env.mk_env
+                                                                    (Pulse_Typing_Env.fstar_env
+                                                                    g)), t1,
+                                                                    ty1))
+                                                                    namedvs))
+                                                                    (fun
+                                                                    uu___2 ->
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___3 ->
+                                                                    match uu___2
+                                                                    with
+                                                                    | 
+                                                                    FStar_Pervasives.Mkdtuple3
+                                                                    (uvs, t2,
+                                                                    ty2) ->
+                                                                    FStar_Pervasives.Mkdtuple3
+                                                                    (uvs, t2,
+                                                                    ty2))))
+                                                                    | 
+                                                                    (FStar_Pervasives_Native.Some
+                                                                    uu___2,
+                                                                    FStar_Pervasives_Native.None)
+                                                                    ->
+                                                                    Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Pure.fst"
+                                                                    (Prims.of_int (224))
+                                                                    (Prims.of_int (29))
+                                                                    (Prims.of_int (224))
+                                                                    (Prims.of_int (50)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Pure.fst"
+                                                                    (Prims.of_int (224))
+                                                                    (Prims.of_int (6))
+                                                                    (Prims.of_int (224))
+                                                                    (Prims.of_int (50)))))
+                                                                    (Obj.magic
+                                                                    (readback_failure
+                                                                    ty))
+                                                                    (fun
+                                                                    uu___3 ->
+                                                                    (fun
+                                                                    uu___3 ->
+                                                                    Obj.magic
+                                                                    (Pulse_Typing_Env.fail
+                                                                    g
+                                                                    (FStar_Pervasives_Native.Some
+                                                                    (t0.Pulse_Syntax_Base.range1))
+                                                                    uu___3))
+                                                                    uu___3))
+                                                                    | 
+                                                                    (FStar_Pervasives_Native.None,
+                                                                    uu___2)
+                                                                    ->
+                                                                    Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Pure.fst"
+                                                                    (Prims.of_int (226))
+                                                                    (Prims.of_int (29))
+                                                                    (Prims.of_int (226))
+                                                                    (Prims.of_int (49)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Pure.fst"
+                                                                    (Prims.of_int (226))
+                                                                    (Prims.of_int (6))
+                                                                    (Prims.of_int (226))
+                                                                    (Prims.of_int (49)))))
+                                                                    (Obj.magic
+                                                                    (readback_failure
+                                                                    t))
+                                                                    (fun
+                                                                    uu___3 ->
+                                                                    (fun
+                                                                    uu___3 ->
+                                                                    Obj.magic
+                                                                    (Pulse_Typing_Env.fail
+                                                                    g
+                                                                    (FStar_Pervasives_Native.Some
+                                                                    (t0.Pulse_Syntax_Base.range1))
+                                                                    uu___3))
+                                                                    uu___3)))
+                                                                    uu___2)))
+                                                                    uu___2)))
+                                                             uu___1))) uu___)))
+                                   uu___))) uu___))) uu___)
 let (check_universe :
   Pulse_Typing_Env.env ->
     Pulse_Syntax_Base.term ->
@@ -2398,13 +2999,13 @@ let (check_universe :
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                 (Prims.of_int (187)) (Prims.of_int (12))
-                 (Prims.of_int (187)) (Prims.of_int (22)))))
+                 (Prims.of_int (230)) (Prims.of_int (12))
+                 (Prims.of_int (230)) (Prims.of_int (22)))))
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                 (Prims.of_int (187)) (Prims.of_int (25))
-                 (Prims.of_int (202)) (Prims.of_int (23)))))
+                 (Prims.of_int (230)) (Prims.of_int (25))
+                 (Prims.of_int (245)) (Prims.of_int (23)))))
         (FStar_Tactics_Effect.lift_div_tac
            (fun uu___ -> Pulse_Typing.elab_env g))
         (fun uu___ ->
@@ -2414,13 +3015,13 @@ let (check_universe :
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                            (Prims.of_int (188)) (Prims.of_int (13))
-                            (Prims.of_int (188)) (Prims.of_int (24)))))
+                            (Prims.of_int (231)) (Prims.of_int (13))
+                            (Prims.of_int (231)) (Prims.of_int (24)))))
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                            (Prims.of_int (188)) (Prims.of_int (27))
-                            (Prims.of_int (202)) (Prims.of_int (23)))))
+                            (Prims.of_int (231)) (Prims.of_int (27))
+                            (Prims.of_int (245)) (Prims.of_int (23)))))
                    (FStar_Tactics_Effect.lift_div_tac
                       (fun uu___ -> Pulse_Elaborate_Pure.elab_term t))
                    (fun uu___ ->
@@ -2431,17 +3032,17 @@ let (check_universe :
                                  (Obj.magic
                                     (FStar_Range.mk_range
                                        "Pulse.Checker.Pure.fst"
-                                       (Prims.of_int (189))
+                                       (Prims.of_int (232))
                                        (Prims.of_int (25))
-                                       (Prims.of_int (189))
+                                       (Prims.of_int (232))
                                        (Prims.of_int (68)))))
                               (FStar_Sealed.seal
                                  (Obj.magic
                                     (FStar_Range.mk_range
                                        "Pulse.Checker.Pure.fst"
-                                       (Prims.of_int (188))
+                                       (Prims.of_int (231))
                                        (Prims.of_int (27))
-                                       (Prims.of_int (202))
+                                       (Prims.of_int (245))
                                        (Prims.of_int (23)))))
                               (Obj.magic
                                  (catch_all
@@ -2456,17 +3057,17 @@ let (check_universe :
                                                 (Obj.magic
                                                    (FStar_Range.mk_range
                                                       "Pulse.Checker.Pure.fst"
-                                                      (Prims.of_int (190))
+                                                      (Prims.of_int (233))
                                                       (Prims.of_int (4))
-                                                      (Prims.of_int (190))
+                                                      (Prims.of_int (233))
                                                       (Prims.of_int (23)))))
                                              (FStar_Sealed.seal
                                                 (Obj.magic
                                                    (FStar_Range.mk_range
                                                       "Pulse.Checker.Pure.fst"
-                                                      (Prims.of_int (191))
+                                                      (Prims.of_int (234))
                                                       (Prims.of_int (4))
-                                                      (Prims.of_int (202))
+                                                      (Prims.of_int (245))
                                                       (Prims.of_int (23)))))
                                              (Obj.magic
                                                 (FStar_Tactics_V2_Builtins.log_issues
@@ -2483,17 +3084,17 @@ let (check_universe :
                                                                   (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (195))
+                                                                    (Prims.of_int (238))
                                                                     (Prims.of_int (18))
-                                                                    (Prims.of_int (195))
+                                                                    (Prims.of_int (238))
                                                                     (Prims.of_int (68)))))
                                                                (FStar_Sealed.seal
                                                                   (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (193))
+                                                                    (Prims.of_int (236))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (195))
+                                                                    (Prims.of_int (238))
                                                                     (Prims.of_int (68)))))
                                                                (Obj.magic
                                                                   (ill_typed_term
@@ -2539,25 +3140,25 @@ let (tc_meta_callback :
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                   (Prims.of_int (207)) (Prims.of_int (6))
-                   (Prims.of_int (212)) (Prims.of_int (14)))))
+                   (Prims.of_int (250)) (Prims.of_int (6))
+                   (Prims.of_int (255)) (Prims.of_int (14)))))
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                   (Prims.of_int (206)) (Prims.of_int (8))
-                   (Prims.of_int (206)) (Prims.of_int (11)))))
+                   (Prims.of_int (249)) (Prims.of_int (8))
+                   (Prims.of_int (249)) (Prims.of_int (11)))))
           (Obj.magic
              (FStar_Tactics_Effect.tac_bind
                 (FStar_Sealed.seal
                    (Obj.magic
                       (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                         (Prims.of_int (207)) (Prims.of_int (12))
-                         (Prims.of_int (207)) (Prims.of_int (50)))))
+                         (Prims.of_int (250)) (Prims.of_int (12))
+                         (Prims.of_int (250)) (Prims.of_int (50)))))
                 (FStar_Sealed.seal
                    (Obj.magic
                       (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                         (Prims.of_int (207)) (Prims.of_int (6))
-                         (Prims.of_int (212)) (Prims.of_int (14)))))
+                         (Prims.of_int (250)) (Prims.of_int (6))
+                         (Prims.of_int (255)) (Prims.of_int (14)))))
                 (Obj.magic (catch_all (fun uu___ -> rtb_tc_term g f e)))
                 (fun uu___ ->
                    FStar_Tactics_Effect.lift_div_tac
@@ -2586,13 +3187,13 @@ let (compute_term_type :
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                 (Prims.of_int (221)) (Prims.of_int (13))
-                 (Prims.of_int (221)) (Prims.of_int (23)))))
+                 (Prims.of_int (264)) (Prims.of_int (13))
+                 (Prims.of_int (264)) (Prims.of_int (23)))))
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                 (Prims.of_int (221)) (Prims.of_int (26))
-                 (Prims.of_int (237)) (Prims.of_int (50)))))
+                 (Prims.of_int (264)) (Prims.of_int (26))
+                 (Prims.of_int (280)) (Prims.of_int (50)))))
         (FStar_Tactics_Effect.lift_div_tac
            (fun uu___ -> Pulse_Typing.elab_env g))
         (fun uu___ ->
@@ -2602,13 +3203,13 @@ let (compute_term_type :
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                            (Prims.of_int (222)) (Prims.of_int (13))
-                            (Prims.of_int (222)) (Prims.of_int (24)))))
+                            (Prims.of_int (265)) (Prims.of_int (13))
+                            (Prims.of_int (265)) (Prims.of_int (24)))))
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                            (Prims.of_int (223)) (Prims.of_int (4))
-                            (Prims.of_int (237)) (Prims.of_int (50)))))
+                            (Prims.of_int (266)) (Prims.of_int (4))
+                            (Prims.of_int (280)) (Prims.of_int (50)))))
                    (FStar_Tactics_Effect.lift_div_tac
                       (fun uu___ -> Pulse_Elaborate_Pure.elab_term t))
                    (fun uu___ ->
@@ -2619,17 +3220,17 @@ let (compute_term_type :
                                  (Obj.magic
                                     (FStar_Range.mk_range
                                        "Pulse.Checker.Pure.fst"
-                                       (Prims.of_int (223))
+                                       (Prims.of_int (266))
                                        (Prims.of_int (4))
-                                       (Prims.of_int (226))
+                                       (Prims.of_int (269))
                                        (Prims.of_int (44)))))
                               (FStar_Sealed.seal
                                  (Obj.magic
                                     (FStar_Range.mk_range
                                        "Pulse.Checker.Pure.fst"
-                                       (Prims.of_int (226))
+                                       (Prims.of_int (269))
                                        (Prims.of_int (45))
-                                       (Prims.of_int (237))
+                                       (Prims.of_int (280))
                                        (Prims.of_int (50)))))
                               (Obj.magic
                                  (debug g
@@ -2639,17 +3240,17 @@ let (compute_term_type :
                                             (Obj.magic
                                                (FStar_Range.mk_range
                                                   "Pulse.Checker.Pure.fst"
-                                                  (Prims.of_int (226))
+                                                  (Prims.of_int (269))
                                                   (Prims.of_int (22))
-                                                  (Prims.of_int (226))
+                                                  (Prims.of_int (269))
                                                   (Prims.of_int (43)))))
                                          (FStar_Sealed.seal
                                             (Obj.magic
                                                (FStar_Range.mk_range
                                                   "Pulse.Checker.Pure.fst"
-                                                  (Prims.of_int (224))
+                                                  (Prims.of_int (267))
                                                   (Prims.of_int (12))
-                                                  (Prims.of_int (226))
+                                                  (Prims.of_int (269))
                                                   (Prims.of_int (43)))))
                                          (Obj.magic
                                             (FStar_Tactics_V2_Builtins.term_to_string
@@ -2662,17 +3263,17 @@ let (compute_term_type :
                                                        (Obj.magic
                                                           (FStar_Range.mk_range
                                                              "Pulse.Checker.Pure.fst"
-                                                             (Prims.of_int (224))
+                                                             (Prims.of_int (267))
                                                              (Prims.of_int (12))
-                                                             (Prims.of_int (226))
+                                                             (Prims.of_int (269))
                                                              (Prims.of_int (43)))))
                                                     (FStar_Sealed.seal
                                                        (Obj.magic
                                                           (FStar_Range.mk_range
                                                              "Pulse.Checker.Pure.fst"
-                                                             (Prims.of_int (224))
+                                                             (Prims.of_int (267))
                                                              (Prims.of_int (12))
-                                                             (Prims.of_int (226))
+                                                             (Prims.of_int (269))
                                                              (Prims.of_int (43)))))
                                                     (Obj.magic
                                                        (FStar_Tactics_Effect.tac_bind
@@ -2680,9 +3281,9 @@ let (compute_term_type :
                                                              (Obj.magic
                                                                 (FStar_Range.mk_range
                                                                    "Pulse.Checker.Pure.fst"
-                                                                   (Prims.of_int (225))
+                                                                   (Prims.of_int (268))
                                                                    (Prims.of_int (22))
-                                                                   (Prims.of_int (225))
+                                                                   (Prims.of_int (268))
                                                                    (Prims.of_int (42)))))
                                                           (FStar_Sealed.seal
                                                              (Obj.magic
@@ -2720,17 +3321,17 @@ let (compute_term_type :
                                             (Obj.magic
                                                (FStar_Range.mk_range
                                                   "Pulse.Checker.Pure.fst"
-                                                  (Prims.of_int (227))
+                                                  (Prims.of_int (270))
                                                   (Prims.of_int (22))
-                                                  (Prims.of_int (227))
+                                                  (Prims.of_int (270))
                                                   (Prims.of_int (46)))))
                                          (FStar_Sealed.seal
                                             (Obj.magic
                                                (FStar_Range.mk_range
                                                   "Pulse.Checker.Pure.fst"
-                                                  (Prims.of_int (226))
+                                                  (Prims.of_int (269))
                                                   (Prims.of_int (45))
-                                                  (Prims.of_int (237))
+                                                  (Prims.of_int (280))
                                                   (Prims.of_int (50)))))
                                          (Obj.magic
                                             (tc_meta_callback g fg rt))
@@ -2744,17 +3345,17 @@ let (compute_term_type :
                                                            (Obj.magic
                                                               (FStar_Range.mk_range
                                                                  "Pulse.Checker.Pure.fst"
-                                                                 (Prims.of_int (228))
+                                                                 (Prims.of_int (271))
                                                                  (Prims.of_int (4))
-                                                                 (Prims.of_int (228))
+                                                                 (Prims.of_int (271))
                                                                  (Prims.of_int (23)))))
                                                         (FStar_Sealed.seal
                                                            (Obj.magic
                                                               (FStar_Range.mk_range
                                                                  "Pulse.Checker.Pure.fst"
-                                                                 (Prims.of_int (229))
+                                                                 (Prims.of_int (272))
                                                                  (Prims.of_int (4))
-                                                                 (Prims.of_int (237))
+                                                                 (Prims.of_int (280))
                                                                  (Prims.of_int (50)))))
                                                         (Obj.magic
                                                            (FStar_Tactics_V2_Builtins.log_issues
@@ -2772,17 +3373,17 @@ let (compute_term_type :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (232))
+                                                                    (Prims.of_int (275))
                                                                     (Prims.of_int (22))
-                                                                    (Prims.of_int (232))
+                                                                    (Prims.of_int (275))
                                                                     (Prims.of_int (50)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (231))
+                                                                    (Prims.of_int (274))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (232))
+                                                                    (Prims.of_int (275))
                                                                     (Prims.of_int (50)))))
                                                                     (Obj.magic
                                                                     (ill_typed_term
@@ -2823,17 +3424,17 @@ let (compute_term_type :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (235))
+                                                                    (Prims.of_int (278))
                                                                     (Prims.of_int (41))
-                                                                    (Prims.of_int (235))
+                                                                    (Prims.of_int (278))
                                                                     (Prims.of_int (62)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (235))
+                                                                    (Prims.of_int (278))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (235))
+                                                                    (Prims.of_int (278))
                                                                     (Prims.of_int (62)))))
                                                                     (Obj.magic
                                                                     (readback_failure
@@ -2859,17 +3460,17 @@ let (compute_term_type :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (236))
+                                                                    (Prims.of_int (279))
                                                                     (Prims.of_int (41))
-                                                                    (Prims.of_int (236))
+                                                                    (Prims.of_int (279))
                                                                     (Prims.of_int (63)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (236))
+                                                                    (Prims.of_int (279))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (236))
+                                                                    (Prims.of_int (279))
                                                                     (Prims.of_int (63)))))
                                                                     (Obj.magic
                                                                     (readback_failure
@@ -2914,13 +3515,13 @@ let (compute_term_type_and_u :
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                 (Prims.of_int (246)) (Prims.of_int (13))
-                 (Prims.of_int (246)) (Prims.of_int (23)))))
+                 (Prims.of_int (289)) (Prims.of_int (13))
+                 (Prims.of_int (289)) (Prims.of_int (23)))))
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                 (Prims.of_int (246)) (Prims.of_int (26))
-                 (Prims.of_int (261)) (Prims.of_int (45)))))
+                 (Prims.of_int (289)) (Prims.of_int (26))
+                 (Prims.of_int (304)) (Prims.of_int (45)))))
         (FStar_Tactics_Effect.lift_div_tac
            (fun uu___ -> Pulse_Typing.elab_env g))
         (fun uu___ ->
@@ -2930,13 +3531,13 @@ let (compute_term_type_and_u :
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                            (Prims.of_int (247)) (Prims.of_int (13))
-                            (Prims.of_int (247)) (Prims.of_int (24)))))
+                            (Prims.of_int (290)) (Prims.of_int (13))
+                            (Prims.of_int (290)) (Prims.of_int (24)))))
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                            (Prims.of_int (247)) (Prims.of_int (27))
-                            (Prims.of_int (261)) (Prims.of_int (45)))))
+                            (Prims.of_int (290)) (Prims.of_int (27))
+                            (Prims.of_int (304)) (Prims.of_int (45)))))
                    (FStar_Tactics_Effect.lift_div_tac
                       (fun uu___ -> Pulse_Elaborate_Pure.elab_term t))
                    (fun uu___ ->
@@ -2947,17 +3548,17 @@ let (compute_term_type_and_u :
                                  (Obj.magic
                                     (FStar_Range.mk_range
                                        "Pulse.Checker.Pure.fst"
-                                       (Prims.of_int (248))
+                                       (Prims.of_int (291))
                                        (Prims.of_int (22))
-                                       (Prims.of_int (248))
+                                       (Prims.of_int (291))
                                        (Prims.of_int (46)))))
                               (FStar_Sealed.seal
                                  (Obj.magic
                                     (FStar_Range.mk_range
                                        "Pulse.Checker.Pure.fst"
-                                       (Prims.of_int (247))
+                                       (Prims.of_int (290))
                                        (Prims.of_int (27))
-                                       (Prims.of_int (261))
+                                       (Prims.of_int (304))
                                        (Prims.of_int (45)))))
                               (Obj.magic (tc_meta_callback g fg rt))
                               (fun uu___ ->
@@ -2970,17 +3571,17 @@ let (compute_term_type_and_u :
                                                 (Obj.magic
                                                    (FStar_Range.mk_range
                                                       "Pulse.Checker.Pure.fst"
-                                                      (Prims.of_int (249))
+                                                      (Prims.of_int (292))
                                                       (Prims.of_int (4))
-                                                      (Prims.of_int (249))
+                                                      (Prims.of_int (292))
                                                       (Prims.of_int (23)))))
                                              (FStar_Sealed.seal
                                                 (Obj.magic
                                                    (FStar_Range.mk_range
                                                       "Pulse.Checker.Pure.fst"
-                                                      (Prims.of_int (250))
+                                                      (Prims.of_int (293))
                                                       (Prims.of_int (4))
-                                                      (Prims.of_int (261))
+                                                      (Prims.of_int (304))
                                                       (Prims.of_int (45)))))
                                              (Obj.magic
                                                 (FStar_Tactics_V2_Builtins.log_issues
@@ -2996,17 +3597,17 @@ let (compute_term_type_and_u :
                                                                (Obj.magic
                                                                   (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (254))
+                                                                    (Prims.of_int (297))
                                                                     (Prims.of_int (18))
-                                                                    (Prims.of_int (254))
+                                                                    (Prims.of_int (297))
                                                                     (Prims.of_int (46)))))
                                                             (FStar_Sealed.seal
                                                                (Obj.magic
                                                                   (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (252))
+                                                                    (Prims.of_int (295))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (254))
+                                                                    (Prims.of_int (297))
                                                                     (Prims.of_int (46)))))
                                                             (Obj.magic
                                                                (ill_typed_term
@@ -3040,18 +3641,18 @@ let (compute_term_type_and_u :
                                                                     Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (257))
+                                                                    (Prims.of_int (300))
                                                                     (Prims.of_int (41))
-                                                                    (Prims.of_int (257))
+                                                                    (Prims.of_int (300))
                                                                     (Prims.of_int (62)))))
                                                                  (FStar_Sealed.seal
                                                                     (
                                                                     Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (257))
+                                                                    (Prims.of_int (300))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (257))
+                                                                    (Prims.of_int (300))
                                                                     (Prims.of_int (62)))))
                                                                  (Obj.magic
                                                                     (
@@ -3078,18 +3679,18 @@ let (compute_term_type_and_u :
                                                                     Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (258))
+                                                                    (Prims.of_int (301))
                                                                     (Prims.of_int (41))
-                                                                    (Prims.of_int (258))
+                                                                    (Prims.of_int (301))
                                                                     (Prims.of_int (63)))))
                                                                  (FStar_Sealed.seal
                                                                     (
                                                                     Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (258))
+                                                                    (Prims.of_int (301))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (258))
+                                                                    (Prims.of_int (301))
                                                                     (Prims.of_int (63)))))
                                                                  (Obj.magic
                                                                     (
@@ -3117,18 +3718,18 @@ let (compute_term_type_and_u :
                                                                     Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (260))
+                                                                    (Prims.of_int (303))
                                                                     (Prims.of_int (27))
-                                                                    (Prims.of_int (260))
+                                                                    (Prims.of_int (303))
                                                                     (Prims.of_int (46)))))
                                                                  (FStar_Sealed.seal
                                                                     (
                                                                     Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (259))
+                                                                    (Prims.of_int (302))
                                                                     (Prims.of_int (26))
-                                                                    (Prims.of_int (261))
+                                                                    (Prims.of_int (304))
                                                                     (Prims.of_int (45)))))
                                                                  (Obj.magic
                                                                     (
@@ -3169,13 +3770,13 @@ let (check_term :
             (FStar_Sealed.seal
                (Obj.magic
                   (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                     (Prims.of_int (266)) (Prims.of_int (13))
-                     (Prims.of_int (266)) (Prims.of_int (43)))))
+                     (Prims.of_int (309)) (Prims.of_int (13))
+                     (Prims.of_int (309)) (Prims.of_int (43)))))
             (FStar_Sealed.seal
                (Obj.magic
                   (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                     (Prims.of_int (264)) (Prims.of_int (39))
-                     (Prims.of_int (283)) (Prims.of_int (78)))))
+                     (Prims.of_int (307)) (Prims.of_int (39))
+                     (Prims.of_int (326)) (Prims.of_int (78)))))
             (Obj.magic (instantiate_term_implicits g e))
             (fun uu___ ->
                (fun uu___ ->
@@ -3187,14 +3788,14 @@ let (check_term :
                               (Obj.magic
                                  (FStar_Range.mk_range
                                     "Pulse.Checker.Pure.fst"
-                                    (Prims.of_int (268)) (Prims.of_int (11))
-                                    (Prims.of_int (268)) (Prims.of_int (21)))))
+                                    (Prims.of_int (311)) (Prims.of_int (11))
+                                    (Prims.of_int (311)) (Prims.of_int (21)))))
                            (FStar_Sealed.seal
                               (Obj.magic
                                  (FStar_Range.mk_range
                                     "Pulse.Checker.Pure.fst"
-                                    (Prims.of_int (268)) (Prims.of_int (24))
-                                    (Prims.of_int (283)) (Prims.of_int (78)))))
+                                    (Prims.of_int (311)) (Prims.of_int (24))
+                                    (Prims.of_int (326)) (Prims.of_int (78)))))
                            (FStar_Tactics_Effect.lift_div_tac
                               (fun uu___2 -> Pulse_Typing.elab_env g))
                            (fun uu___2 ->
@@ -3205,17 +3806,17 @@ let (check_term :
                                          (Obj.magic
                                             (FStar_Range.mk_range
                                                "Pulse.Checker.Pure.fst"
-                                               (Prims.of_int (269))
+                                               (Prims.of_int (312))
                                                (Prims.of_int (11))
-                                               (Prims.of_int (269))
+                                               (Prims.of_int (312))
                                                (Prims.of_int (22)))))
                                       (FStar_Sealed.seal
                                          (Obj.magic
                                             (FStar_Range.mk_range
                                                "Pulse.Checker.Pure.fst"
-                                               (Prims.of_int (269))
+                                               (Prims.of_int (312))
                                                (Prims.of_int (25))
-                                               (Prims.of_int (283))
+                                               (Prims.of_int (326))
                                                (Prims.of_int (78)))))
                                       (FStar_Tactics_Effect.lift_div_tac
                                          (fun uu___2 ->
@@ -3228,17 +3829,17 @@ let (check_term :
                                                     (Obj.magic
                                                        (FStar_Range.mk_range
                                                           "Pulse.Checker.Pure.fst"
-                                                          (Prims.of_int (270))
+                                                          (Prims.of_int (313))
                                                           (Prims.of_int (11))
-                                                          (Prims.of_int (270))
+                                                          (Prims.of_int (313))
                                                           (Prims.of_int (22)))))
                                                  (FStar_Sealed.seal
                                                     (Obj.magic
                                                        (FStar_Range.mk_range
                                                           "Pulse.Checker.Pure.fst"
-                                                          (Prims.of_int (270))
+                                                          (Prims.of_int (313))
                                                           (Prims.of_int (25))
-                                                          (Prims.of_int (283))
+                                                          (Prims.of_int (326))
                                                           (Prims.of_int (78)))))
                                                  (FStar_Tactics_Effect.lift_div_tac
                                                     (fun uu___2 ->
@@ -3252,17 +3853,17 @@ let (check_term :
                                                                (Obj.magic
                                                                   (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (273))
+                                                                    (Prims.of_int (316))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (276))
+                                                                    (Prims.of_int (319))
                                                                     (Prims.of_int (22)))))
                                                             (FStar_Sealed.seal
                                                                (Obj.magic
                                                                   (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (270))
+                                                                    (Prims.of_int (313))
                                                                     (Prims.of_int (25))
-                                                                    (Prims.of_int (283))
+                                                                    (Prims.of_int (326))
                                                                     (Prims.of_int (78)))))
                                                             (Obj.magic
                                                                (catch_all
@@ -3288,17 +3889,17 @@ let (check_term :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (277))
+                                                                    (Prims.of_int (320))
                                                                     (Prims.of_int (2))
-                                                                    (Prims.of_int (277))
+                                                                    (Prims.of_int (320))
                                                                     (Prims.of_int (21)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (278))
+                                                                    (Prims.of_int (321))
                                                                     (Prims.of_int (2))
-                                                                    (Prims.of_int (283))
+                                                                    (Prims.of_int (326))
                                                                     (Prims.of_int (78)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_V2_Builtins.log_issues
@@ -3319,17 +3920,17 @@ let (check_term :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (282))
+                                                                    (Prims.of_int (325))
                                                                     (Prims.of_int (16))
-                                                                    (Prims.of_int (282))
+                                                                    (Prims.of_int (325))
                                                                     (Prims.of_int (48)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (280))
+                                                                    (Prims.of_int (323))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (282))
+                                                                    (Prims.of_int (325))
                                                                     (Prims.of_int (48)))))
                                                                     (Obj.magic
                                                                     (ill_typed_term
@@ -3376,13 +3977,13 @@ let (check_term_at_type :
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                   (Prims.of_int (288)) (Prims.of_int (13))
-                   (Prims.of_int (288)) (Prims.of_int (43)))))
+                   (Prims.of_int (331)) (Prims.of_int (13))
+                   (Prims.of_int (331)) (Prims.of_int (43)))))
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                   (Prims.of_int (286)) (Prims.of_int (60))
-                   (Prims.of_int (305)) (Prims.of_int (65)))))
+                   (Prims.of_int (329)) (Prims.of_int (60))
+                   (Prims.of_int (348)) (Prims.of_int (65)))))
           (Obj.magic (instantiate_term_implicits g e))
           (fun uu___ ->
              (fun uu___ ->
@@ -3393,13 +3994,13 @@ let (check_term_at_type :
                          (FStar_Sealed.seal
                             (Obj.magic
                                (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                                  (Prims.of_int (289)) (Prims.of_int (11))
-                                  (Prims.of_int (289)) (Prims.of_int (21)))))
+                                  (Prims.of_int (332)) (Prims.of_int (11))
+                                  (Prims.of_int (332)) (Prims.of_int (21)))))
                          (FStar_Sealed.seal
                             (Obj.magic
                                (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                                  (Prims.of_int (289)) (Prims.of_int (24))
-                                  (Prims.of_int (305)) (Prims.of_int (65)))))
+                                  (Prims.of_int (332)) (Prims.of_int (24))
+                                  (Prims.of_int (348)) (Prims.of_int (65)))))
                          (FStar_Tactics_Effect.lift_div_tac
                             (fun uu___2 -> Pulse_Typing.elab_env g))
                          (fun uu___2 ->
@@ -3410,17 +4011,17 @@ let (check_term_at_type :
                                        (Obj.magic
                                           (FStar_Range.mk_range
                                              "Pulse.Checker.Pure.fst"
-                                             (Prims.of_int (290))
+                                             (Prims.of_int (333))
                                              (Prims.of_int (11))
-                                             (Prims.of_int (290))
+                                             (Prims.of_int (333))
                                              (Prims.of_int (22)))))
                                     (FStar_Sealed.seal
                                        (Obj.magic
                                           (FStar_Range.mk_range
                                              "Pulse.Checker.Pure.fst"
-                                             (Prims.of_int (290))
+                                             (Prims.of_int (333))
                                              (Prims.of_int (25))
-                                             (Prims.of_int (305))
+                                             (Prims.of_int (348))
                                              (Prims.of_int (65)))))
                                     (FStar_Tactics_Effect.lift_div_tac
                                        (fun uu___2 ->
@@ -3433,17 +4034,17 @@ let (check_term_at_type :
                                                   (Obj.magic
                                                      (FStar_Range.mk_range
                                                         "Pulse.Checker.Pure.fst"
-                                                        (Prims.of_int (291))
+                                                        (Prims.of_int (334))
                                                         (Prims.of_int (11))
-                                                        (Prims.of_int (291))
+                                                        (Prims.of_int (334))
                                                         (Prims.of_int (22)))))
                                                (FStar_Sealed.seal
                                                   (Obj.magic
                                                      (FStar_Range.mk_range
                                                         "Pulse.Checker.Pure.fst"
-                                                        (Prims.of_int (291))
+                                                        (Prims.of_int (334))
                                                         (Prims.of_int (25))
-                                                        (Prims.of_int (305))
+                                                        (Prims.of_int (348))
                                                         (Prims.of_int (65)))))
                                                (FStar_Tactics_Effect.lift_div_tac
                                                   (fun uu___2 ->
@@ -3457,17 +4058,17 @@ let (check_term_at_type :
                                                              (Obj.magic
                                                                 (FStar_Range.mk_range
                                                                    "Pulse.Checker.Pure.fst"
-                                                                   (Prims.of_int (294))
+                                                                   (Prims.of_int (337))
                                                                    (Prims.of_int (4))
-                                                                   (Prims.of_int (297))
+                                                                   (Prims.of_int (340))
                                                                    (Prims.of_int (15)))))
                                                           (FStar_Sealed.seal
                                                              (Obj.magic
                                                                 (FStar_Range.mk_range
                                                                    "Pulse.Checker.Pure.fst"
-                                                                   (Prims.of_int (291))
+                                                                   (Prims.of_int (334))
                                                                    (Prims.of_int (25))
-                                                                   (Prims.of_int (305))
+                                                                   (Prims.of_int (348))
                                                                    (Prims.of_int (65)))))
                                                           (Obj.magic
                                                              (catch_all
@@ -3492,17 +4093,17 @@ let (check_term_at_type :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (298))
+                                                                    (Prims.of_int (341))
                                                                     (Prims.of_int (2))
-                                                                    (Prims.of_int (298))
+                                                                    (Prims.of_int (341))
                                                                     (Prims.of_int (21)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (299))
+                                                                    (Prims.of_int (342))
                                                                     (Prims.of_int (2))
-                                                                    (Prims.of_int (305))
+                                                                    (Prims.of_int (348))
                                                                     (Prims.of_int (65)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_V2_Builtins.log_issues
@@ -3523,17 +4124,17 @@ let (check_term_at_type :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (303))
+                                                                    (Prims.of_int (346))
                                                                     (Prims.of_int (16))
-                                                                    (Prims.of_int (303))
+                                                                    (Prims.of_int (346))
                                                                     (Prims.of_int (48)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (301))
+                                                                    (Prims.of_int (344))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (303))
+                                                                    (Prims.of_int (346))
                                                                     (Prims.of_int (48)))))
                                                                     (Obj.magic
                                                                     (ill_typed_term
@@ -3583,13 +4184,13 @@ let (tc_with_core :
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                   (Prims.of_int (309)) (Prims.of_int (23))
-                   (Prims.of_int (309)) (Prims.of_int (124)))))
+                   (Prims.of_int (352)) (Prims.of_int (23))
+                   (Prims.of_int (352)) (Prims.of_int (124)))))
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                   (Prims.of_int (309)) (Prims.of_int (3))
-                   (Prims.of_int (313)) (Prims.of_int (76)))))
+                   (Prims.of_int (352)) (Prims.of_int (3))
+                   (Prims.of_int (356)) (Prims.of_int (76)))))
           (Obj.magic
              (catch_all
                 (fun uu___ ->
@@ -3623,13 +4224,13 @@ let (core_compute_term_type :
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                 (Prims.of_int (319)) (Prims.of_int (13))
-                 (Prims.of_int (319)) (Prims.of_int (23)))))
+                 (Prims.of_int (362)) (Prims.of_int (13))
+                 (Prims.of_int (362)) (Prims.of_int (23)))))
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                 (Prims.of_int (319)) (Prims.of_int (26))
-                 (Prims.of_int (333)) (Prims.of_int (30)))))
+                 (Prims.of_int (362)) (Prims.of_int (26))
+                 (Prims.of_int (376)) (Prims.of_int (30)))))
         (FStar_Tactics_Effect.lift_div_tac
            (fun uu___ -> Pulse_Typing.elab_env g))
         (fun uu___ ->
@@ -3639,13 +4240,13 @@ let (core_compute_term_type :
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                            (Prims.of_int (320)) (Prims.of_int (13))
-                            (Prims.of_int (320)) (Prims.of_int (24)))))
+                            (Prims.of_int (363)) (Prims.of_int (13))
+                            (Prims.of_int (363)) (Prims.of_int (24)))))
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                            (Prims.of_int (320)) (Prims.of_int (27))
-                            (Prims.of_int (333)) (Prims.of_int (30)))))
+                            (Prims.of_int (363)) (Prims.of_int (27))
+                            (Prims.of_int (376)) (Prims.of_int (30)))))
                    (FStar_Tactics_Effect.lift_div_tac
                       (fun uu___ -> Pulse_Elaborate_Pure.elab_term t))
                    (fun uu___ ->
@@ -3656,17 +4257,17 @@ let (core_compute_term_type :
                                  (Obj.magic
                                     (FStar_Range.mk_range
                                        "Pulse.Checker.Pure.fst"
-                                       (Prims.of_int (321))
+                                       (Prims.of_int (364))
                                        (Prims.of_int (22))
-                                       (Prims.of_int (321))
+                                       (Prims.of_int (364))
                                        (Prims.of_int (94)))))
                               (FStar_Sealed.seal
                                  (Obj.magic
                                     (FStar_Range.mk_range
                                        "Pulse.Checker.Pure.fst"
-                                       (Prims.of_int (320))
+                                       (Prims.of_int (363))
                                        (Prims.of_int (27))
-                                       (Prims.of_int (333))
+                                       (Prims.of_int (376))
                                        (Prims.of_int (30)))))
                               (Obj.magic
                                  (tc_with_core
@@ -3684,17 +4285,17 @@ let (core_compute_term_type :
                                                 (Obj.magic
                                                    (FStar_Range.mk_range
                                                       "Pulse.Checker.Pure.fst"
-                                                      (Prims.of_int (322))
+                                                      (Prims.of_int (365))
                                                       (Prims.of_int (4))
-                                                      (Prims.of_int (322))
+                                                      (Prims.of_int (365))
                                                       (Prims.of_int (23)))))
                                              (FStar_Sealed.seal
                                                 (Obj.magic
                                                    (FStar_Range.mk_range
                                                       "Pulse.Checker.Pure.fst"
-                                                      (Prims.of_int (323))
+                                                      (Prims.of_int (366))
                                                       (Prims.of_int (4))
-                                                      (Prims.of_int (333))
+                                                      (Prims.of_int (376))
                                                       (Prims.of_int (30)))))
                                              (Obj.magic
                                                 (FStar_Tactics_V2_Builtins.log_issues
@@ -3711,17 +4312,17 @@ let (core_compute_term_type :
                                                                   (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (327))
+                                                                    (Prims.of_int (370))
                                                                     (Prims.of_int (18))
-                                                                    (Prims.of_int (327))
+                                                                    (Prims.of_int (370))
                                                                     (Prims.of_int (46)))))
                                                                (FStar_Sealed.seal
                                                                   (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (325))
+                                                                    (Prims.of_int (368))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (327))
+                                                                    (Prims.of_int (370))
                                                                     (Prims.of_int (46)))))
                                                                (Obj.magic
                                                                   (ill_typed_term
@@ -3753,17 +4354,17 @@ let (core_compute_term_type :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (331))
+                                                                    (Prims.of_int (374))
                                                                     (Prims.of_int (32))
-                                                                    (Prims.of_int (331))
+                                                                    (Prims.of_int (374))
                                                                     (Prims.of_int (54)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (331))
+                                                                    (Prims.of_int (374))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (331))
+                                                                    (Prims.of_int (374))
                                                                     (Prims.of_int (54)))))
                                                                     (Obj.magic
                                                                     (readback_failure
@@ -3804,13 +4405,13 @@ let (core_check_term :
             (FStar_Sealed.seal
                (Obj.magic
                   (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                     (Prims.of_int (336)) (Prims.of_int (11))
-                     (Prims.of_int (336)) (Prims.of_int (21)))))
+                     (Prims.of_int (379)) (Prims.of_int (11))
+                     (Prims.of_int (379)) (Prims.of_int (21)))))
             (FStar_Sealed.seal
                (Obj.magic
                   (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                     (Prims.of_int (336)) (Prims.of_int (24))
-                     (Prims.of_int (350)) (Prims.of_int (69)))))
+                     (Prims.of_int (379)) (Prims.of_int (24))
+                     (Prims.of_int (393)) (Prims.of_int (69)))))
             (FStar_Tactics_Effect.lift_div_tac
                (fun uu___ -> Pulse_Typing.elab_env g))
             (fun uu___ ->
@@ -3820,13 +4421,13 @@ let (core_check_term :
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                                (Prims.of_int (337)) (Prims.of_int (11))
-                                (Prims.of_int (337)) (Prims.of_int (22)))))
+                                (Prims.of_int (380)) (Prims.of_int (11))
+                                (Prims.of_int (380)) (Prims.of_int (22)))))
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                                (Prims.of_int (337)) (Prims.of_int (25))
-                                (Prims.of_int (350)) (Prims.of_int (69)))))
+                                (Prims.of_int (380)) (Prims.of_int (25))
+                                (Prims.of_int (393)) (Prims.of_int (69)))))
                        (FStar_Tactics_Effect.lift_div_tac
                           (fun uu___ -> Pulse_Elaborate_Pure.elab_term e))
                        (fun uu___ ->
@@ -3837,17 +4438,17 @@ let (core_check_term :
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "Pulse.Checker.Pure.fst"
-                                           (Prims.of_int (338))
+                                           (Prims.of_int (381))
                                            (Prims.of_int (11))
-                                           (Prims.of_int (338))
+                                           (Prims.of_int (381))
                                            (Prims.of_int (22)))))
                                   (FStar_Sealed.seal
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "Pulse.Checker.Pure.fst"
-                                           (Prims.of_int (338))
+                                           (Prims.of_int (381))
                                            (Prims.of_int (25))
-                                           (Prims.of_int (350))
+                                           (Prims.of_int (393))
                                            (Prims.of_int (69)))))
                                   (FStar_Tactics_Effect.lift_div_tac
                                      (fun uu___ ->
@@ -3860,17 +4461,17 @@ let (core_check_term :
                                                 (Obj.magic
                                                    (FStar_Range.mk_range
                                                       "Pulse.Checker.Pure.fst"
-                                                      (Prims.of_int (340))
+                                                      (Prims.of_int (383))
                                                       (Prims.of_int (4))
-                                                      (Prims.of_int (343))
+                                                      (Prims.of_int (386))
                                                       (Prims.of_int (20)))))
                                              (FStar_Sealed.seal
                                                 (Obj.magic
                                                    (FStar_Range.mk_range
                                                       "Pulse.Checker.Pure.fst"
-                                                      (Prims.of_int (338))
+                                                      (Prims.of_int (381))
                                                       (Prims.of_int (25))
-                                                      (Prims.of_int (350))
+                                                      (Prims.of_int (393))
                                                       (Prims.of_int (69)))))
                                              (Obj.magic
                                                 (catch_all
@@ -3892,17 +4493,17 @@ let (core_check_term :
                                                                (Obj.magic
                                                                   (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (344))
+                                                                    (Prims.of_int (387))
                                                                     (Prims.of_int (2))
-                                                                    (Prims.of_int (344))
+                                                                    (Prims.of_int (387))
                                                                     (Prims.of_int (21)))))
                                                             (FStar_Sealed.seal
                                                                (Obj.magic
                                                                   (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (345))
+                                                                    (Prims.of_int (388))
                                                                     (Prims.of_int (2))
-                                                                    (Prims.of_int (350))
+                                                                    (Prims.of_int (393))
                                                                     (Prims.of_int (69)))))
                                                             (Obj.magic
                                                                (FStar_Tactics_V2_Builtins.log_issues
@@ -3920,17 +4521,17 @@ let (core_check_term :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (349))
+                                                                    (Prims.of_int (392))
                                                                     (Prims.of_int (16))
-                                                                    (Prims.of_int (349))
+                                                                    (Prims.of_int (392))
                                                                     (Prims.of_int (48)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (347))
+                                                                    (Prims.of_int (390))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (349))
+                                                                    (Prims.of_int (392))
                                                                     (Prims.of_int (48)))))
                                                                     (Obj.magic
                                                                     (ill_typed_term
@@ -3973,13 +4574,13 @@ let (core_check_term_at_type :
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                   (Prims.of_int (353)) (Prims.of_int (11))
-                   (Prims.of_int (353)) (Prims.of_int (21)))))
+                   (Prims.of_int (396)) (Prims.of_int (11))
+                   (Prims.of_int (396)) (Prims.of_int (21)))))
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                   (Prims.of_int (353)) (Prims.of_int (24))
-                   (Prims.of_int (368)) (Prims.of_int (62)))))
+                   (Prims.of_int (396)) (Prims.of_int (24))
+                   (Prims.of_int (411)) (Prims.of_int (62)))))
           (FStar_Tactics_Effect.lift_div_tac
              (fun uu___ -> Pulse_Typing.elab_env g))
           (fun uu___ ->
@@ -3989,13 +4590,13 @@ let (core_check_term_at_type :
                      (FStar_Sealed.seal
                         (Obj.magic
                            (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                              (Prims.of_int (354)) (Prims.of_int (11))
-                              (Prims.of_int (354)) (Prims.of_int (22)))))
+                              (Prims.of_int (397)) (Prims.of_int (11))
+                              (Prims.of_int (397)) (Prims.of_int (22)))))
                      (FStar_Sealed.seal
                         (Obj.magic
                            (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                              (Prims.of_int (354)) (Prims.of_int (25))
-                              (Prims.of_int (368)) (Prims.of_int (62)))))
+                              (Prims.of_int (397)) (Prims.of_int (25))
+                              (Prims.of_int (411)) (Prims.of_int (62)))))
                      (FStar_Tactics_Effect.lift_div_tac
                         (fun uu___ -> Pulse_Elaborate_Pure.elab_term e))
                      (fun uu___ ->
@@ -4006,17 +4607,17 @@ let (core_check_term_at_type :
                                    (Obj.magic
                                       (FStar_Range.mk_range
                                          "Pulse.Checker.Pure.fst"
-                                         (Prims.of_int (355))
+                                         (Prims.of_int (398))
                                          (Prims.of_int (11))
-                                         (Prims.of_int (355))
+                                         (Prims.of_int (398))
                                          (Prims.of_int (22)))))
                                 (FStar_Sealed.seal
                                    (Obj.magic
                                       (FStar_Range.mk_range
                                          "Pulse.Checker.Pure.fst"
-                                         (Prims.of_int (355))
+                                         (Prims.of_int (398))
                                          (Prims.of_int (25))
-                                         (Prims.of_int (368))
+                                         (Prims.of_int (411))
                                          (Prims.of_int (62)))))
                                 (FStar_Tactics_Effect.lift_div_tac
                                    (fun uu___ ->
@@ -4029,17 +4630,17 @@ let (core_check_term_at_type :
                                               (Obj.magic
                                                  (FStar_Range.mk_range
                                                     "Pulse.Checker.Pure.fst"
-                                                    (Prims.of_int (357))
+                                                    (Prims.of_int (400))
                                                     (Prims.of_int (4))
-                                                    (Prims.of_int (360))
+                                                    (Prims.of_int (403))
                                                     (Prims.of_int (16)))))
                                            (FStar_Sealed.seal
                                               (Obj.magic
                                                  (FStar_Range.mk_range
                                                     "Pulse.Checker.Pure.fst"
-                                                    (Prims.of_int (355))
+                                                    (Prims.of_int (398))
                                                     (Prims.of_int (25))
-                                                    (Prims.of_int (368))
+                                                    (Prims.of_int (411))
                                                     (Prims.of_int (62)))))
                                            (Obj.magic
                                               (catch_all
@@ -4060,17 +4661,17 @@ let (core_check_term_at_type :
                                                              (Obj.magic
                                                                 (FStar_Range.mk_range
                                                                    "Pulse.Checker.Pure.fst"
-                                                                   (Prims.of_int (361))
+                                                                   (Prims.of_int (404))
                                                                    (Prims.of_int (2))
-                                                                   (Prims.of_int (361))
+                                                                   (Prims.of_int (404))
                                                                    (Prims.of_int (21)))))
                                                           (FStar_Sealed.seal
                                                              (Obj.magic
                                                                 (FStar_Range.mk_range
                                                                    "Pulse.Checker.Pure.fst"
-                                                                   (Prims.of_int (362))
+                                                                   (Prims.of_int (405))
                                                                    (Prims.of_int (2))
-                                                                   (Prims.of_int (368))
+                                                                   (Prims.of_int (411))
                                                                    (Prims.of_int (62)))))
                                                           (Obj.magic
                                                              (FStar_Tactics_V2_Builtins.log_issues
@@ -4088,17 +4689,17 @@ let (core_check_term_at_type :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (366))
+                                                                    (Prims.of_int (409))
                                                                     (Prims.of_int (16))
-                                                                    (Prims.of_int (366))
+                                                                    (Prims.of_int (409))
                                                                     (Prims.of_int (48)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (364))
+                                                                    (Prims.of_int (407))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (366))
+                                                                    (Prims.of_int (409))
                                                                     (Prims.of_int (48)))))
                                                                     (Obj.magic
                                                                     (ill_typed_term
@@ -4166,13 +4767,13 @@ let (get_non_informative_witness :
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                   (Prims.of_int (391)) (Prims.of_int (6))
-                   (Prims.of_int (395)) (Prims.of_int (7)))))
+                   (Prims.of_int (434)) (Prims.of_int (6))
+                   (Prims.of_int (438)) (Prims.of_int (7)))))
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                   (Prims.of_int (396)) (Prims.of_int (6))
-                   (Prims.of_int (430)) (Prims.of_int (39)))))
+                   (Prims.of_int (439)) (Prims.of_int (6))
+                   (Prims.of_int (473)) (Prims.of_int (39)))))
           (FStar_Tactics_Effect.lift_div_tac
              (fun uu___ ->
                 fun uu___1 ->
@@ -4180,44 +4781,44 @@ let (get_non_informative_witness :
                     (FStar_Sealed.seal
                        (Obj.magic
                           (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                             (Prims.of_int (392)) (Prims.of_int (32))
-                             (Prims.of_int (395)) (Prims.of_int (7)))))
+                             (Prims.of_int (435)) (Prims.of_int (32))
+                             (Prims.of_int (438)) (Prims.of_int (7)))))
                     (FStar_Sealed.seal
                        (Obj.magic
                           (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                             (Prims.of_int (392)) (Prims.of_int (6))
-                             (Prims.of_int (395)) (Prims.of_int (7)))))
+                             (Prims.of_int (435)) (Prims.of_int (6))
+                             (Prims.of_int (438)) (Prims.of_int (7)))))
                     (Obj.magic
                        (FStar_Tactics_Effect.tac_bind
                           (FStar_Sealed.seal
                              (Obj.magic
                                 (FStar_Range.mk_range
                                    "Pulse.Checker.Pure.fst"
-                                   (Prims.of_int (393)) (Prims.of_int (8))
-                                   (Prims.of_int (394)) (Prims.of_int (18)))))
+                                   (Prims.of_int (436)) (Prims.of_int (8))
+                                   (Prims.of_int (437)) (Prims.of_int (18)))))
                           (FStar_Sealed.seal
                              (Obj.magic
                                 (FStar_Range.mk_range
                                    "Pulse.Checker.Pure.fst"
-                                   (Prims.of_int (392)) (Prims.of_int (32))
-                                   (Prims.of_int (395)) (Prims.of_int (7)))))
+                                   (Prims.of_int (435)) (Prims.of_int (32))
+                                   (Prims.of_int (438)) (Prims.of_int (7)))))
                           (Obj.magic
                              (FStar_Tactics_Effect.tac_bind
                                 (FStar_Sealed.seal
                                    (Obj.magic
                                       (FStar_Range.mk_range
                                          "Pulse.Checker.Pure.fst"
-                                         (Prims.of_int (394))
+                                         (Prims.of_int (437))
                                          (Prims.of_int (14))
-                                         (Prims.of_int (394))
+                                         (Prims.of_int (437))
                                          (Prims.of_int (18)))))
                                 (FStar_Sealed.seal
                                    (Obj.magic
                                       (FStar_Range.mk_range
                                          "Pulse.Checker.Pure.fst"
-                                         (Prims.of_int (393))
+                                         (Prims.of_int (436))
                                          (Prims.of_int (8))
-                                         (Prims.of_int (394))
+                                         (Prims.of_int (437))
                                          (Prims.of_int (18)))))
                                 (Obj.magic (Pulse_PP.pp Pulse_PP.uu___44 t))
                                 (fun uu___2 ->
@@ -4244,13 +4845,13 @@ let (get_non_informative_witness :
                      (FStar_Sealed.seal
                         (Obj.magic
                            (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                              (Prims.of_int (397)) (Prims.of_int (14))
-                              (Prims.of_int (421)) (Prims.of_int (17)))))
+                              (Prims.of_int (440)) (Prims.of_int (14))
+                              (Prims.of_int (464)) (Prims.of_int (17)))))
                      (FStar_Sealed.seal
                         (Obj.magic
                            (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                              (Prims.of_int (423)) (Prims.of_int (4))
-                              (Prims.of_int (430)) (Prims.of_int (39)))))
+                              (Prims.of_int (466)) (Prims.of_int (4))
+                              (Prims.of_int (473)) (Prims.of_int (39)))))
                      (FStar_Tactics_Effect.lift_div_tac
                         (fun uu___ ->
                            match Pulse_Syntax_Pure.is_fvar_app t with
@@ -4347,13 +4948,13 @@ let (check_prop_validity :
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                   (Prims.of_int (434)) (Prims.of_int (24))
-                   (Prims.of_int (434)) (Prims.of_int (76)))))
+                   (Prims.of_int (477)) (Prims.of_int (24))
+                   (Prims.of_int (477)) (Prims.of_int (76)))))
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                   (Prims.of_int (434)) (Prims.of_int (3))
-                   (Prims.of_int (441)) (Prims.of_int (21)))))
+                   (Prims.of_int (477)) (Prims.of_int (3))
+                   (Prims.of_int (484)) (Prims.of_int (21)))))
           (Obj.magic
              (rtb_check_prop_validity g (Pulse_Typing.elab_env g)
                 (Pulse_Elaborate_Pure.elab_term p)))
@@ -4366,13 +4967,13 @@ let (check_prop_validity :
                          (FStar_Sealed.seal
                             (Obj.magic
                                (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                                  (Prims.of_int (435)) (Prims.of_int (4))
-                                  (Prims.of_int (435)) (Prims.of_int (23)))))
+                                  (Prims.of_int (478)) (Prims.of_int (4))
+                                  (Prims.of_int (478)) (Prims.of_int (23)))))
                          (FStar_Sealed.seal
                             (Obj.magic
                                (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                                  (Prims.of_int (436)) (Prims.of_int (4))
-                                  (Prims.of_int (441)) (Prims.of_int (21)))))
+                                  (Prims.of_int (479)) (Prims.of_int (4))
+                                  (Prims.of_int (484)) (Prims.of_int (21)))))
                          (Obj.magic
                             (FStar_Tactics_V2_Builtins.log_issues issues))
                          (fun uu___2 ->
@@ -4386,17 +4987,17 @@ let (check_prop_validity :
                                               (Obj.magic
                                                  (FStar_Range.mk_range
                                                     "Pulse.Checker.Pure.fst"
-                                                    (Prims.of_int (440))
+                                                    (Prims.of_int (483))
                                                     (Prims.of_int (21))
-                                                    (Prims.of_int (440))
+                                                    (Prims.of_int (483))
                                                     (Prims.of_int (64)))))
                                            (FStar_Sealed.seal
                                               (Obj.magic
                                                  (FStar_Range.mk_range
                                                     "Pulse.Checker.Pure.fst"
-                                                    (Prims.of_int (439))
+                                                    (Prims.of_int (482))
                                                     (Prims.of_int (6))
-                                                    (Prims.of_int (440))
+                                                    (Prims.of_int (483))
                                                     (Prims.of_int (64)))))
                                            (Obj.magic
                                               (FStar_Tactics_Effect.tac_bind
@@ -4404,17 +5005,17 @@ let (check_prop_validity :
                                                     (Obj.magic
                                                        (FStar_Range.mk_range
                                                           "Pulse.Checker.Pure.fst"
-                                                          (Prims.of_int (440))
+                                                          (Prims.of_int (483))
                                                           (Prims.of_int (22))
-                                                          (Prims.of_int (440))
+                                                          (Prims.of_int (483))
                                                           (Prims.of_int (63)))))
                                                  (FStar_Sealed.seal
                                                     (Obj.magic
                                                        (FStar_Range.mk_range
                                                           "Pulse.Checker.Pure.fst"
-                                                          (Prims.of_int (440))
+                                                          (Prims.of_int (483))
                                                           (Prims.of_int (21))
-                                                          (Prims.of_int (440))
+                                                          (Prims.of_int (483))
                                                           (Prims.of_int (64)))))
                                                  (Obj.magic
                                                     (FStar_Tactics_Effect.tac_bind
@@ -4422,17 +5023,17 @@ let (check_prop_validity :
                                                           (Obj.magic
                                                              (FStar_Range.mk_range
                                                                 "Pulse.Checker.Pure.fst"
-                                                                (Prims.of_int (440))
+                                                                (Prims.of_int (483))
                                                                 (Prims.of_int (59))
-                                                                (Prims.of_int (440))
+                                                                (Prims.of_int (483))
                                                                 (Prims.of_int (63)))))
                                                        (FStar_Sealed.seal
                                                           (Obj.magic
                                                              (FStar_Range.mk_range
                                                                 "Pulse.Checker.Pure.fst"
-                                                                (Prims.of_int (440))
+                                                                (Prims.of_int (483))
                                                                 (Prims.of_int (22))
-                                                                (Prims.of_int (440))
+                                                                (Prims.of_int (483))
                                                                 (Prims.of_int (63)))))
                                                        (Obj.magic
                                                           (Pulse_PP.pp
@@ -4471,20 +5072,20 @@ let fail_expected_tot_found_ghost :
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                 (Prims.of_int (445)) (Prims.of_int (4)) (Prims.of_int (445))
+                 (Prims.of_int (488)) (Prims.of_int (4)) (Prims.of_int (488))
                  (Prims.of_int (86)))))
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                 (Prims.of_int (444)) (Prims.of_int (2)) (Prims.of_int (445))
+                 (Prims.of_int (487)) (Prims.of_int (2)) (Prims.of_int (488))
                  (Prims.of_int (86)))))
         (Obj.magic
            (FStar_Tactics_Effect.tac_bind
               (FStar_Sealed.seal
                  (Obj.magic
                     (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                       (Prims.of_int (445)) (Prims.of_int (65))
-                       (Prims.of_int (445)) (Prims.of_int (85)))))
+                       (Prims.of_int (488)) (Prims.of_int (65))
+                       (Prims.of_int (488)) (Prims.of_int (85)))))
               (FStar_Sealed.seal
                  (Obj.magic
                     (FStar_Range.mk_range "prims.fst" (Prims.of_int (590))
@@ -4515,13 +5116,13 @@ let (compute_tot_term_type :
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                 (Prims.of_int (448)) (Prims.of_int (35))
-                 (Prims.of_int (448)) (Prims.of_int (56)))))
+                 (Prims.of_int (491)) (Prims.of_int (35))
+                 (Prims.of_int (491)) (Prims.of_int (56)))))
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                 (Prims.of_int (447)) (Prims.of_int (31))
-                 (Prims.of_int (450)) (Prims.of_int (40)))))
+                 (Prims.of_int (490)) (Prims.of_int (31))
+                 (Prims.of_int (493)) (Prims.of_int (40)))))
         (Obj.magic (compute_term_type g t))
         (fun uu___ ->
            (fun uu___ ->
@@ -4550,13 +5151,13 @@ let (compute_tot_term_type_and_u :
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                 (Prims.of_int (453)) (Prims.of_int (55))
-                 (Prims.of_int (453)) (Prims.of_int (82)))))
+                 (Prims.of_int (496)) (Prims.of_int (55))
+                 (Prims.of_int (496)) (Prims.of_int (82)))))
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                 (Prims.of_int (452)) (Prims.of_int (37))
-                 (Prims.of_int (455)) (Prims.of_int (40)))))
+                 (Prims.of_int (495)) (Prims.of_int (37))
+                 (Prims.of_int (498)) (Prims.of_int (40)))))
         (Obj.magic (compute_term_type_and_u g t))
         (fun uu___ ->
            (fun uu___ ->
@@ -4593,13 +5194,13 @@ let (core_compute_tot_term_type :
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                 (Prims.of_int (461)) (Prims.of_int (25))
-                 (Prims.of_int (461)) (Prims.of_int (51)))))
+                 (Prims.of_int (504)) (Prims.of_int (25))
+                 (Prims.of_int (504)) (Prims.of_int (51)))))
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                 (Prims.of_int (460)) (Prims.of_int (36))
-                 (Prims.of_int (463)) (Prims.of_int (40)))))
+                 (Prims.of_int (503)) (Prims.of_int (36))
+                 (Prims.of_int (506)) (Prims.of_int (40)))))
         (Obj.magic (core_compute_term_type g t))
         (fun uu___ ->
            (fun uu___ ->
@@ -4634,13 +5235,13 @@ let (is_non_informative :
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                 (Prims.of_int (469)) (Prims.of_int (21))
-                 (Prims.of_int (469)) (Prims.of_int (89)))))
+                 (Prims.of_int (512)) (Prims.of_int (21))
+                 (Prims.of_int (512)) (Prims.of_int (89)))))
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                 (Prims.of_int (468)) (Prims.of_int (28))
-                 (Prims.of_int (471)) (Prims.of_int (6)))))
+                 (Prims.of_int (511)) (Prims.of_int (28))
+                 (Prims.of_int (514)) (Prims.of_int (6)))))
         (Obj.magic
            (catch_all
               (fun uu___ ->
@@ -4656,13 +5257,13 @@ let (is_non_informative :
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                                (Prims.of_int (470)) (Prims.of_int (2))
-                                (Prims.of_int (470)) (Prims.of_int (21)))))
+                                (Prims.of_int (513)) (Prims.of_int (2))
+                                (Prims.of_int (513)) (Prims.of_int (21)))))
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                                (Prims.of_int (469)) (Prims.of_int (6))
-                                (Prims.of_int (469)) (Prims.of_int (10)))))
+                                (Prims.of_int (512)) (Prims.of_int (6))
+                                (Prims.of_int (512)) (Prims.of_int (10)))))
                        (Obj.magic
                           (FStar_Tactics_V2_Builtins.log_issues issues))
                        (fun uu___1 ->
@@ -4684,13 +5285,13 @@ let (check_subtyping :
                (FStar_Sealed.seal
                   (Obj.magic
                      (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                        (Prims.of_int (475)) (Prims.of_int (20))
-                        (Prims.of_int (475)) (Prims.of_int (47)))))
+                        (Prims.of_int (518)) (Prims.of_int (20))
+                        (Prims.of_int (518)) (Prims.of_int (47)))))
                (FStar_Sealed.seal
                   (Obj.magic
                      (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                        (Prims.of_int (474)) (Prims.of_int (34))
-                        (Prims.of_int (483)) (Prims.of_int (47)))))
+                        (Prims.of_int (517)) (Prims.of_int (34))
+                        (Prims.of_int (526)) (Prims.of_int (47)))))
                (Obj.magic (rtb_check_subtyping g t1 t2))
                (fun uu___1 ->
                   (fun uu___1 ->
@@ -4702,17 +5303,17 @@ let (check_subtyping :
                                  (Obj.magic
                                     (FStar_Range.mk_range
                                        "Pulse.Checker.Pure.fst"
-                                       (Prims.of_int (476))
+                                       (Prims.of_int (519))
                                        (Prims.of_int (2))
-                                       (Prims.of_int (476))
+                                       (Prims.of_int (519))
                                        (Prims.of_int (21)))))
                               (FStar_Sealed.seal
                                  (Obj.magic
                                     (FStar_Range.mk_range
                                        "Pulse.Checker.Pure.fst"
-                                       (Prims.of_int (477))
+                                       (Prims.of_int (520))
                                        (Prims.of_int (2))
-                                       (Prims.of_int (483))
+                                       (Prims.of_int (526))
                                        (Prims.of_int (47)))))
                               (Obj.magic
                                  (FStar_Tactics_V2_Builtins.log_issues issues))
@@ -4732,17 +5333,17 @@ let (check_subtyping :
                                                    (Obj.magic
                                                       (FStar_Range.mk_range
                                                          "Pulse.Checker.Pure.fst"
-                                                         (Prims.of_int (482))
+                                                         (Prims.of_int (525))
                                                          (Prims.of_int (10))
-                                                         (Prims.of_int (483))
+                                                         (Prims.of_int (526))
                                                          (Prims.of_int (47)))))
                                                 (FStar_Sealed.seal
                                                    (Obj.magic
                                                       (FStar_Range.mk_range
                                                          "Pulse.Checker.Pure.fst"
-                                                         (Prims.of_int (481))
+                                                         (Prims.of_int (524))
                                                          (Prims.of_int (4))
-                                                         (Prims.of_int (483))
+                                                         (Prims.of_int (526))
                                                          (Prims.of_int (47)))))
                                                 (Obj.magic
                                                    (FStar_Tactics_Effect.tac_bind
@@ -4750,17 +5351,17 @@ let (check_subtyping :
                                                          (Obj.magic
                                                             (FStar_Range.mk_range
                                                                "Pulse.Checker.Pure.fst"
-                                                               (Prims.of_int (482))
+                                                               (Prims.of_int (525))
                                                                (Prims.of_int (12))
-                                                               (Prims.of_int (483))
+                                                               (Prims.of_int (526))
                                                                (Prims.of_int (46)))))
                                                       (FStar_Sealed.seal
                                                          (Obj.magic
                                                             (FStar_Range.mk_range
                                                                "Pulse.Checker.Pure.fst"
-                                                               (Prims.of_int (482))
+                                                               (Prims.of_int (525))
                                                                (Prims.of_int (10))
-                                                               (Prims.of_int (483))
+                                                               (Prims.of_int (526))
                                                                (Prims.of_int (47)))))
                                                       (Obj.magic
                                                          (FStar_Tactics_Effect.tac_bind
@@ -4768,17 +5369,17 @@ let (check_subtyping :
                                                                (Obj.magic
                                                                   (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (483))
+                                                                    (Prims.of_int (526))
                                                                     (Prims.of_int (16))
-                                                                    (Prims.of_int (483))
+                                                                    (Prims.of_int (526))
                                                                     (Prims.of_int (46)))))
                                                             (FStar_Sealed.seal
                                                                (Obj.magic
                                                                   (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (482))
+                                                                    (Prims.of_int (525))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (483))
+                                                                    (Prims.of_int (526))
                                                                     (Prims.of_int (46)))))
                                                             (Obj.magic
                                                                (FStar_Tactics_Effect.tac_bind
@@ -4786,17 +5387,17 @@ let (check_subtyping :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (483))
+                                                                    (Prims.of_int (526))
                                                                     (Prims.of_int (16))
-                                                                    (Prims.of_int (483))
+                                                                    (Prims.of_int (526))
                                                                     (Prims.of_int (21)))))
                                                                   (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (483))
+                                                                    (Prims.of_int (526))
                                                                     (Prims.of_int (16))
-                                                                    (Prims.of_int (483))
+                                                                    (Prims.of_int (526))
                                                                     (Prims.of_int (46)))))
                                                                   (Obj.magic
                                                                     (Pulse_PP.pp
@@ -4812,17 +5413,17 @@ let (check_subtyping :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (483))
+                                                                    (Prims.of_int (526))
                                                                     (Prims.of_int (26))
-                                                                    (Prims.of_int (483))
+                                                                    (Prims.of_int (526))
                                                                     (Prims.of_int (46)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (483))
+                                                                    (Prims.of_int (526))
                                                                     (Prims.of_int (16))
-                                                                    (Prims.of_int (483))
+                                                                    (Prims.of_int (526))
                                                                     (Prims.of_int (46)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -4830,17 +5431,17 @@ let (check_subtyping :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (483))
+                                                                    (Prims.of_int (526))
                                                                     (Prims.of_int (41))
-                                                                    (Prims.of_int (483))
+                                                                    (Prims.of_int (526))
                                                                     (Prims.of_int (46)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (483))
+                                                                    (Prims.of_int (526))
                                                                     (Prims.of_int (26))
-                                                                    (Prims.of_int (483))
+                                                                    (Prims.of_int (526))
                                                                     (Prims.of_int (46)))))
                                                                     (Obj.magic
                                                                     (Pulse_PP.pp
@@ -4899,13 +5500,13 @@ let (check_equiv :
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                   (Prims.of_int (488)) (Prims.of_int (4))
-                   (Prims.of_int (488)) (Prims.of_int (80)))))
+                   (Prims.of_int (531)) (Prims.of_int (4))
+                   (Prims.of_int (531)) (Prims.of_int (80)))))
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                   (Prims.of_int (486)) (Prims.of_int (25))
-                   (Prims.of_int (490)) (Prims.of_int (5)))))
+                   (Prims.of_int (529)) (Prims.of_int (25))
+                   (Prims.of_int (533)) (Prims.of_int (5)))))
           (Obj.magic
              (Pulse_Typing_Util.check_equiv_now (Pulse_Typing.elab_env g)
                 (Pulse_Elaborate_Pure.elab_term t1)
@@ -4919,13 +5520,13 @@ let (check_equiv :
                          (FStar_Sealed.seal
                             (Obj.magic
                                (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                                  (Prims.of_int (489)) (Prims.of_int (2))
-                                  (Prims.of_int (489)) (Prims.of_int (21)))))
+                                  (Prims.of_int (532)) (Prims.of_int (2))
+                                  (Prims.of_int (532)) (Prims.of_int (21)))))
                          (FStar_Sealed.seal
                             (Obj.magic
                                (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                                  (Prims.of_int (487)) (Prims.of_int (6))
-                                  (Prims.of_int (487)) (Prims.of_int (9)))))
+                                  (Prims.of_int (530)) (Prims.of_int (6))
+                                  (Prims.of_int (530)) (Prims.of_int (9)))))
                          (Obj.magic
                             (FStar_Tactics_V2_Builtins.log_issues issues))
                          (fun uu___1 ->

--- a/src/ocaml/plugin/generated/Pulse_Checker_Pure.ml
+++ b/src/ocaml/plugin/generated/Pulse_Checker_Pure.ml
@@ -710,9 +710,10 @@ let (rtb_instantiate_implicits :
   Pulse_Typing_Env.env ->
     FStar_Reflection_Types.env ->
       FStar_Reflection_Types.term ->
-        (((FStar_Reflection_Types.namedv Prims.list *
-           FStar_Reflection_Types.term * FStar_Reflection_Types.typ)
-           FStar_Pervasives_Native.option * FStar_Issue.issue Prims.list),
+        ((((FStar_Reflection_Types.namedv * FStar_Reflection_Types.typ)
+           Prims.list * FStar_Reflection_Types.term *
+           FStar_Reflection_Types.typ) FStar_Pervasives_Native.option *
+           FStar_Issue.issue Prims.list),
           unit) FStar_Tactics_Effect.tac_repr)
   =
   fun g ->

--- a/src/ocaml/plugin/generated/Pulse_Checker_Pure.ml
+++ b/src/ocaml/plugin/generated/Pulse_Checker_Pure.ml
@@ -710,7 +710,8 @@ let (rtb_instantiate_implicits :
   Pulse_Typing_Env.env ->
     FStar_Reflection_Types.env ->
       FStar_Reflection_Types.term ->
-        (((FStar_Reflection_Types.term * FStar_Reflection_Types.typ)
+        (((FStar_Reflection_Types.namedv Prims.list *
+           FStar_Reflection_Types.term * FStar_Reflection_Types.typ)
            FStar_Pervasives_Native.option * FStar_Issue.issue Prims.list),
           unit) FStar_Tactics_Effect.tac_repr)
   =
@@ -828,7 +829,7 @@ let (rtb_instantiate_implicits :
                                                          (fun uu___3 ->
                                                             (res, iss))))
                                            | FStar_Pervasives_Native.Some
-                                               (t2, uu___2) ->
+                                               (uu___2, t2, uu___3) ->
                                                Obj.magic
                                                  (FStar_Tactics_Effect.tac_bind
                                                     (FStar_Sealed.seal
@@ -849,7 +850,7 @@ let (rtb_instantiate_implicits :
                                                              (Prims.of_int (12)))))
                                                     (Obj.magic
                                                        (debug g
-                                                          (fun uu___3 ->
+                                                          (fun uu___4 ->
                                                              FStar_Tactics_Effect.tac_bind
                                                                (FStar_Sealed.seal
                                                                   (Obj.magic
@@ -870,18 +871,18 @@ let (rtb_instantiate_implicits :
                                                                (Obj.magic
                                                                   (FStar_Tactics_V2_Builtins.term_to_string
                                                                     t2))
-                                                               (fun uu___4 ->
+                                                               (fun uu___5 ->
                                                                   FStar_Tactics_Effect.lift_div_tac
                                                                     (
                                                                     fun
-                                                                    uu___5 ->
+                                                                    uu___6 ->
                                                                     Prims.strcat
                                                                     "Returned from instantiate_implicits: "
                                                                     (Prims.strcat
-                                                                    uu___4 ""))))))
-                                                    (fun uu___3 ->
+                                                                    uu___5 ""))))))
+                                                    (fun uu___4 ->
                                                        FStar_Tactics_Effect.lift_div_tac
-                                                         (fun uu___4 ->
+                                                         (fun uu___5 ->
                                                             (res, iss))))))
                                      uu___1))) uu___1))) uu___)
 let (rtb_core_check_term :
@@ -1933,7 +1934,7 @@ let (instantiate_term_implicits :
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
                  (Prims.of_int (152)) (Prims.of_int (23))
-                 (Prims.of_int (174)) (Prims.of_int (49)))))
+                 (Prims.of_int (183)) (Prims.of_int (51)))))
         (FStar_Tactics_Effect.lift_div_tac
            (fun uu___ -> Pulse_Typing.elab_env g))
         (fun uu___ ->
@@ -1949,7 +1950,7 @@ let (instantiate_term_implicits :
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
                             (Prims.of_int (153)) (Prims.of_int (26))
-                            (Prims.of_int (174)) (Prims.of_int (49)))))
+                            (Prims.of_int (183)) (Prims.of_int (51)))))
                    (FStar_Tactics_Effect.lift_div_tac
                       (fun uu___ -> Pulse_Elaborate_Pure.elab_term t0))
                    (fun uu___ ->
@@ -1970,8 +1971,8 @@ let (instantiate_term_implicits :
                                        "Pulse.Checker.Pure.fst"
                                        (Prims.of_int (154))
                                        (Prims.of_int (78))
-                                       (Prims.of_int (174))
-                                       (Prims.of_int (49)))))
+                                       (Prims.of_int (183))
+                                       (Prims.of_int (51)))))
                               (Obj.magic
                                  (FStar_Tactics_Effect.tac_bind
                                     (FStar_Sealed.seal
@@ -2017,8 +2018,8 @@ let (instantiate_term_implicits :
                                                   "Pulse.Checker.Pure.fst"
                                                   (Prims.of_int (154))
                                                   (Prims.of_int (78))
-                                                  (Prims.of_int (174))
-                                                  (Prims.of_int (49)))))
+                                                  (Prims.of_int (183))
+                                                  (Prims.of_int (51)))))
                                          (Obj.magic
                                             (catch_all
                                                (fun uu___ ->
@@ -2044,8 +2045,8 @@ let (instantiate_term_implicits :
                                                                  "Pulse.Checker.Pure.fst"
                                                                  (Prims.of_int (157))
                                                                  (Prims.of_int (2))
-                                                                 (Prims.of_int (174))
-                                                                 (Prims.of_int (49)))))
+                                                                 (Prims.of_int (183))
+                                                                 (Prims.of_int (51)))))
                                                         (Obj.magic
                                                            (FStar_Tactics_V2_Builtins.log_issues
                                                               issues))
@@ -2141,33 +2142,126 @@ let (instantiate_term_implicits :
                                                                     uu___2))
                                                                     uu___2))
                                                               | FStar_Pervasives_Native.Some
-                                                                  (t, ty) ->
-                                                                  Obj.magic
-                                                                    (
-                                                                    FStar_Tactics_Effect.tac_bind
+                                                                  (namedvs,
+                                                                   t, ty)
+                                                                  ->
+                                                                  if
+                                                                    (FStar_List_Tot_Base.length
+                                                                    namedvs)
+                                                                    <>
+                                                                    Prims.int_zero
+                                                                  then
+                                                                    Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (167))
-                                                                    (Prims.of_int (15))
-                                                                    (Prims.of_int (167))
-                                                                    (Prims.of_int (28)))))
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (167))
-                                                                    (Prims.of_int (31))
+                                                                    (Prims.of_int (171))
+                                                                    (Prims.of_int (19))
                                                                     (Prims.of_int (174))
-                                                                    (Prims.of_int (49)))))
-                                                                    (FStar_Tactics_Effect.lift_div_tac
+                                                                    (Prims.of_int (9)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Pure.fst"
+                                                                    (Prims.of_int (170))
+                                                                    (Prims.of_int (6))
+                                                                    (Prims.of_int (174))
+                                                                    (Prims.of_int (9)))))
+                                                                    (Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Pure.fst"
+                                                                    (Prims.of_int (172))
+                                                                    (Prims.of_int (10))
+                                                                    (Prims.of_int (173))
+                                                                    (Prims.of_int (31)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Pure.fst"
+                                                                    (Prims.of_int (171))
+                                                                    (Prims.of_int (19))
+                                                                    (Prims.of_int (174))
+                                                                    (Prims.of_int (9)))))
+                                                                    (Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Pure.fst"
+                                                                    (Prims.of_int (173))
+                                                                    (Prims.of_int (24))
+                                                                    (Prims.of_int (173))
+                                                                    (Prims.of_int (31)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Pure.fst"
+                                                                    (Prims.of_int (172))
+                                                                    (Prims.of_int (10))
+                                                                    (Prims.of_int (173))
+                                                                    (Prims.of_int (31)))))
+                                                                    (Obj.magic
+                                                                    (Pulse_PP.pp
+                                                                    Pulse_PP.uu___44
+                                                                    t0))
                                                                     (fun
                                                                     uu___2 ->
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___3 ->
+                                                                    FStar_Pprint.prefix
+                                                                    (Prims.of_int (4))
+                                                                    Prims.int_one
+                                                                    (Pulse_PP.text
+                                                                    "check_term: could not infer implicit arguments in")
+                                                                    uu___2))))
+                                                                    (fun
+                                                                    uu___2 ->
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___3 ->
+                                                                    [uu___2]))))
+                                                                    (fun
+                                                                    uu___2 ->
+                                                                    (fun
+                                                                    uu___2 ->
+                                                                    Obj.magic
+                                                                    (maybe_fail_doc
+                                                                    [] g
+                                                                    t0.Pulse_Syntax_Base.range1
+                                                                    uu___2))
+                                                                    uu___2))
+                                                                  else
+                                                                    Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Pure.fst"
+                                                                    (Prims.of_int (176))
+                                                                    (Prims.of_int (17))
+                                                                    (Prims.of_int (176))
+                                                                    (Prims.of_int (30)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Pure.fst"
+                                                                    (Prims.of_int (176))
+                                                                    (Prims.of_int (33))
+                                                                    (Prims.of_int (183))
+                                                                    (Prims.of_int (51)))))
+                                                                    (FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___3 ->
                                                                     Pulse_Readback.readback_ty
                                                                     t))
                                                                     (fun
-                                                                    uu___2 ->
+                                                                    uu___3 ->
                                                                     (fun
                                                                     topt1 ->
                                                                     Obj.magic
@@ -2176,25 +2270,25 @@ let (instantiate_term_implicits :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (168))
-                                                                    (Prims.of_int (16))
-                                                                    (Prims.of_int (168))
-                                                                    (Prims.of_int (30)))))
+                                                                    (Prims.of_int (177))
+                                                                    (Prims.of_int (18))
+                                                                    (Prims.of_int (177))
+                                                                    (Prims.of_int (32)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (169))
-                                                                    (Prims.of_int (4))
-                                                                    (Prims.of_int (174))
-                                                                    (Prims.of_int (49)))))
+                                                                    (Prims.of_int (178))
+                                                                    (Prims.of_int (6))
+                                                                    (Prims.of_int (183))
+                                                                    (Prims.of_int (51)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
-                                                                    uu___2 ->
+                                                                    uu___3 ->
                                                                     Pulse_Readback.readback_ty
                                                                     ty))
                                                                     (fun
-                                                                    uu___2 ->
+                                                                    uu___3 ->
                                                                     (fun
                                                                     tyopt ->
                                                                     match 
@@ -2210,11 +2304,11 @@ let (instantiate_term_implicits :
                                                                     (Obj.repr
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
-                                                                    uu___2 ->
+                                                                    uu___3 ->
                                                                     (t1, ty1))))
                                                                     | 
                                                                     (FStar_Pervasives_Native.Some
-                                                                    uu___2,
+                                                                    uu___3,
                                                                     FStar_Pervasives_Native.None)
                                                                     ->
                                                                     Obj.magic
@@ -2224,35 +2318,35 @@ let (instantiate_term_implicits :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (172))
-                                                                    (Prims.of_int (29))
-                                                                    (Prims.of_int (172))
-                                                                    (Prims.of_int (50)))))
+                                                                    (Prims.of_int (181))
+                                                                    (Prims.of_int (31))
+                                                                    (Prims.of_int (181))
+                                                                    (Prims.of_int (52)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (172))
-                                                                    (Prims.of_int (6))
-                                                                    (Prims.of_int (172))
-                                                                    (Prims.of_int (50)))))
+                                                                    (Prims.of_int (181))
+                                                                    (Prims.of_int (8))
+                                                                    (Prims.of_int (181))
+                                                                    (Prims.of_int (52)))))
                                                                     (Obj.magic
                                                                     (readback_failure
                                                                     ty))
                                                                     (fun
-                                                                    uu___3 ->
+                                                                    uu___4 ->
                                                                     (fun
-                                                                    uu___3 ->
+                                                                    uu___4 ->
                                                                     Obj.magic
                                                                     (Pulse_Typing_Env.fail
                                                                     g
                                                                     (FStar_Pervasives_Native.Some
                                                                     (t0.Pulse_Syntax_Base.range1))
-                                                                    uu___3))
-                                                                    uu___3)))
+                                                                    uu___4))
+                                                                    uu___4)))
                                                                     | 
                                                                     (FStar_Pervasives_Native.None,
-                                                                    uu___2)
+                                                                    uu___3)
                                                                     ->
                                                                     Obj.magic
                                                                     (Obj.repr
@@ -2261,34 +2355,34 @@ let (instantiate_term_implicits :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (174))
-                                                                    (Prims.of_int (29))
-                                                                    (Prims.of_int (174))
-                                                                    (Prims.of_int (49)))))
+                                                                    (Prims.of_int (183))
+                                                                    (Prims.of_int (31))
+                                                                    (Prims.of_int (183))
+                                                                    (Prims.of_int (51)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (174))
-                                                                    (Prims.of_int (6))
-                                                                    (Prims.of_int (174))
-                                                                    (Prims.of_int (49)))))
+                                                                    (Prims.of_int (183))
+                                                                    (Prims.of_int (8))
+                                                                    (Prims.of_int (183))
+                                                                    (Prims.of_int (51)))))
                                                                     (Obj.magic
                                                                     (readback_failure
                                                                     t))
                                                                     (fun
-                                                                    uu___3 ->
+                                                                    uu___4 ->
                                                                     (fun
-                                                                    uu___3 ->
+                                                                    uu___4 ->
                                                                     Obj.magic
                                                                     (Pulse_Typing_Env.fail
                                                                     g
                                                                     (FStar_Pervasives_Native.Some
                                                                     (t0.Pulse_Syntax_Base.range1))
-                                                                    uu___3))
-                                                                    uu___3))))
-                                                                    uu___2)))
-                                                                    uu___2)))
+                                                                    uu___4))
+                                                                    uu___4))))
+                                                                    uu___3)))
+                                                                    uu___3)))
                                                              uu___1))) uu___)))
                                    uu___))) uu___))) uu___)
 let (check_universe :
@@ -2303,13 +2397,13 @@ let (check_universe :
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                 (Prims.of_int (178)) (Prims.of_int (12))
-                 (Prims.of_int (178)) (Prims.of_int (22)))))
+                 (Prims.of_int (187)) (Prims.of_int (12))
+                 (Prims.of_int (187)) (Prims.of_int (22)))))
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                 (Prims.of_int (178)) (Prims.of_int (25))
-                 (Prims.of_int (193)) (Prims.of_int (23)))))
+                 (Prims.of_int (187)) (Prims.of_int (25))
+                 (Prims.of_int (202)) (Prims.of_int (23)))))
         (FStar_Tactics_Effect.lift_div_tac
            (fun uu___ -> Pulse_Typing.elab_env g))
         (fun uu___ ->
@@ -2319,13 +2413,13 @@ let (check_universe :
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                            (Prims.of_int (179)) (Prims.of_int (13))
-                            (Prims.of_int (179)) (Prims.of_int (24)))))
+                            (Prims.of_int (188)) (Prims.of_int (13))
+                            (Prims.of_int (188)) (Prims.of_int (24)))))
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                            (Prims.of_int (179)) (Prims.of_int (27))
-                            (Prims.of_int (193)) (Prims.of_int (23)))))
+                            (Prims.of_int (188)) (Prims.of_int (27))
+                            (Prims.of_int (202)) (Prims.of_int (23)))))
                    (FStar_Tactics_Effect.lift_div_tac
                       (fun uu___ -> Pulse_Elaborate_Pure.elab_term t))
                    (fun uu___ ->
@@ -2336,17 +2430,17 @@ let (check_universe :
                                  (Obj.magic
                                     (FStar_Range.mk_range
                                        "Pulse.Checker.Pure.fst"
-                                       (Prims.of_int (180))
+                                       (Prims.of_int (189))
                                        (Prims.of_int (25))
-                                       (Prims.of_int (180))
+                                       (Prims.of_int (189))
                                        (Prims.of_int (68)))))
                               (FStar_Sealed.seal
                                  (Obj.magic
                                     (FStar_Range.mk_range
                                        "Pulse.Checker.Pure.fst"
-                                       (Prims.of_int (179))
+                                       (Prims.of_int (188))
                                        (Prims.of_int (27))
-                                       (Prims.of_int (193))
+                                       (Prims.of_int (202))
                                        (Prims.of_int (23)))))
                               (Obj.magic
                                  (catch_all
@@ -2361,17 +2455,17 @@ let (check_universe :
                                                 (Obj.magic
                                                    (FStar_Range.mk_range
                                                       "Pulse.Checker.Pure.fst"
-                                                      (Prims.of_int (181))
+                                                      (Prims.of_int (190))
                                                       (Prims.of_int (4))
-                                                      (Prims.of_int (181))
+                                                      (Prims.of_int (190))
                                                       (Prims.of_int (23)))))
                                              (FStar_Sealed.seal
                                                 (Obj.magic
                                                    (FStar_Range.mk_range
                                                       "Pulse.Checker.Pure.fst"
-                                                      (Prims.of_int (182))
+                                                      (Prims.of_int (191))
                                                       (Prims.of_int (4))
-                                                      (Prims.of_int (193))
+                                                      (Prims.of_int (202))
                                                       (Prims.of_int (23)))))
                                              (Obj.magic
                                                 (FStar_Tactics_V2_Builtins.log_issues
@@ -2388,17 +2482,17 @@ let (check_universe :
                                                                   (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (186))
+                                                                    (Prims.of_int (195))
                                                                     (Prims.of_int (18))
-                                                                    (Prims.of_int (186))
+                                                                    (Prims.of_int (195))
                                                                     (Prims.of_int (68)))))
                                                                (FStar_Sealed.seal
                                                                   (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (184))
+                                                                    (Prims.of_int (193))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (186))
+                                                                    (Prims.of_int (195))
                                                                     (Prims.of_int (68)))))
                                                                (Obj.magic
                                                                   (ill_typed_term
@@ -2444,25 +2538,25 @@ let (tc_meta_callback :
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                   (Prims.of_int (198)) (Prims.of_int (6))
-                   (Prims.of_int (203)) (Prims.of_int (14)))))
+                   (Prims.of_int (207)) (Prims.of_int (6))
+                   (Prims.of_int (212)) (Prims.of_int (14)))))
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                   (Prims.of_int (197)) (Prims.of_int (8))
-                   (Prims.of_int (197)) (Prims.of_int (11)))))
+                   (Prims.of_int (206)) (Prims.of_int (8))
+                   (Prims.of_int (206)) (Prims.of_int (11)))))
           (Obj.magic
              (FStar_Tactics_Effect.tac_bind
                 (FStar_Sealed.seal
                    (Obj.magic
                       (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                         (Prims.of_int (198)) (Prims.of_int (12))
-                         (Prims.of_int (198)) (Prims.of_int (50)))))
+                         (Prims.of_int (207)) (Prims.of_int (12))
+                         (Prims.of_int (207)) (Prims.of_int (50)))))
                 (FStar_Sealed.seal
                    (Obj.magic
                       (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                         (Prims.of_int (198)) (Prims.of_int (6))
-                         (Prims.of_int (203)) (Prims.of_int (14)))))
+                         (Prims.of_int (207)) (Prims.of_int (6))
+                         (Prims.of_int (212)) (Prims.of_int (14)))))
                 (Obj.magic (catch_all (fun uu___ -> rtb_tc_term g f e)))
                 (fun uu___ ->
                    FStar_Tactics_Effect.lift_div_tac
@@ -2491,13 +2585,13 @@ let (compute_term_type :
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                 (Prims.of_int (212)) (Prims.of_int (13))
-                 (Prims.of_int (212)) (Prims.of_int (23)))))
+                 (Prims.of_int (221)) (Prims.of_int (13))
+                 (Prims.of_int (221)) (Prims.of_int (23)))))
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                 (Prims.of_int (212)) (Prims.of_int (26))
-                 (Prims.of_int (228)) (Prims.of_int (50)))))
+                 (Prims.of_int (221)) (Prims.of_int (26))
+                 (Prims.of_int (237)) (Prims.of_int (50)))))
         (FStar_Tactics_Effect.lift_div_tac
            (fun uu___ -> Pulse_Typing.elab_env g))
         (fun uu___ ->
@@ -2507,13 +2601,13 @@ let (compute_term_type :
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                            (Prims.of_int (213)) (Prims.of_int (13))
-                            (Prims.of_int (213)) (Prims.of_int (24)))))
+                            (Prims.of_int (222)) (Prims.of_int (13))
+                            (Prims.of_int (222)) (Prims.of_int (24)))))
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                            (Prims.of_int (214)) (Prims.of_int (4))
-                            (Prims.of_int (228)) (Prims.of_int (50)))))
+                            (Prims.of_int (223)) (Prims.of_int (4))
+                            (Prims.of_int (237)) (Prims.of_int (50)))))
                    (FStar_Tactics_Effect.lift_div_tac
                       (fun uu___ -> Pulse_Elaborate_Pure.elab_term t))
                    (fun uu___ ->
@@ -2524,17 +2618,17 @@ let (compute_term_type :
                                  (Obj.magic
                                     (FStar_Range.mk_range
                                        "Pulse.Checker.Pure.fst"
-                                       (Prims.of_int (214))
+                                       (Prims.of_int (223))
                                        (Prims.of_int (4))
-                                       (Prims.of_int (217))
+                                       (Prims.of_int (226))
                                        (Prims.of_int (44)))))
                               (FStar_Sealed.seal
                                  (Obj.magic
                                     (FStar_Range.mk_range
                                        "Pulse.Checker.Pure.fst"
-                                       (Prims.of_int (217))
+                                       (Prims.of_int (226))
                                        (Prims.of_int (45))
-                                       (Prims.of_int (228))
+                                       (Prims.of_int (237))
                                        (Prims.of_int (50)))))
                               (Obj.magic
                                  (debug g
@@ -2544,17 +2638,17 @@ let (compute_term_type :
                                             (Obj.magic
                                                (FStar_Range.mk_range
                                                   "Pulse.Checker.Pure.fst"
-                                                  (Prims.of_int (217))
+                                                  (Prims.of_int (226))
                                                   (Prims.of_int (22))
-                                                  (Prims.of_int (217))
+                                                  (Prims.of_int (226))
                                                   (Prims.of_int (43)))))
                                          (FStar_Sealed.seal
                                             (Obj.magic
                                                (FStar_Range.mk_range
                                                   "Pulse.Checker.Pure.fst"
-                                                  (Prims.of_int (215))
+                                                  (Prims.of_int (224))
                                                   (Prims.of_int (12))
-                                                  (Prims.of_int (217))
+                                                  (Prims.of_int (226))
                                                   (Prims.of_int (43)))))
                                          (Obj.magic
                                             (FStar_Tactics_V2_Builtins.term_to_string
@@ -2567,17 +2661,17 @@ let (compute_term_type :
                                                        (Obj.magic
                                                           (FStar_Range.mk_range
                                                              "Pulse.Checker.Pure.fst"
-                                                             (Prims.of_int (215))
+                                                             (Prims.of_int (224))
                                                              (Prims.of_int (12))
-                                                             (Prims.of_int (217))
+                                                             (Prims.of_int (226))
                                                              (Prims.of_int (43)))))
                                                     (FStar_Sealed.seal
                                                        (Obj.magic
                                                           (FStar_Range.mk_range
                                                              "Pulse.Checker.Pure.fst"
-                                                             (Prims.of_int (215))
+                                                             (Prims.of_int (224))
                                                              (Prims.of_int (12))
-                                                             (Prims.of_int (217))
+                                                             (Prims.of_int (226))
                                                              (Prims.of_int (43)))))
                                                     (Obj.magic
                                                        (FStar_Tactics_Effect.tac_bind
@@ -2585,9 +2679,9 @@ let (compute_term_type :
                                                              (Obj.magic
                                                                 (FStar_Range.mk_range
                                                                    "Pulse.Checker.Pure.fst"
-                                                                   (Prims.of_int (216))
+                                                                   (Prims.of_int (225))
                                                                    (Prims.of_int (22))
-                                                                   (Prims.of_int (216))
+                                                                   (Prims.of_int (225))
                                                                    (Prims.of_int (42)))))
                                                           (FStar_Sealed.seal
                                                              (Obj.magic
@@ -2625,17 +2719,17 @@ let (compute_term_type :
                                             (Obj.magic
                                                (FStar_Range.mk_range
                                                   "Pulse.Checker.Pure.fst"
-                                                  (Prims.of_int (218))
+                                                  (Prims.of_int (227))
                                                   (Prims.of_int (22))
-                                                  (Prims.of_int (218))
+                                                  (Prims.of_int (227))
                                                   (Prims.of_int (46)))))
                                          (FStar_Sealed.seal
                                             (Obj.magic
                                                (FStar_Range.mk_range
                                                   "Pulse.Checker.Pure.fst"
-                                                  (Prims.of_int (217))
+                                                  (Prims.of_int (226))
                                                   (Prims.of_int (45))
-                                                  (Prims.of_int (228))
+                                                  (Prims.of_int (237))
                                                   (Prims.of_int (50)))))
                                          (Obj.magic
                                             (tc_meta_callback g fg rt))
@@ -2649,17 +2743,17 @@ let (compute_term_type :
                                                            (Obj.magic
                                                               (FStar_Range.mk_range
                                                                  "Pulse.Checker.Pure.fst"
-                                                                 (Prims.of_int (219))
+                                                                 (Prims.of_int (228))
                                                                  (Prims.of_int (4))
-                                                                 (Prims.of_int (219))
+                                                                 (Prims.of_int (228))
                                                                  (Prims.of_int (23)))))
                                                         (FStar_Sealed.seal
                                                            (Obj.magic
                                                               (FStar_Range.mk_range
                                                                  "Pulse.Checker.Pure.fst"
-                                                                 (Prims.of_int (220))
+                                                                 (Prims.of_int (229))
                                                                  (Prims.of_int (4))
-                                                                 (Prims.of_int (228))
+                                                                 (Prims.of_int (237))
                                                                  (Prims.of_int (50)))))
                                                         (Obj.magic
                                                            (FStar_Tactics_V2_Builtins.log_issues
@@ -2677,17 +2771,17 @@ let (compute_term_type :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (223))
+                                                                    (Prims.of_int (232))
                                                                     (Prims.of_int (22))
-                                                                    (Prims.of_int (223))
+                                                                    (Prims.of_int (232))
                                                                     (Prims.of_int (50)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (222))
+                                                                    (Prims.of_int (231))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (223))
+                                                                    (Prims.of_int (232))
                                                                     (Prims.of_int (50)))))
                                                                     (Obj.magic
                                                                     (ill_typed_term
@@ -2728,17 +2822,17 @@ let (compute_term_type :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (226))
+                                                                    (Prims.of_int (235))
                                                                     (Prims.of_int (41))
-                                                                    (Prims.of_int (226))
+                                                                    (Prims.of_int (235))
                                                                     (Prims.of_int (62)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (226))
+                                                                    (Prims.of_int (235))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (226))
+                                                                    (Prims.of_int (235))
                                                                     (Prims.of_int (62)))))
                                                                     (Obj.magic
                                                                     (readback_failure
@@ -2764,17 +2858,17 @@ let (compute_term_type :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (227))
+                                                                    (Prims.of_int (236))
                                                                     (Prims.of_int (41))
-                                                                    (Prims.of_int (227))
+                                                                    (Prims.of_int (236))
                                                                     (Prims.of_int (63)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (227))
+                                                                    (Prims.of_int (236))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (227))
+                                                                    (Prims.of_int (236))
                                                                     (Prims.of_int (63)))))
                                                                     (Obj.magic
                                                                     (readback_failure
@@ -2819,13 +2913,13 @@ let (compute_term_type_and_u :
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                 (Prims.of_int (237)) (Prims.of_int (13))
-                 (Prims.of_int (237)) (Prims.of_int (23)))))
+                 (Prims.of_int (246)) (Prims.of_int (13))
+                 (Prims.of_int (246)) (Prims.of_int (23)))))
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                 (Prims.of_int (237)) (Prims.of_int (26))
-                 (Prims.of_int (252)) (Prims.of_int (45)))))
+                 (Prims.of_int (246)) (Prims.of_int (26))
+                 (Prims.of_int (261)) (Prims.of_int (45)))))
         (FStar_Tactics_Effect.lift_div_tac
            (fun uu___ -> Pulse_Typing.elab_env g))
         (fun uu___ ->
@@ -2835,13 +2929,13 @@ let (compute_term_type_and_u :
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                            (Prims.of_int (238)) (Prims.of_int (13))
-                            (Prims.of_int (238)) (Prims.of_int (24)))))
+                            (Prims.of_int (247)) (Prims.of_int (13))
+                            (Prims.of_int (247)) (Prims.of_int (24)))))
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                            (Prims.of_int (238)) (Prims.of_int (27))
-                            (Prims.of_int (252)) (Prims.of_int (45)))))
+                            (Prims.of_int (247)) (Prims.of_int (27))
+                            (Prims.of_int (261)) (Prims.of_int (45)))))
                    (FStar_Tactics_Effect.lift_div_tac
                       (fun uu___ -> Pulse_Elaborate_Pure.elab_term t))
                    (fun uu___ ->
@@ -2852,17 +2946,17 @@ let (compute_term_type_and_u :
                                  (Obj.magic
                                     (FStar_Range.mk_range
                                        "Pulse.Checker.Pure.fst"
-                                       (Prims.of_int (239))
+                                       (Prims.of_int (248))
                                        (Prims.of_int (22))
-                                       (Prims.of_int (239))
+                                       (Prims.of_int (248))
                                        (Prims.of_int (46)))))
                               (FStar_Sealed.seal
                                  (Obj.magic
                                     (FStar_Range.mk_range
                                        "Pulse.Checker.Pure.fst"
-                                       (Prims.of_int (238))
+                                       (Prims.of_int (247))
                                        (Prims.of_int (27))
-                                       (Prims.of_int (252))
+                                       (Prims.of_int (261))
                                        (Prims.of_int (45)))))
                               (Obj.magic (tc_meta_callback g fg rt))
                               (fun uu___ ->
@@ -2875,17 +2969,17 @@ let (compute_term_type_and_u :
                                                 (Obj.magic
                                                    (FStar_Range.mk_range
                                                       "Pulse.Checker.Pure.fst"
-                                                      (Prims.of_int (240))
+                                                      (Prims.of_int (249))
                                                       (Prims.of_int (4))
-                                                      (Prims.of_int (240))
+                                                      (Prims.of_int (249))
                                                       (Prims.of_int (23)))))
                                              (FStar_Sealed.seal
                                                 (Obj.magic
                                                    (FStar_Range.mk_range
                                                       "Pulse.Checker.Pure.fst"
-                                                      (Prims.of_int (241))
+                                                      (Prims.of_int (250))
                                                       (Prims.of_int (4))
-                                                      (Prims.of_int (252))
+                                                      (Prims.of_int (261))
                                                       (Prims.of_int (45)))))
                                              (Obj.magic
                                                 (FStar_Tactics_V2_Builtins.log_issues
@@ -2901,17 +2995,17 @@ let (compute_term_type_and_u :
                                                                (Obj.magic
                                                                   (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (245))
+                                                                    (Prims.of_int (254))
                                                                     (Prims.of_int (18))
-                                                                    (Prims.of_int (245))
+                                                                    (Prims.of_int (254))
                                                                     (Prims.of_int (46)))))
                                                             (FStar_Sealed.seal
                                                                (Obj.magic
                                                                   (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (243))
+                                                                    (Prims.of_int (252))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (245))
+                                                                    (Prims.of_int (254))
                                                                     (Prims.of_int (46)))))
                                                             (Obj.magic
                                                                (ill_typed_term
@@ -2945,18 +3039,18 @@ let (compute_term_type_and_u :
                                                                     Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (248))
+                                                                    (Prims.of_int (257))
                                                                     (Prims.of_int (41))
-                                                                    (Prims.of_int (248))
+                                                                    (Prims.of_int (257))
                                                                     (Prims.of_int (62)))))
                                                                  (FStar_Sealed.seal
                                                                     (
                                                                     Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (248))
+                                                                    (Prims.of_int (257))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (248))
+                                                                    (Prims.of_int (257))
                                                                     (Prims.of_int (62)))))
                                                                  (Obj.magic
                                                                     (
@@ -2983,18 +3077,18 @@ let (compute_term_type_and_u :
                                                                     Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (249))
+                                                                    (Prims.of_int (258))
                                                                     (Prims.of_int (41))
-                                                                    (Prims.of_int (249))
+                                                                    (Prims.of_int (258))
                                                                     (Prims.of_int (63)))))
                                                                  (FStar_Sealed.seal
                                                                     (
                                                                     Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (249))
+                                                                    (Prims.of_int (258))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (249))
+                                                                    (Prims.of_int (258))
                                                                     (Prims.of_int (63)))))
                                                                  (Obj.magic
                                                                     (
@@ -3022,18 +3116,18 @@ let (compute_term_type_and_u :
                                                                     Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (251))
+                                                                    (Prims.of_int (260))
                                                                     (Prims.of_int (27))
-                                                                    (Prims.of_int (251))
+                                                                    (Prims.of_int (260))
                                                                     (Prims.of_int (46)))))
                                                                  (FStar_Sealed.seal
                                                                     (
                                                                     Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (250))
+                                                                    (Prims.of_int (259))
                                                                     (Prims.of_int (26))
-                                                                    (Prims.of_int (252))
+                                                                    (Prims.of_int (261))
                                                                     (Prims.of_int (45)))))
                                                                  (Obj.magic
                                                                     (
@@ -3074,13 +3168,13 @@ let (check_term :
             (FStar_Sealed.seal
                (Obj.magic
                   (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                     (Prims.of_int (257)) (Prims.of_int (13))
-                     (Prims.of_int (257)) (Prims.of_int (43)))))
+                     (Prims.of_int (266)) (Prims.of_int (13))
+                     (Prims.of_int (266)) (Prims.of_int (43)))))
             (FStar_Sealed.seal
                (Obj.magic
                   (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                     (Prims.of_int (255)) (Prims.of_int (39))
-                     (Prims.of_int (274)) (Prims.of_int (78)))))
+                     (Prims.of_int (264)) (Prims.of_int (39))
+                     (Prims.of_int (283)) (Prims.of_int (78)))))
             (Obj.magic (instantiate_term_implicits g e))
             (fun uu___ ->
                (fun uu___ ->
@@ -3092,14 +3186,14 @@ let (check_term :
                               (Obj.magic
                                  (FStar_Range.mk_range
                                     "Pulse.Checker.Pure.fst"
-                                    (Prims.of_int (259)) (Prims.of_int (11))
-                                    (Prims.of_int (259)) (Prims.of_int (21)))))
+                                    (Prims.of_int (268)) (Prims.of_int (11))
+                                    (Prims.of_int (268)) (Prims.of_int (21)))))
                            (FStar_Sealed.seal
                               (Obj.magic
                                  (FStar_Range.mk_range
                                     "Pulse.Checker.Pure.fst"
-                                    (Prims.of_int (259)) (Prims.of_int (24))
-                                    (Prims.of_int (274)) (Prims.of_int (78)))))
+                                    (Prims.of_int (268)) (Prims.of_int (24))
+                                    (Prims.of_int (283)) (Prims.of_int (78)))))
                            (FStar_Tactics_Effect.lift_div_tac
                               (fun uu___2 -> Pulse_Typing.elab_env g))
                            (fun uu___2 ->
@@ -3110,17 +3204,17 @@ let (check_term :
                                          (Obj.magic
                                             (FStar_Range.mk_range
                                                "Pulse.Checker.Pure.fst"
-                                               (Prims.of_int (260))
+                                               (Prims.of_int (269))
                                                (Prims.of_int (11))
-                                               (Prims.of_int (260))
+                                               (Prims.of_int (269))
                                                (Prims.of_int (22)))))
                                       (FStar_Sealed.seal
                                          (Obj.magic
                                             (FStar_Range.mk_range
                                                "Pulse.Checker.Pure.fst"
-                                               (Prims.of_int (260))
+                                               (Prims.of_int (269))
                                                (Prims.of_int (25))
-                                               (Prims.of_int (274))
+                                               (Prims.of_int (283))
                                                (Prims.of_int (78)))))
                                       (FStar_Tactics_Effect.lift_div_tac
                                          (fun uu___2 ->
@@ -3133,17 +3227,17 @@ let (check_term :
                                                     (Obj.magic
                                                        (FStar_Range.mk_range
                                                           "Pulse.Checker.Pure.fst"
-                                                          (Prims.of_int (261))
+                                                          (Prims.of_int (270))
                                                           (Prims.of_int (11))
-                                                          (Prims.of_int (261))
+                                                          (Prims.of_int (270))
                                                           (Prims.of_int (22)))))
                                                  (FStar_Sealed.seal
                                                     (Obj.magic
                                                        (FStar_Range.mk_range
                                                           "Pulse.Checker.Pure.fst"
-                                                          (Prims.of_int (261))
+                                                          (Prims.of_int (270))
                                                           (Prims.of_int (25))
-                                                          (Prims.of_int (274))
+                                                          (Prims.of_int (283))
                                                           (Prims.of_int (78)))))
                                                  (FStar_Tactics_Effect.lift_div_tac
                                                     (fun uu___2 ->
@@ -3157,17 +3251,17 @@ let (check_term :
                                                                (Obj.magic
                                                                   (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (264))
+                                                                    (Prims.of_int (273))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (267))
-                                                                    (Prims.of_int (20)))))
+                                                                    (Prims.of_int (276))
+                                                                    (Prims.of_int (22)))))
                                                             (FStar_Sealed.seal
                                                                (Obj.magic
                                                                   (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (261))
+                                                                    (Prims.of_int (270))
                                                                     (Prims.of_int (25))
-                                                                    (Prims.of_int (274))
+                                                                    (Prims.of_int (283))
                                                                     (Prims.of_int (78)))))
                                                             (Obj.magic
                                                                (catch_all
@@ -3193,17 +3287,17 @@ let (check_term :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (268))
+                                                                    (Prims.of_int (277))
                                                                     (Prims.of_int (2))
-                                                                    (Prims.of_int (268))
+                                                                    (Prims.of_int (277))
                                                                     (Prims.of_int (21)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (269))
+                                                                    (Prims.of_int (278))
                                                                     (Prims.of_int (2))
-                                                                    (Prims.of_int (274))
+                                                                    (Prims.of_int (283))
                                                                     (Prims.of_int (78)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_V2_Builtins.log_issues
@@ -3224,17 +3318,17 @@ let (check_term :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (273))
+                                                                    (Prims.of_int (282))
                                                                     (Prims.of_int (16))
-                                                                    (Prims.of_int (273))
+                                                                    (Prims.of_int (282))
                                                                     (Prims.of_int (48)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (271))
+                                                                    (Prims.of_int (280))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (273))
+                                                                    (Prims.of_int (282))
                                                                     (Prims.of_int (48)))))
                                                                     (Obj.magic
                                                                     (ill_typed_term
@@ -3281,13 +3375,13 @@ let (check_term_at_type :
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                   (Prims.of_int (279)) (Prims.of_int (13))
-                   (Prims.of_int (279)) (Prims.of_int (43)))))
+                   (Prims.of_int (288)) (Prims.of_int (13))
+                   (Prims.of_int (288)) (Prims.of_int (43)))))
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                   (Prims.of_int (277)) (Prims.of_int (60))
-                   (Prims.of_int (297)) (Prims.of_int (65)))))
+                   (Prims.of_int (286)) (Prims.of_int (60))
+                   (Prims.of_int (305)) (Prims.of_int (65)))))
           (Obj.magic (instantiate_term_implicits g e))
           (fun uu___ ->
              (fun uu___ ->
@@ -3298,13 +3392,13 @@ let (check_term_at_type :
                          (FStar_Sealed.seal
                             (Obj.magic
                                (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                                  (Prims.of_int (281)) (Prims.of_int (11))
-                                  (Prims.of_int (281)) (Prims.of_int (21)))))
+                                  (Prims.of_int (289)) (Prims.of_int (11))
+                                  (Prims.of_int (289)) (Prims.of_int (21)))))
                          (FStar_Sealed.seal
                             (Obj.magic
                                (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                                  (Prims.of_int (281)) (Prims.of_int (24))
-                                  (Prims.of_int (297)) (Prims.of_int (65)))))
+                                  (Prims.of_int (289)) (Prims.of_int (24))
+                                  (Prims.of_int (305)) (Prims.of_int (65)))))
                          (FStar_Tactics_Effect.lift_div_tac
                             (fun uu___2 -> Pulse_Typing.elab_env g))
                          (fun uu___2 ->
@@ -3315,17 +3409,17 @@ let (check_term_at_type :
                                        (Obj.magic
                                           (FStar_Range.mk_range
                                              "Pulse.Checker.Pure.fst"
-                                             (Prims.of_int (282))
+                                             (Prims.of_int (290))
                                              (Prims.of_int (11))
-                                             (Prims.of_int (282))
+                                             (Prims.of_int (290))
                                              (Prims.of_int (22)))))
                                     (FStar_Sealed.seal
                                        (Obj.magic
                                           (FStar_Range.mk_range
                                              "Pulse.Checker.Pure.fst"
-                                             (Prims.of_int (282))
+                                             (Prims.of_int (290))
                                              (Prims.of_int (25))
-                                             (Prims.of_int (297))
+                                             (Prims.of_int (305))
                                              (Prims.of_int (65)))))
                                     (FStar_Tactics_Effect.lift_div_tac
                                        (fun uu___2 ->
@@ -3338,17 +3432,17 @@ let (check_term_at_type :
                                                   (Obj.magic
                                                      (FStar_Range.mk_range
                                                         "Pulse.Checker.Pure.fst"
-                                                        (Prims.of_int (283))
+                                                        (Prims.of_int (291))
                                                         (Prims.of_int (11))
-                                                        (Prims.of_int (283))
+                                                        (Prims.of_int (291))
                                                         (Prims.of_int (22)))))
                                                (FStar_Sealed.seal
                                                   (Obj.magic
                                                      (FStar_Range.mk_range
                                                         "Pulse.Checker.Pure.fst"
-                                                        (Prims.of_int (283))
+                                                        (Prims.of_int (291))
                                                         (Prims.of_int (25))
-                                                        (Prims.of_int (297))
+                                                        (Prims.of_int (305))
                                                         (Prims.of_int (65)))))
                                                (FStar_Tactics_Effect.lift_div_tac
                                                   (fun uu___2 ->
@@ -3362,17 +3456,17 @@ let (check_term_at_type :
                                                              (Obj.magic
                                                                 (FStar_Range.mk_range
                                                                    "Pulse.Checker.Pure.fst"
-                                                                   (Prims.of_int (286))
+                                                                   (Prims.of_int (294))
                                                                    (Prims.of_int (4))
-                                                                   (Prims.of_int (289))
-                                                                   (Prims.of_int (16)))))
+                                                                   (Prims.of_int (297))
+                                                                   (Prims.of_int (15)))))
                                                           (FStar_Sealed.seal
                                                              (Obj.magic
                                                                 (FStar_Range.mk_range
                                                                    "Pulse.Checker.Pure.fst"
-                                                                   (Prims.of_int (283))
+                                                                   (Prims.of_int (291))
                                                                    (Prims.of_int (25))
-                                                                   (Prims.of_int (297))
+                                                                   (Prims.of_int (305))
                                                                    (Prims.of_int (65)))))
                                                           (Obj.magic
                                                              (catch_all
@@ -3397,17 +3491,17 @@ let (check_term_at_type :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (290))
+                                                                    (Prims.of_int (298))
                                                                     (Prims.of_int (2))
-                                                                    (Prims.of_int (290))
+                                                                    (Prims.of_int (298))
                                                                     (Prims.of_int (21)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (291))
+                                                                    (Prims.of_int (299))
                                                                     (Prims.of_int (2))
-                                                                    (Prims.of_int (297))
+                                                                    (Prims.of_int (305))
                                                                     (Prims.of_int (65)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_V2_Builtins.log_issues
@@ -3428,17 +3522,17 @@ let (check_term_at_type :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (295))
+                                                                    (Prims.of_int (303))
                                                                     (Prims.of_int (16))
-                                                                    (Prims.of_int (295))
+                                                                    (Prims.of_int (303))
                                                                     (Prims.of_int (48)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (293))
+                                                                    (Prims.of_int (301))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (295))
+                                                                    (Prims.of_int (303))
                                                                     (Prims.of_int (48)))))
                                                                     (Obj.magic
                                                                     (ill_typed_term
@@ -3488,13 +3582,13 @@ let (tc_with_core :
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                   (Prims.of_int (301)) (Prims.of_int (23))
-                   (Prims.of_int (301)) (Prims.of_int (124)))))
+                   (Prims.of_int (309)) (Prims.of_int (23))
+                   (Prims.of_int (309)) (Prims.of_int (124)))))
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                   (Prims.of_int (301)) (Prims.of_int (3))
-                   (Prims.of_int (305)) (Prims.of_int (76)))))
+                   (Prims.of_int (309)) (Prims.of_int (3))
+                   (Prims.of_int (313)) (Prims.of_int (76)))))
           (Obj.magic
              (catch_all
                 (fun uu___ ->
@@ -3528,13 +3622,13 @@ let (core_compute_term_type :
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                 (Prims.of_int (311)) (Prims.of_int (13))
-                 (Prims.of_int (311)) (Prims.of_int (23)))))
+                 (Prims.of_int (319)) (Prims.of_int (13))
+                 (Prims.of_int (319)) (Prims.of_int (23)))))
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                 (Prims.of_int (311)) (Prims.of_int (26))
-                 (Prims.of_int (325)) (Prims.of_int (30)))))
+                 (Prims.of_int (319)) (Prims.of_int (26))
+                 (Prims.of_int (333)) (Prims.of_int (30)))))
         (FStar_Tactics_Effect.lift_div_tac
            (fun uu___ -> Pulse_Typing.elab_env g))
         (fun uu___ ->
@@ -3544,13 +3638,13 @@ let (core_compute_term_type :
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                            (Prims.of_int (312)) (Prims.of_int (13))
-                            (Prims.of_int (312)) (Prims.of_int (24)))))
+                            (Prims.of_int (320)) (Prims.of_int (13))
+                            (Prims.of_int (320)) (Prims.of_int (24)))))
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                            (Prims.of_int (312)) (Prims.of_int (27))
-                            (Prims.of_int (325)) (Prims.of_int (30)))))
+                            (Prims.of_int (320)) (Prims.of_int (27))
+                            (Prims.of_int (333)) (Prims.of_int (30)))))
                    (FStar_Tactics_Effect.lift_div_tac
                       (fun uu___ -> Pulse_Elaborate_Pure.elab_term t))
                    (fun uu___ ->
@@ -3561,17 +3655,17 @@ let (core_compute_term_type :
                                  (Obj.magic
                                     (FStar_Range.mk_range
                                        "Pulse.Checker.Pure.fst"
-                                       (Prims.of_int (313))
+                                       (Prims.of_int (321))
                                        (Prims.of_int (22))
-                                       (Prims.of_int (313))
+                                       (Prims.of_int (321))
                                        (Prims.of_int (94)))))
                               (FStar_Sealed.seal
                                  (Obj.magic
                                     (FStar_Range.mk_range
                                        "Pulse.Checker.Pure.fst"
-                                       (Prims.of_int (312))
+                                       (Prims.of_int (320))
                                        (Prims.of_int (27))
-                                       (Prims.of_int (325))
+                                       (Prims.of_int (333))
                                        (Prims.of_int (30)))))
                               (Obj.magic
                                  (tc_with_core
@@ -3589,17 +3683,17 @@ let (core_compute_term_type :
                                                 (Obj.magic
                                                    (FStar_Range.mk_range
                                                       "Pulse.Checker.Pure.fst"
-                                                      (Prims.of_int (314))
+                                                      (Prims.of_int (322))
                                                       (Prims.of_int (4))
-                                                      (Prims.of_int (314))
+                                                      (Prims.of_int (322))
                                                       (Prims.of_int (23)))))
                                              (FStar_Sealed.seal
                                                 (Obj.magic
                                                    (FStar_Range.mk_range
                                                       "Pulse.Checker.Pure.fst"
-                                                      (Prims.of_int (315))
+                                                      (Prims.of_int (323))
                                                       (Prims.of_int (4))
-                                                      (Prims.of_int (325))
+                                                      (Prims.of_int (333))
                                                       (Prims.of_int (30)))))
                                              (Obj.magic
                                                 (FStar_Tactics_V2_Builtins.log_issues
@@ -3616,17 +3710,17 @@ let (core_compute_term_type :
                                                                   (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (319))
+                                                                    (Prims.of_int (327))
                                                                     (Prims.of_int (18))
-                                                                    (Prims.of_int (319))
+                                                                    (Prims.of_int (327))
                                                                     (Prims.of_int (46)))))
                                                                (FStar_Sealed.seal
                                                                   (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (317))
+                                                                    (Prims.of_int (325))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (319))
+                                                                    (Prims.of_int (327))
                                                                     (Prims.of_int (46)))))
                                                                (Obj.magic
                                                                   (ill_typed_term
@@ -3658,17 +3752,17 @@ let (core_compute_term_type :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (323))
+                                                                    (Prims.of_int (331))
                                                                     (Prims.of_int (32))
-                                                                    (Prims.of_int (323))
+                                                                    (Prims.of_int (331))
                                                                     (Prims.of_int (54)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (323))
+                                                                    (Prims.of_int (331))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (323))
+                                                                    (Prims.of_int (331))
                                                                     (Prims.of_int (54)))))
                                                                     (Obj.magic
                                                                     (readback_failure
@@ -3709,13 +3803,13 @@ let (core_check_term :
             (FStar_Sealed.seal
                (Obj.magic
                   (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                     (Prims.of_int (328)) (Prims.of_int (11))
-                     (Prims.of_int (328)) (Prims.of_int (21)))))
+                     (Prims.of_int (336)) (Prims.of_int (11))
+                     (Prims.of_int (336)) (Prims.of_int (21)))))
             (FStar_Sealed.seal
                (Obj.magic
                   (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                     (Prims.of_int (328)) (Prims.of_int (24))
-                     (Prims.of_int (342)) (Prims.of_int (69)))))
+                     (Prims.of_int (336)) (Prims.of_int (24))
+                     (Prims.of_int (350)) (Prims.of_int (69)))))
             (FStar_Tactics_Effect.lift_div_tac
                (fun uu___ -> Pulse_Typing.elab_env g))
             (fun uu___ ->
@@ -3725,13 +3819,13 @@ let (core_check_term :
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                                (Prims.of_int (329)) (Prims.of_int (11))
-                                (Prims.of_int (329)) (Prims.of_int (22)))))
+                                (Prims.of_int (337)) (Prims.of_int (11))
+                                (Prims.of_int (337)) (Prims.of_int (22)))))
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                                (Prims.of_int (329)) (Prims.of_int (25))
-                                (Prims.of_int (342)) (Prims.of_int (69)))))
+                                (Prims.of_int (337)) (Prims.of_int (25))
+                                (Prims.of_int (350)) (Prims.of_int (69)))))
                        (FStar_Tactics_Effect.lift_div_tac
                           (fun uu___ -> Pulse_Elaborate_Pure.elab_term e))
                        (fun uu___ ->
@@ -3742,17 +3836,17 @@ let (core_check_term :
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "Pulse.Checker.Pure.fst"
-                                           (Prims.of_int (330))
+                                           (Prims.of_int (338))
                                            (Prims.of_int (11))
-                                           (Prims.of_int (330))
+                                           (Prims.of_int (338))
                                            (Prims.of_int (22)))))
                                   (FStar_Sealed.seal
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "Pulse.Checker.Pure.fst"
-                                           (Prims.of_int (330))
+                                           (Prims.of_int (338))
                                            (Prims.of_int (25))
-                                           (Prims.of_int (342))
+                                           (Prims.of_int (350))
                                            (Prims.of_int (69)))))
                                   (FStar_Tactics_Effect.lift_div_tac
                                      (fun uu___ ->
@@ -3765,17 +3859,17 @@ let (core_check_term :
                                                 (Obj.magic
                                                    (FStar_Range.mk_range
                                                       "Pulse.Checker.Pure.fst"
-                                                      (Prims.of_int (332))
+                                                      (Prims.of_int (340))
                                                       (Prims.of_int (4))
-                                                      (Prims.of_int (335))
+                                                      (Prims.of_int (343))
                                                       (Prims.of_int (20)))))
                                              (FStar_Sealed.seal
                                                 (Obj.magic
                                                    (FStar_Range.mk_range
                                                       "Pulse.Checker.Pure.fst"
-                                                      (Prims.of_int (330))
+                                                      (Prims.of_int (338))
                                                       (Prims.of_int (25))
-                                                      (Prims.of_int (342))
+                                                      (Prims.of_int (350))
                                                       (Prims.of_int (69)))))
                                              (Obj.magic
                                                 (catch_all
@@ -3797,17 +3891,17 @@ let (core_check_term :
                                                                (Obj.magic
                                                                   (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (336))
+                                                                    (Prims.of_int (344))
                                                                     (Prims.of_int (2))
-                                                                    (Prims.of_int (336))
+                                                                    (Prims.of_int (344))
                                                                     (Prims.of_int (21)))))
                                                             (FStar_Sealed.seal
                                                                (Obj.magic
                                                                   (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (337))
+                                                                    (Prims.of_int (345))
                                                                     (Prims.of_int (2))
-                                                                    (Prims.of_int (342))
+                                                                    (Prims.of_int (350))
                                                                     (Prims.of_int (69)))))
                                                             (Obj.magic
                                                                (FStar_Tactics_V2_Builtins.log_issues
@@ -3825,17 +3919,17 @@ let (core_check_term :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (341))
+                                                                    (Prims.of_int (349))
                                                                     (Prims.of_int (16))
-                                                                    (Prims.of_int (341))
+                                                                    (Prims.of_int (349))
                                                                     (Prims.of_int (48)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (339))
+                                                                    (Prims.of_int (347))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (341))
+                                                                    (Prims.of_int (349))
                                                                     (Prims.of_int (48)))))
                                                                     (Obj.magic
                                                                     (ill_typed_term
@@ -3878,13 +3972,13 @@ let (core_check_term_at_type :
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                   (Prims.of_int (345)) (Prims.of_int (11))
-                   (Prims.of_int (345)) (Prims.of_int (21)))))
+                   (Prims.of_int (353)) (Prims.of_int (11))
+                   (Prims.of_int (353)) (Prims.of_int (21)))))
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                   (Prims.of_int (345)) (Prims.of_int (24))
-                   (Prims.of_int (360)) (Prims.of_int (62)))))
+                   (Prims.of_int (353)) (Prims.of_int (24))
+                   (Prims.of_int (368)) (Prims.of_int (62)))))
           (FStar_Tactics_Effect.lift_div_tac
              (fun uu___ -> Pulse_Typing.elab_env g))
           (fun uu___ ->
@@ -3894,13 +3988,13 @@ let (core_check_term_at_type :
                      (FStar_Sealed.seal
                         (Obj.magic
                            (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                              (Prims.of_int (346)) (Prims.of_int (11))
-                              (Prims.of_int (346)) (Prims.of_int (22)))))
+                              (Prims.of_int (354)) (Prims.of_int (11))
+                              (Prims.of_int (354)) (Prims.of_int (22)))))
                      (FStar_Sealed.seal
                         (Obj.magic
                            (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                              (Prims.of_int (346)) (Prims.of_int (25))
-                              (Prims.of_int (360)) (Prims.of_int (62)))))
+                              (Prims.of_int (354)) (Prims.of_int (25))
+                              (Prims.of_int (368)) (Prims.of_int (62)))))
                      (FStar_Tactics_Effect.lift_div_tac
                         (fun uu___ -> Pulse_Elaborate_Pure.elab_term e))
                      (fun uu___ ->
@@ -3911,17 +4005,17 @@ let (core_check_term_at_type :
                                    (Obj.magic
                                       (FStar_Range.mk_range
                                          "Pulse.Checker.Pure.fst"
-                                         (Prims.of_int (347))
+                                         (Prims.of_int (355))
                                          (Prims.of_int (11))
-                                         (Prims.of_int (347))
+                                         (Prims.of_int (355))
                                          (Prims.of_int (22)))))
                                 (FStar_Sealed.seal
                                    (Obj.magic
                                       (FStar_Range.mk_range
                                          "Pulse.Checker.Pure.fst"
-                                         (Prims.of_int (347))
+                                         (Prims.of_int (355))
                                          (Prims.of_int (25))
-                                         (Prims.of_int (360))
+                                         (Prims.of_int (368))
                                          (Prims.of_int (62)))))
                                 (FStar_Tactics_Effect.lift_div_tac
                                    (fun uu___ ->
@@ -3934,17 +4028,17 @@ let (core_check_term_at_type :
                                               (Obj.magic
                                                  (FStar_Range.mk_range
                                                     "Pulse.Checker.Pure.fst"
-                                                    (Prims.of_int (349))
+                                                    (Prims.of_int (357))
                                                     (Prims.of_int (4))
-                                                    (Prims.of_int (352))
+                                                    (Prims.of_int (360))
                                                     (Prims.of_int (16)))))
                                            (FStar_Sealed.seal
                                               (Obj.magic
                                                  (FStar_Range.mk_range
                                                     "Pulse.Checker.Pure.fst"
-                                                    (Prims.of_int (347))
+                                                    (Prims.of_int (355))
                                                     (Prims.of_int (25))
-                                                    (Prims.of_int (360))
+                                                    (Prims.of_int (368))
                                                     (Prims.of_int (62)))))
                                            (Obj.magic
                                               (catch_all
@@ -3965,17 +4059,17 @@ let (core_check_term_at_type :
                                                              (Obj.magic
                                                                 (FStar_Range.mk_range
                                                                    "Pulse.Checker.Pure.fst"
-                                                                   (Prims.of_int (353))
+                                                                   (Prims.of_int (361))
                                                                    (Prims.of_int (2))
-                                                                   (Prims.of_int (353))
+                                                                   (Prims.of_int (361))
                                                                    (Prims.of_int (21)))))
                                                           (FStar_Sealed.seal
                                                              (Obj.magic
                                                                 (FStar_Range.mk_range
                                                                    "Pulse.Checker.Pure.fst"
-                                                                   (Prims.of_int (354))
+                                                                   (Prims.of_int (362))
                                                                    (Prims.of_int (2))
-                                                                   (Prims.of_int (360))
+                                                                   (Prims.of_int (368))
                                                                    (Prims.of_int (62)))))
                                                           (Obj.magic
                                                              (FStar_Tactics_V2_Builtins.log_issues
@@ -3993,17 +4087,17 @@ let (core_check_term_at_type :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (358))
+                                                                    (Prims.of_int (366))
                                                                     (Prims.of_int (16))
-                                                                    (Prims.of_int (358))
+                                                                    (Prims.of_int (366))
                                                                     (Prims.of_int (48)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (356))
+                                                                    (Prims.of_int (364))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (358))
+                                                                    (Prims.of_int (366))
                                                                     (Prims.of_int (48)))))
                                                                     (Obj.magic
                                                                     (ill_typed_term
@@ -4071,13 +4165,13 @@ let (get_non_informative_witness :
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                   (Prims.of_int (383)) (Prims.of_int (6))
-                   (Prims.of_int (387)) (Prims.of_int (7)))))
+                   (Prims.of_int (391)) (Prims.of_int (6))
+                   (Prims.of_int (395)) (Prims.of_int (7)))))
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                   (Prims.of_int (388)) (Prims.of_int (6))
-                   (Prims.of_int (422)) (Prims.of_int (39)))))
+                   (Prims.of_int (396)) (Prims.of_int (6))
+                   (Prims.of_int (430)) (Prims.of_int (39)))))
           (FStar_Tactics_Effect.lift_div_tac
              (fun uu___ ->
                 fun uu___1 ->
@@ -4085,44 +4179,44 @@ let (get_non_informative_witness :
                     (FStar_Sealed.seal
                        (Obj.magic
                           (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                             (Prims.of_int (384)) (Prims.of_int (32))
-                             (Prims.of_int (387)) (Prims.of_int (7)))))
+                             (Prims.of_int (392)) (Prims.of_int (32))
+                             (Prims.of_int (395)) (Prims.of_int (7)))))
                     (FStar_Sealed.seal
                        (Obj.magic
                           (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                             (Prims.of_int (384)) (Prims.of_int (6))
-                             (Prims.of_int (387)) (Prims.of_int (7)))))
+                             (Prims.of_int (392)) (Prims.of_int (6))
+                             (Prims.of_int (395)) (Prims.of_int (7)))))
                     (Obj.magic
                        (FStar_Tactics_Effect.tac_bind
                           (FStar_Sealed.seal
                              (Obj.magic
                                 (FStar_Range.mk_range
                                    "Pulse.Checker.Pure.fst"
-                                   (Prims.of_int (385)) (Prims.of_int (8))
-                                   (Prims.of_int (386)) (Prims.of_int (18)))))
+                                   (Prims.of_int (393)) (Prims.of_int (8))
+                                   (Prims.of_int (394)) (Prims.of_int (18)))))
                           (FStar_Sealed.seal
                              (Obj.magic
                                 (FStar_Range.mk_range
                                    "Pulse.Checker.Pure.fst"
-                                   (Prims.of_int (384)) (Prims.of_int (32))
-                                   (Prims.of_int (387)) (Prims.of_int (7)))))
+                                   (Prims.of_int (392)) (Prims.of_int (32))
+                                   (Prims.of_int (395)) (Prims.of_int (7)))))
                           (Obj.magic
                              (FStar_Tactics_Effect.tac_bind
                                 (FStar_Sealed.seal
                                    (Obj.magic
                                       (FStar_Range.mk_range
                                          "Pulse.Checker.Pure.fst"
-                                         (Prims.of_int (386))
+                                         (Prims.of_int (394))
                                          (Prims.of_int (14))
-                                         (Prims.of_int (386))
+                                         (Prims.of_int (394))
                                          (Prims.of_int (18)))))
                                 (FStar_Sealed.seal
                                    (Obj.magic
                                       (FStar_Range.mk_range
                                          "Pulse.Checker.Pure.fst"
-                                         (Prims.of_int (385))
+                                         (Prims.of_int (393))
                                          (Prims.of_int (8))
-                                         (Prims.of_int (386))
+                                         (Prims.of_int (394))
                                          (Prims.of_int (18)))))
                                 (Obj.magic (Pulse_PP.pp Pulse_PP.uu___44 t))
                                 (fun uu___2 ->
@@ -4149,13 +4243,13 @@ let (get_non_informative_witness :
                      (FStar_Sealed.seal
                         (Obj.magic
                            (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                              (Prims.of_int (389)) (Prims.of_int (14))
-                              (Prims.of_int (413)) (Prims.of_int (17)))))
+                              (Prims.of_int (397)) (Prims.of_int (14))
+                              (Prims.of_int (421)) (Prims.of_int (17)))))
                      (FStar_Sealed.seal
                         (Obj.magic
                            (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                              (Prims.of_int (415)) (Prims.of_int (4))
-                              (Prims.of_int (422)) (Prims.of_int (39)))))
+                              (Prims.of_int (423)) (Prims.of_int (4))
+                              (Prims.of_int (430)) (Prims.of_int (39)))))
                      (FStar_Tactics_Effect.lift_div_tac
                         (fun uu___ ->
                            match Pulse_Syntax_Pure.is_fvar_app t with
@@ -4252,13 +4346,13 @@ let (check_prop_validity :
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                   (Prims.of_int (426)) (Prims.of_int (24))
-                   (Prims.of_int (426)) (Prims.of_int (76)))))
+                   (Prims.of_int (434)) (Prims.of_int (24))
+                   (Prims.of_int (434)) (Prims.of_int (76)))))
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                   (Prims.of_int (426)) (Prims.of_int (3))
-                   (Prims.of_int (433)) (Prims.of_int (21)))))
+                   (Prims.of_int (434)) (Prims.of_int (3))
+                   (Prims.of_int (441)) (Prims.of_int (21)))))
           (Obj.magic
              (rtb_check_prop_validity g (Pulse_Typing.elab_env g)
                 (Pulse_Elaborate_Pure.elab_term p)))
@@ -4271,13 +4365,13 @@ let (check_prop_validity :
                          (FStar_Sealed.seal
                             (Obj.magic
                                (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                                  (Prims.of_int (427)) (Prims.of_int (4))
-                                  (Prims.of_int (427)) (Prims.of_int (23)))))
+                                  (Prims.of_int (435)) (Prims.of_int (4))
+                                  (Prims.of_int (435)) (Prims.of_int (23)))))
                          (FStar_Sealed.seal
                             (Obj.magic
                                (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                                  (Prims.of_int (428)) (Prims.of_int (4))
-                                  (Prims.of_int (433)) (Prims.of_int (21)))))
+                                  (Prims.of_int (436)) (Prims.of_int (4))
+                                  (Prims.of_int (441)) (Prims.of_int (21)))))
                          (Obj.magic
                             (FStar_Tactics_V2_Builtins.log_issues issues))
                          (fun uu___2 ->
@@ -4291,17 +4385,17 @@ let (check_prop_validity :
                                               (Obj.magic
                                                  (FStar_Range.mk_range
                                                     "Pulse.Checker.Pure.fst"
-                                                    (Prims.of_int (432))
+                                                    (Prims.of_int (440))
                                                     (Prims.of_int (21))
-                                                    (Prims.of_int (432))
+                                                    (Prims.of_int (440))
                                                     (Prims.of_int (64)))))
                                            (FStar_Sealed.seal
                                               (Obj.magic
                                                  (FStar_Range.mk_range
                                                     "Pulse.Checker.Pure.fst"
-                                                    (Prims.of_int (431))
+                                                    (Prims.of_int (439))
                                                     (Prims.of_int (6))
-                                                    (Prims.of_int (432))
+                                                    (Prims.of_int (440))
                                                     (Prims.of_int (64)))))
                                            (Obj.magic
                                               (FStar_Tactics_Effect.tac_bind
@@ -4309,17 +4403,17 @@ let (check_prop_validity :
                                                     (Obj.magic
                                                        (FStar_Range.mk_range
                                                           "Pulse.Checker.Pure.fst"
-                                                          (Prims.of_int (432))
+                                                          (Prims.of_int (440))
                                                           (Prims.of_int (22))
-                                                          (Prims.of_int (432))
+                                                          (Prims.of_int (440))
                                                           (Prims.of_int (63)))))
                                                  (FStar_Sealed.seal
                                                     (Obj.magic
                                                        (FStar_Range.mk_range
                                                           "Pulse.Checker.Pure.fst"
-                                                          (Prims.of_int (432))
+                                                          (Prims.of_int (440))
                                                           (Prims.of_int (21))
-                                                          (Prims.of_int (432))
+                                                          (Prims.of_int (440))
                                                           (Prims.of_int (64)))))
                                                  (Obj.magic
                                                     (FStar_Tactics_Effect.tac_bind
@@ -4327,17 +4421,17 @@ let (check_prop_validity :
                                                           (Obj.magic
                                                              (FStar_Range.mk_range
                                                                 "Pulse.Checker.Pure.fst"
-                                                                (Prims.of_int (432))
+                                                                (Prims.of_int (440))
                                                                 (Prims.of_int (59))
-                                                                (Prims.of_int (432))
+                                                                (Prims.of_int (440))
                                                                 (Prims.of_int (63)))))
                                                        (FStar_Sealed.seal
                                                           (Obj.magic
                                                              (FStar_Range.mk_range
                                                                 "Pulse.Checker.Pure.fst"
-                                                                (Prims.of_int (432))
+                                                                (Prims.of_int (440))
                                                                 (Prims.of_int (22))
-                                                                (Prims.of_int (432))
+                                                                (Prims.of_int (440))
                                                                 (Prims.of_int (63)))))
                                                        (Obj.magic
                                                           (Pulse_PP.pp
@@ -4376,20 +4470,20 @@ let fail_expected_tot_found_ghost :
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                 (Prims.of_int (437)) (Prims.of_int (4)) (Prims.of_int (437))
+                 (Prims.of_int (445)) (Prims.of_int (4)) (Prims.of_int (445))
                  (Prims.of_int (86)))))
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                 (Prims.of_int (436)) (Prims.of_int (2)) (Prims.of_int (437))
+                 (Prims.of_int (444)) (Prims.of_int (2)) (Prims.of_int (445))
                  (Prims.of_int (86)))))
         (Obj.magic
            (FStar_Tactics_Effect.tac_bind
               (FStar_Sealed.seal
                  (Obj.magic
                     (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                       (Prims.of_int (437)) (Prims.of_int (65))
-                       (Prims.of_int (437)) (Prims.of_int (85)))))
+                       (Prims.of_int (445)) (Prims.of_int (65))
+                       (Prims.of_int (445)) (Prims.of_int (85)))))
               (FStar_Sealed.seal
                  (Obj.magic
                     (FStar_Range.mk_range "prims.fst" (Prims.of_int (590))
@@ -4420,13 +4514,13 @@ let (compute_tot_term_type :
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                 (Prims.of_int (440)) (Prims.of_int (35))
-                 (Prims.of_int (440)) (Prims.of_int (56)))))
+                 (Prims.of_int (448)) (Prims.of_int (35))
+                 (Prims.of_int (448)) (Prims.of_int (56)))))
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                 (Prims.of_int (439)) (Prims.of_int (31))
-                 (Prims.of_int (442)) (Prims.of_int (40)))))
+                 (Prims.of_int (447)) (Prims.of_int (31))
+                 (Prims.of_int (450)) (Prims.of_int (40)))))
         (Obj.magic (compute_term_type g t))
         (fun uu___ ->
            (fun uu___ ->
@@ -4455,13 +4549,13 @@ let (compute_tot_term_type_and_u :
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                 (Prims.of_int (445)) (Prims.of_int (55))
-                 (Prims.of_int (445)) (Prims.of_int (82)))))
+                 (Prims.of_int (453)) (Prims.of_int (55))
+                 (Prims.of_int (453)) (Prims.of_int (82)))))
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                 (Prims.of_int (444)) (Prims.of_int (37))
-                 (Prims.of_int (447)) (Prims.of_int (40)))))
+                 (Prims.of_int (452)) (Prims.of_int (37))
+                 (Prims.of_int (455)) (Prims.of_int (40)))))
         (Obj.magic (compute_term_type_and_u g t))
         (fun uu___ ->
            (fun uu___ ->
@@ -4498,13 +4592,13 @@ let (core_compute_tot_term_type :
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                 (Prims.of_int (453)) (Prims.of_int (25))
-                 (Prims.of_int (453)) (Prims.of_int (51)))))
+                 (Prims.of_int (461)) (Prims.of_int (25))
+                 (Prims.of_int (461)) (Prims.of_int (51)))))
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                 (Prims.of_int (452)) (Prims.of_int (36))
-                 (Prims.of_int (455)) (Prims.of_int (40)))))
+                 (Prims.of_int (460)) (Prims.of_int (36))
+                 (Prims.of_int (463)) (Prims.of_int (40)))))
         (Obj.magic (core_compute_term_type g t))
         (fun uu___ ->
            (fun uu___ ->
@@ -4539,13 +4633,13 @@ let (is_non_informative :
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                 (Prims.of_int (461)) (Prims.of_int (21))
-                 (Prims.of_int (461)) (Prims.of_int (89)))))
+                 (Prims.of_int (469)) (Prims.of_int (21))
+                 (Prims.of_int (469)) (Prims.of_int (89)))))
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                 (Prims.of_int (460)) (Prims.of_int (28))
-                 (Prims.of_int (463)) (Prims.of_int (6)))))
+                 (Prims.of_int (468)) (Prims.of_int (28))
+                 (Prims.of_int (471)) (Prims.of_int (6)))))
         (Obj.magic
            (catch_all
               (fun uu___ ->
@@ -4561,13 +4655,13 @@ let (is_non_informative :
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                                (Prims.of_int (462)) (Prims.of_int (2))
-                                (Prims.of_int (462)) (Prims.of_int (21)))))
+                                (Prims.of_int (470)) (Prims.of_int (2))
+                                (Prims.of_int (470)) (Prims.of_int (21)))))
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                                (Prims.of_int (461)) (Prims.of_int (6))
-                                (Prims.of_int (461)) (Prims.of_int (10)))))
+                                (Prims.of_int (469)) (Prims.of_int (6))
+                                (Prims.of_int (469)) (Prims.of_int (10)))))
                        (Obj.magic
                           (FStar_Tactics_V2_Builtins.log_issues issues))
                        (fun uu___1 ->
@@ -4589,13 +4683,13 @@ let (check_subtyping :
                (FStar_Sealed.seal
                   (Obj.magic
                      (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                        (Prims.of_int (467)) (Prims.of_int (20))
-                        (Prims.of_int (467)) (Prims.of_int (47)))))
+                        (Prims.of_int (475)) (Prims.of_int (20))
+                        (Prims.of_int (475)) (Prims.of_int (47)))))
                (FStar_Sealed.seal
                   (Obj.magic
                      (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                        (Prims.of_int (466)) (Prims.of_int (34))
-                        (Prims.of_int (475)) (Prims.of_int (47)))))
+                        (Prims.of_int (474)) (Prims.of_int (34))
+                        (Prims.of_int (483)) (Prims.of_int (47)))))
                (Obj.magic (rtb_check_subtyping g t1 t2))
                (fun uu___1 ->
                   (fun uu___1 ->
@@ -4607,17 +4701,17 @@ let (check_subtyping :
                                  (Obj.magic
                                     (FStar_Range.mk_range
                                        "Pulse.Checker.Pure.fst"
-                                       (Prims.of_int (468))
+                                       (Prims.of_int (476))
                                        (Prims.of_int (2))
-                                       (Prims.of_int (468))
+                                       (Prims.of_int (476))
                                        (Prims.of_int (21)))))
                               (FStar_Sealed.seal
                                  (Obj.magic
                                     (FStar_Range.mk_range
                                        "Pulse.Checker.Pure.fst"
-                                       (Prims.of_int (469))
+                                       (Prims.of_int (477))
                                        (Prims.of_int (2))
-                                       (Prims.of_int (475))
+                                       (Prims.of_int (483))
                                        (Prims.of_int (47)))))
                               (Obj.magic
                                  (FStar_Tactics_V2_Builtins.log_issues issues))
@@ -4637,17 +4731,17 @@ let (check_subtyping :
                                                    (Obj.magic
                                                       (FStar_Range.mk_range
                                                          "Pulse.Checker.Pure.fst"
-                                                         (Prims.of_int (474))
+                                                         (Prims.of_int (482))
                                                          (Prims.of_int (10))
-                                                         (Prims.of_int (475))
+                                                         (Prims.of_int (483))
                                                          (Prims.of_int (47)))))
                                                 (FStar_Sealed.seal
                                                    (Obj.magic
                                                       (FStar_Range.mk_range
                                                          "Pulse.Checker.Pure.fst"
-                                                         (Prims.of_int (473))
+                                                         (Prims.of_int (481))
                                                          (Prims.of_int (4))
-                                                         (Prims.of_int (475))
+                                                         (Prims.of_int (483))
                                                          (Prims.of_int (47)))))
                                                 (Obj.magic
                                                    (FStar_Tactics_Effect.tac_bind
@@ -4655,17 +4749,17 @@ let (check_subtyping :
                                                          (Obj.magic
                                                             (FStar_Range.mk_range
                                                                "Pulse.Checker.Pure.fst"
-                                                               (Prims.of_int (474))
+                                                               (Prims.of_int (482))
                                                                (Prims.of_int (12))
-                                                               (Prims.of_int (475))
+                                                               (Prims.of_int (483))
                                                                (Prims.of_int (46)))))
                                                       (FStar_Sealed.seal
                                                          (Obj.magic
                                                             (FStar_Range.mk_range
                                                                "Pulse.Checker.Pure.fst"
-                                                               (Prims.of_int (474))
+                                                               (Prims.of_int (482))
                                                                (Prims.of_int (10))
-                                                               (Prims.of_int (475))
+                                                               (Prims.of_int (483))
                                                                (Prims.of_int (47)))))
                                                       (Obj.magic
                                                          (FStar_Tactics_Effect.tac_bind
@@ -4673,17 +4767,17 @@ let (check_subtyping :
                                                                (Obj.magic
                                                                   (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (475))
+                                                                    (Prims.of_int (483))
                                                                     (Prims.of_int (16))
-                                                                    (Prims.of_int (475))
+                                                                    (Prims.of_int (483))
                                                                     (Prims.of_int (46)))))
                                                             (FStar_Sealed.seal
                                                                (Obj.magic
                                                                   (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (474))
+                                                                    (Prims.of_int (482))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (475))
+                                                                    (Prims.of_int (483))
                                                                     (Prims.of_int (46)))))
                                                             (Obj.magic
                                                                (FStar_Tactics_Effect.tac_bind
@@ -4691,17 +4785,17 @@ let (check_subtyping :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (475))
+                                                                    (Prims.of_int (483))
                                                                     (Prims.of_int (16))
-                                                                    (Prims.of_int (475))
+                                                                    (Prims.of_int (483))
                                                                     (Prims.of_int (21)))))
                                                                   (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (475))
+                                                                    (Prims.of_int (483))
                                                                     (Prims.of_int (16))
-                                                                    (Prims.of_int (475))
+                                                                    (Prims.of_int (483))
                                                                     (Prims.of_int (46)))))
                                                                   (Obj.magic
                                                                     (Pulse_PP.pp
@@ -4717,17 +4811,17 @@ let (check_subtyping :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (475))
+                                                                    (Prims.of_int (483))
                                                                     (Prims.of_int (26))
-                                                                    (Prims.of_int (475))
+                                                                    (Prims.of_int (483))
                                                                     (Prims.of_int (46)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (475))
+                                                                    (Prims.of_int (483))
                                                                     (Prims.of_int (16))
-                                                                    (Prims.of_int (475))
+                                                                    (Prims.of_int (483))
                                                                     (Prims.of_int (46)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -4735,17 +4829,17 @@ let (check_subtyping :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (475))
+                                                                    (Prims.of_int (483))
                                                                     (Prims.of_int (41))
-                                                                    (Prims.of_int (475))
+                                                                    (Prims.of_int (483))
                                                                     (Prims.of_int (46)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (475))
+                                                                    (Prims.of_int (483))
                                                                     (Prims.of_int (26))
-                                                                    (Prims.of_int (475))
+                                                                    (Prims.of_int (483))
                                                                     (Prims.of_int (46)))))
                                                                     (Obj.magic
                                                                     (Pulse_PP.pp
@@ -4804,13 +4898,13 @@ let (check_equiv :
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                   (Prims.of_int (480)) (Prims.of_int (4))
-                   (Prims.of_int (480)) (Prims.of_int (80)))))
+                   (Prims.of_int (488)) (Prims.of_int (4))
+                   (Prims.of_int (488)) (Prims.of_int (80)))))
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                   (Prims.of_int (478)) (Prims.of_int (25))
-                   (Prims.of_int (482)) (Prims.of_int (5)))))
+                   (Prims.of_int (486)) (Prims.of_int (25))
+                   (Prims.of_int (490)) (Prims.of_int (5)))))
           (Obj.magic
              (Pulse_Typing_Util.check_equiv_now (Pulse_Typing.elab_env g)
                 (Pulse_Elaborate_Pure.elab_term t1)
@@ -4824,13 +4918,13 @@ let (check_equiv :
                          (FStar_Sealed.seal
                             (Obj.magic
                                (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                                  (Prims.of_int (481)) (Prims.of_int (2))
-                                  (Prims.of_int (481)) (Prims.of_int (21)))))
+                                  (Prims.of_int (489)) (Prims.of_int (2))
+                                  (Prims.of_int (489)) (Prims.of_int (21)))))
                          (FStar_Sealed.seal
                             (Obj.magic
                                (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                                  (Prims.of_int (479)) (Prims.of_int (6))
-                                  (Prims.of_int (479)) (Prims.of_int (9)))))
+                                  (Prims.of_int (487)) (Prims.of_int (6))
+                                  (Prims.of_int (487)) (Prims.of_int (9)))))
                          (Obj.magic
                             (FStar_Tactics_V2_Builtins.log_issues issues))
                          (fun uu___1 ->

--- a/src/ocaml/plugin/generated/Pulse_Checker_STApp.ml
+++ b/src/ocaml/plugin/generated/Pulse_Checker_STApp.ml
@@ -309,12 +309,12 @@ let (instantiate_implicits :
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.STApp.fst"
-                 (Prims.of_int (77)) (Prims.of_int (14)) (Prims.of_int (77))
+                 (Prims.of_int (76)) (Prims.of_int (14)) (Prims.of_int (76))
                  (Prims.of_int (21)))))
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.STApp.fst"
-                 (Prims.of_int (77)) (Prims.of_int (24)) (Prims.of_int (93))
+                 (Prims.of_int (76)) (Prims.of_int (24)) (Prims.of_int (91))
                  (Prims.of_int (32)))))
         (FStar_Tactics_Effect.lift_div_tac
            (fun uu___ -> t.Pulse_Syntax_Base.range2))
@@ -325,13 +325,13 @@ let (instantiate_implicits :
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Checker.STApp.fst"
-                            (Prims.of_int (78)) (Prims.of_int (46))
-                            (Prims.of_int (78)) (Prims.of_int (52)))))
+                            (Prims.of_int (77)) (Prims.of_int (46))
+                            (Prims.of_int (77)) (Prims.of_int (52)))))
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Checker.STApp.fst"
-                            (Prims.of_int (77)) (Prims.of_int (24))
-                            (Prims.of_int (93)) (Prims.of_int (32)))))
+                            (Prims.of_int (76)) (Prims.of_int (24))
+                            (Prims.of_int (91)) (Prims.of_int (32)))))
                    (FStar_Tactics_Effect.lift_div_tac
                       (fun uu___ -> t.Pulse_Syntax_Base.term1))
                    (fun uu___ ->
@@ -348,17 +348,17 @@ let (instantiate_implicits :
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "Pulse.Checker.STApp.fst"
-                                           (Prims.of_int (79))
+                                           (Prims.of_int (78))
                                            (Prims.of_int (17))
-                                           (Prims.of_int (79))
+                                           (Prims.of_int (78))
                                            (Prims.of_int (41)))))
                                   (FStar_Sealed.seal
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "Pulse.Checker.STApp.fst"
-                                           (Prims.of_int (79))
+                                           (Prims.of_int (78))
                                            (Prims.of_int (44))
-                                           (Prims.of_int (93))
+                                           (Prims.of_int (91))
                                            (Prims.of_int (32)))))
                                   (FStar_Tactics_Effect.lift_div_tac
                                      (fun uu___1 ->
@@ -372,25 +372,26 @@ let (instantiate_implicits :
                                                 (Obj.magic
                                                    (FStar_Range.mk_range
                                                       "Pulse.Checker.STApp.fst"
-                                                      (Prims.of_int (80))
-                                                      (Prims.of_int (14))
-                                                      (Prims.of_int (80))
-                                                      (Prims.of_int (51)))))
+                                                      (Prims.of_int (79))
+                                                      (Prims.of_int (25))
+                                                      (Prims.of_int (79))
+                                                      (Prims.of_int (66)))))
                                              (FStar_Sealed.seal
                                                 (Obj.magic
                                                    (FStar_Range.mk_range
                                                       "Pulse.Checker.STApp.fst"
-                                                      (Prims.of_int (79))
+                                                      (Prims.of_int (78))
                                                       (Prims.of_int (44))
-                                                      (Prims.of_int (93))
+                                                      (Prims.of_int (91))
                                                       (Prims.of_int (32)))))
                                              (Obj.magic
-                                                (Pulse_Checker_Pure.instantiate_term_implicits
+                                                (Pulse_Checker_Pure.instantiate_term_implicits_uvs
                                                    g pure_app))
                                              (fun uu___1 ->
                                                 (fun uu___1 ->
                                                    match uu___1 with
-                                                   | (t1, ty) ->
+                                                   | FStar_Pervasives.Mkdtuple3
+                                                       (uvs, t1, ty) ->
                                                        (match Pulse_Syntax_Pure.is_arrow
                                                                 ty
                                                         with
@@ -403,11 +404,8 @@ let (instantiate_implicits :
                                                             Obj.magic
                                                               (Obj.repr
                                                                  (intro_uvars_for_logical_implicits
-                                                                    g
-                                                                    (
-                                                                    Pulse_Typing_Env.mk_env
-                                                                    (Pulse_Typing_Env.fstar_env
-                                                                    g)) t1 ty))
+                                                                    g uvs t1
+                                                                    ty))
                                                         | uu___2 ->
                                                             Obj.magic
                                                               (Obj.repr
@@ -424,14 +422,9 @@ let (instantiate_implicits :
                                                                     (fun
                                                                     uu___3 ->
                                                                     FStar_Pervasives.Mkdtuple3
-                                                                    ((Pulse_Typing_Env.mk_env
-                                                                    (Pulse_Typing_Env.fstar_env
-                                                                    g)),
+                                                                    (uvs,
                                                                     (Pulse_Typing_Env.push_env
-                                                                    g
-                                                                    (Pulse_Typing_Env.mk_env
-                                                                    (Pulse_Typing_Env.fstar_env
-                                                                    g))),
+                                                                    g uvs),
                                                                     {
                                                                     Pulse_Syntax_Base.term1
                                                                     =
@@ -458,17 +451,17 @@ let (instantiate_implicits :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.STApp.fst"
-                                                                    (Prims.of_int (92))
+                                                                    (Prims.of_int (90))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (93))
+                                                                    (Prims.of_int (91))
                                                                     (Prims.of_int (32)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.STApp.fst"
-                                                                    (Prims.of_int (91))
+                                                                    (Prims.of_int (89))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (93))
+                                                                    (Prims.of_int (91))
                                                                     (Prims.of_int (32)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -476,9 +469,9 @@ let (instantiate_implicits :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.STApp.fst"
-                                                                    (Prims.of_int (93))
+                                                                    (Prims.of_int (91))
                                                                     (Prims.of_int (11))
-                                                                    (Prims.of_int (93))
+                                                                    (Prims.of_int (91))
                                                                     (Prims.of_int (31)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -557,17 +550,17 @@ let (apply_impure_function :
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "Pulse.Checker.STApp.fst"
-                                           (Prims.of_int (113))
+                                           (Prims.of_int (111))
                                            (Prims.of_int (67))
-                                           (Prims.of_int (113))
+                                           (Prims.of_int (111))
                                            (Prims.of_int (68)))))
                                   (FStar_Sealed.seal
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "Pulse.Checker.STApp.fst"
-                                           (Prims.of_int (113))
+                                           (Prims.of_int (111))
                                            (Prims.of_int (3))
-                                           (Prims.of_int (186))
+                                           (Prims.of_int (184))
                                            (Prims.of_int (5)))))
                                   (FStar_Tactics_Effect.lift_div_tac
                                      (fun uu___ -> b))
@@ -586,17 +579,17 @@ let (apply_impure_function :
                                                     (Obj.magic
                                                        (FStar_Range.mk_range
                                                           "Pulse.Checker.STApp.fst"
-                                                          (Prims.of_int (115))
+                                                          (Prims.of_int (113))
                                                           (Prims.of_int (38))
-                                                          (Prims.of_int (115))
+                                                          (Prims.of_int (113))
                                                           (Prims.of_int (47)))))
                                                  (FStar_Sealed.seal
                                                     (Obj.magic
                                                        (FStar_Range.mk_range
                                                           "Pulse.Checker.STApp.fst"
-                                                          (Prims.of_int (117))
+                                                          (Prims.of_int (115))
                                                           (Prims.of_int (4))
-                                                          (Prims.of_int (186))
+                                                          (Prims.of_int (184))
                                                           (Prims.of_int (5)))))
                                                  (FStar_Tactics_Effect.lift_div_tac
                                                     (fun uu___1 -> post_hint))
@@ -608,17 +601,17 @@ let (apply_impure_function :
                                                                (Obj.magic
                                                                   (FStar_Range.mk_range
                                                                     "Pulse.Checker.STApp.fst"
-                                                                    (Prims.of_int (117))
+                                                                    (Prims.of_int (115))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (119))
+                                                                    (Prims.of_int (117))
                                                                     (Prims.of_int (46)))))
                                                             (FStar_Sealed.seal
                                                                (Obj.magic
                                                                   (FStar_Range.mk_range
                                                                     "Pulse.Checker.STApp.fst"
-                                                                    (Prims.of_int (119))
+                                                                    (Prims.of_int (117))
                                                                     (Prims.of_int (47))
-                                                                    (Prims.of_int (186))
+                                                                    (Prims.of_int (184))
                                                                     (Prims.of_int (5)))))
                                                             (Obj.magic
                                                                (debug_log g
@@ -629,17 +622,17 @@ let (apply_impure_function :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.STApp.fst"
-                                                                    (Prims.of_int (118))
+                                                                    (Prims.of_int (116))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (119))
+                                                                    (Prims.of_int (117))
                                                                     (Prims.of_int (45)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.STApp.fst"
-                                                                    (Prims.of_int (118))
+                                                                    (Prims.of_int (116))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (119))
+                                                                    (Prims.of_int (117))
                                                                     (Prims.of_int (45)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -647,9 +640,9 @@ let (apply_impure_function :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.STApp.fst"
-                                                                    (Prims.of_int (119))
+                                                                    (Prims.of_int (117))
                                                                     (Prims.of_int (17))
-                                                                    (Prims.of_int (119))
+                                                                    (Prims.of_int (117))
                                                                     (Prims.of_int (44)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -689,17 +682,17 @@ let (apply_impure_function :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.STApp.fst"
-                                                                    (Prims.of_int (121))
+                                                                    (Prims.of_int (119))
                                                                     (Prims.of_int (22))
-                                                                    (Prims.of_int (121))
+                                                                    (Prims.of_int (119))
                                                                     (Prims.of_int (41)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.STApp.fst"
-                                                                    (Prims.of_int (122))
+                                                                    (Prims.of_int (120))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (186))
+                                                                    (Prims.of_int (184))
                                                                     (Prims.of_int (5)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -717,17 +710,17 @@ let (apply_impure_function :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.STApp.fst"
-                                                                    (Prims.of_int (122))
+                                                                    (Prims.of_int (120))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (126))
+                                                                    (Prims.of_int (124))
                                                                     (Prims.of_int (38)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.STApp.fst"
-                                                                    (Prims.of_int (128))
+                                                                    (Prims.of_int (126))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (186))
+                                                                    (Prims.of_int (184))
                                                                     (Prims.of_int (5)))))
                                                                     (if
                                                                     (Prims.op_Negation
@@ -744,17 +737,17 @@ let (apply_impure_function :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.STApp.fst"
-                                                                    (Prims.of_int (125))
+                                                                    (Prims.of_int (123))
                                                                     (Prims.of_int (11))
-                                                                    (Prims.of_int (126))
+                                                                    (Prims.of_int (124))
                                                                     (Prims.of_int (38)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.STApp.fst"
-                                                                    (Prims.of_int (124))
+                                                                    (Prims.of_int (122))
                                                                     (Prims.of_int (9))
-                                                                    (Prims.of_int (126))
+                                                                    (Prims.of_int (124))
                                                                     (Prims.of_int (38)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -762,9 +755,9 @@ let (apply_impure_function :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.STApp.fst"
-                                                                    (Prims.of_int (126))
+                                                                    (Prims.of_int (124))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (126))
+                                                                    (Prims.of_int (124))
                                                                     (Prims.of_int (37)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -819,17 +812,17 @@ let (apply_impure_function :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.STApp.fst"
-                                                                    (Prims.of_int (130))
+                                                                    (Prims.of_int (128))
                                                                     (Prims.of_int (25))
-                                                                    (Prims.of_int (133))
+                                                                    (Prims.of_int (131))
                                                                     (Prims.of_int (39)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.STApp.fst"
-                                                                    (Prims.of_int (129))
+                                                                    (Prims.of_int (127))
                                                                     (Prims.of_int (9))
-                                                                    (Prims.of_int (135))
+                                                                    (Prims.of_int (133))
                                                                     (Prims.of_int (5)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -837,17 +830,17 @@ let (apply_impure_function :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.STApp.fst"
-                                                                    (Prims.of_int (133))
+                                                                    (Prims.of_int (131))
                                                                     (Prims.of_int (16))
-                                                                    (Prims.of_int (133))
+                                                                    (Prims.of_int (131))
                                                                     (Prims.of_int (38)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.STApp.fst"
-                                                                    (Prims.of_int (130))
+                                                                    (Prims.of_int (128))
                                                                     (Prims.of_int (25))
-                                                                    (Prims.of_int (133))
+                                                                    (Prims.of_int (131))
                                                                     (Prims.of_int (39)))))
                                                                     (Obj.magic
                                                                     (Pulse_Syntax_Printer.term_to_string
@@ -862,17 +855,17 @@ let (apply_impure_function :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.STApp.fst"
-                                                                    (Prims.of_int (130))
+                                                                    (Prims.of_int (128))
                                                                     (Prims.of_int (25))
-                                                                    (Prims.of_int (133))
+                                                                    (Prims.of_int (131))
                                                                     (Prims.of_int (39)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.STApp.fst"
-                                                                    (Prims.of_int (130))
+                                                                    (Prims.of_int (128))
                                                                     (Prims.of_int (25))
-                                                                    (Prims.of_int (133))
+                                                                    (Prims.of_int (131))
                                                                     (Prims.of_int (39)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -880,17 +873,17 @@ let (apply_impure_function :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.STApp.fst"
-                                                                    (Prims.of_int (132))
+                                                                    (Prims.of_int (130))
                                                                     (Prims.of_int (16))
-                                                                    (Prims.of_int (132))
+                                                                    (Prims.of_int (130))
                                                                     (Prims.of_int (39)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.STApp.fst"
-                                                                    (Prims.of_int (130))
+                                                                    (Prims.of_int (128))
                                                                     (Prims.of_int (25))
-                                                                    (Prims.of_int (133))
+                                                                    (Prims.of_int (131))
                                                                     (Prims.of_int (39)))))
                                                                     (Obj.magic
                                                                     (Pulse_Syntax_Printer.term_to_string
@@ -905,17 +898,17 @@ let (apply_impure_function :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.STApp.fst"
-                                                                    (Prims.of_int (130))
+                                                                    (Prims.of_int (128))
                                                                     (Prims.of_int (25))
-                                                                    (Prims.of_int (133))
+                                                                    (Prims.of_int (131))
                                                                     (Prims.of_int (39)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.STApp.fst"
-                                                                    (Prims.of_int (130))
+                                                                    (Prims.of_int (128))
                                                                     (Prims.of_int (25))
-                                                                    (Prims.of_int (133))
+                                                                    (Prims.of_int (131))
                                                                     (Prims.of_int (39)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -923,9 +916,9 @@ let (apply_impure_function :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.STApp.fst"
-                                                                    (Prims.of_int (131))
+                                                                    (Prims.of_int (129))
                                                                     (Prims.of_int (16))
-                                                                    (Prims.of_int (131))
+                                                                    (Prims.of_int (129))
                                                                     (Prims.of_int (42)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -991,17 +984,17 @@ let (apply_impure_function :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.STApp.fst"
-                                                                    (Prims.of_int (137))
+                                                                    (Prims.of_int (135))
                                                                     (Prims.of_int (20))
-                                                                    (Prims.of_int (137))
+                                                                    (Prims.of_int (135))
                                                                     (Prims.of_int (64)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.STApp.fst"
-                                                                    (Prims.of_int (137))
+                                                                    (Prims.of_int (135))
                                                                     (Prims.of_int (67))
-                                                                    (Prims.of_int (185))
+                                                                    (Prims.of_int (183))
                                                                     (Prims.of_int (144)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -1023,17 +1016,17 @@ let (apply_impure_function :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.STApp.fst"
-                                                                    (Prims.of_int (138))
+                                                                    (Prims.of_int (136))
                                                                     (Prims.of_int (28))
-                                                                    (Prims.of_int (138))
+                                                                    (Prims.of_int (136))
                                                                     (Prims.of_int (59)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.STApp.fst"
-                                                                    (Prims.of_int (137))
+                                                                    (Prims.of_int (135))
                                                                     (Prims.of_int (67))
-                                                                    (Prims.of_int (185))
+                                                                    (Prims.of_int (183))
                                                                     (Prims.of_int (144)))))
                                                                     (Obj.magic
                                                                     (Pulse_Checker_Pure.check_term
@@ -1056,17 +1049,17 @@ let (apply_impure_function :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.STApp.fst"
-                                                                    (Prims.of_int (140))
+                                                                    (Prims.of_int (138))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (183))
+                                                                    (Prims.of_int (181))
                                                                     (Prims.of_int (108)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.STApp.fst"
-                                                                    (Prims.of_int (138))
+                                                                    (Prims.of_int (136))
                                                                     (Prims.of_int (62))
-                                                                    (Prims.of_int (185))
+                                                                    (Prims.of_int (183))
                                                                     (Prims.of_int (144)))))
                                                                     (match comp_typ
                                                                     with
@@ -1194,17 +1187,17 @@ let (apply_impure_function :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.STApp.fst"
-                                                                    (Prims.of_int (152))
+                                                                    (Prims.of_int (150))
                                                                     (Prims.of_int (18))
-                                                                    (Prims.of_int (152))
+                                                                    (Prims.of_int (150))
                                                                     (Prims.of_int (25)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.STApp.fst"
-                                                                    (Prims.of_int (153))
+                                                                    (Prims.of_int (151))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (180))
+                                                                    (Prims.of_int (178))
                                                                     (Prims.of_int (23)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -1220,17 +1213,17 @@ let (apply_impure_function :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.STApp.fst"
-                                                                    (Prims.of_int (153))
+                                                                    (Prims.of_int (151))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (155))
+                                                                    (Prims.of_int (153))
                                                                     (Prims.of_int (81)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.STApp.fst"
-                                                                    (Prims.of_int (155))
+                                                                    (Prims.of_int (153))
                                                                     (Prims.of_int (82))
-                                                                    (Prims.of_int (180))
+                                                                    (Prims.of_int (178))
                                                                     (Prims.of_int (23)))))
                                                                     (if
                                                                     FStar_Set.mem
@@ -1262,17 +1255,17 @@ let (apply_impure_function :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.STApp.fst"
-                                                                    (Prims.of_int (160))
+                                                                    (Prims.of_int (158))
                                                                     (Prims.of_int (26))
-                                                                    (Prims.of_int (170))
+                                                                    (Prims.of_int (168))
                                                                     (Prims.of_int (50)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.STApp.fst"
-                                                                    (Prims.of_int (180))
+                                                                    (Prims.of_int (178))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (180))
+                                                                    (Prims.of_int (178))
                                                                     (Prims.of_int (23)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1280,17 +1273,17 @@ let (apply_impure_function :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.STApp.fst"
-                                                                    (Prims.of_int (162))
+                                                                    (Prims.of_int (160))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (163))
+                                                                    (Prims.of_int (161))
                                                                     (Prims.of_int (71)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.STApp.fst"
-                                                                    (Prims.of_int (164))
+                                                                    (Prims.of_int (162))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (170))
+                                                                    (Prims.of_int (168))
                                                                     (Prims.of_int (50)))))
                                                                     (Obj.magic
                                                                     (Pulse_Checker_Pure.is_non_informative
@@ -1318,17 +1311,17 @@ let (apply_impure_function :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.STApp.fst"
-                                                                    (Prims.of_int (167))
+                                                                    (Prims.of_int (165))
                                                                     (Prims.of_int (16))
-                                                                    (Prims.of_int (167))
+                                                                    (Prims.of_int (165))
                                                                     (Prims.of_int (103)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.STApp.fst"
-                                                                    (Prims.of_int (166))
+                                                                    (Prims.of_int (164))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (167))
+                                                                    (Prims.of_int (165))
                                                                     (Prims.of_int (103)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1336,9 +1329,9 @@ let (apply_impure_function :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.STApp.fst"
-                                                                    (Prims.of_int (167))
+                                                                    (Prims.of_int (165))
                                                                     (Prims.of_int (75))
-                                                                    (Prims.of_int (167))
+                                                                    (Prims.of_int (165))
                                                                     (Prims.of_int (102)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -1472,17 +1465,17 @@ let (apply_impure_function :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.STApp.fst"
-                                                                    (Prims.of_int (185))
+                                                                    (Prims.of_int (183))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (185))
+                                                                    (Prims.of_int (183))
                                                                     (Prims.of_int (144)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.STApp.fst"
-                                                                    (Prims.of_int (185))
+                                                                    (Prims.of_int (183))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (185))
+                                                                    (Prims.of_int (183))
                                                                     (Prims.of_int (144)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -1498,17 +1491,17 @@ let (apply_impure_function :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.STApp.fst"
-                                                                    (Prims.of_int (185))
+                                                                    (Prims.of_int (183))
                                                                     (Prims.of_int (31))
-                                                                    (Prims.of_int (185))
+                                                                    (Prims.of_int (183))
                                                                     (Prims.of_int (128)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.STApp.fst"
-                                                                    (Prims.of_int (185))
+                                                                    (Prims.of_int (183))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (185))
+                                                                    (Prims.of_int (183))
                                                                     (Prims.of_int (144)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1516,17 +1509,17 @@ let (apply_impure_function :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.STApp.fst"
-                                                                    (Prims.of_int (185))
+                                                                    (Prims.of_int (183))
                                                                     (Prims.of_int (73))
-                                                                    (Prims.of_int (185))
+                                                                    (Prims.of_int (183))
                                                                     (Prims.of_int (116)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.STApp.fst"
-                                                                    (Prims.of_int (185))
+                                                                    (Prims.of_int (183))
                                                                     (Prims.of_int (31))
-                                                                    (Prims.of_int (185))
+                                                                    (Prims.of_int (183))
                                                                     (Prims.of_int (128)))))
                                                                     (Obj.magic
                                                                     (Pulse_Checker_Base.match_comp_res_with_post_hint
@@ -1582,13 +1575,13 @@ let (check :
                 (FStar_Sealed.seal
                    (Obj.magic
                       (FStar_Range.mk_range "Pulse.Checker.STApp.fst"
-                         (Prims.of_int (198)) (Prims.of_int (11))
-                         (Prims.of_int (198)) (Prims.of_int (43)))))
+                         (Prims.of_int (196)) (Prims.of_int (11))
+                         (Prims.of_int (196)) (Prims.of_int (43)))))
                 (FStar_Sealed.seal
                    (Obj.magic
                       (FStar_Range.mk_range "Pulse.Checker.STApp.fst"
-                         (Prims.of_int (198)) (Prims.of_int (46))
-                         (Prims.of_int (229)) (Prims.of_int (117)))))
+                         (Prims.of_int (196)) (Prims.of_int (46))
+                         (Prims.of_int (227)) (Prims.of_int (117)))))
                 (FStar_Tactics_Effect.lift_div_tac
                    (fun uu___ ->
                       Pulse_Checker_Pure.push_context "st_app"
@@ -1601,14 +1594,14 @@ let (check :
                               (Obj.magic
                                  (FStar_Range.mk_range
                                     "Pulse.Checker.STApp.fst"
-                                    (Prims.of_int (199)) (Prims.of_int (14))
-                                    (Prims.of_int (199)) (Prims.of_int (21)))))
+                                    (Prims.of_int (197)) (Prims.of_int (14))
+                                    (Prims.of_int (197)) (Prims.of_int (21)))))
                            (FStar_Sealed.seal
                               (Obj.magic
                                  (FStar_Range.mk_range
                                     "Pulse.Checker.STApp.fst"
-                                    (Prims.of_int (199)) (Prims.of_int (24))
-                                    (Prims.of_int (229)) (Prims.of_int (117)))))
+                                    (Prims.of_int (197)) (Prims.of_int (24))
+                                    (Prims.of_int (227)) (Prims.of_int (117)))))
                            (FStar_Tactics_Effect.lift_div_tac
                               (fun uu___ -> t.Pulse_Syntax_Base.range2))
                            (fun uu___ ->
@@ -1619,17 +1612,17 @@ let (check :
                                          (Obj.magic
                                             (FStar_Range.mk_range
                                                "Pulse.Checker.STApp.fst"
-                                               (Prims.of_int (201))
+                                               (Prims.of_int (199))
                                                (Prims.of_int (24))
-                                               (Prims.of_int (201))
+                                               (Prims.of_int (199))
                                                (Prims.of_int (50)))))
                                       (FStar_Sealed.seal
                                          (Obj.magic
                                             (FStar_Range.mk_range
                                                "Pulse.Checker.STApp.fst"
-                                               (Prims.of_int (199))
+                                               (Prims.of_int (197))
                                                (Prims.of_int (24))
-                                               (Prims.of_int (229))
+                                               (Prims.of_int (227))
                                                (Prims.of_int (117)))))
                                       (Obj.magic
                                          (instantiate_implicits g01 t))
@@ -1644,17 +1637,17 @@ let (check :
                                                         (Obj.magic
                                                            (FStar_Range.mk_range
                                                               "Pulse.Checker.STApp.fst"
-                                                              (Prims.of_int (203))
+                                                              (Prims.of_int (201))
                                                               (Prims.of_int (36))
-                                                              (Prims.of_int (203))
+                                                              (Prims.of_int (201))
                                                               (Prims.of_int (45)))))
                                                      (FStar_Sealed.seal
                                                         (Obj.magic
                                                            (FStar_Range.mk_range
                                                               "Pulse.Checker.STApp.fst"
-                                                              (Prims.of_int (203))
+                                                              (Prims.of_int (201))
                                                               (Prims.of_int (48))
-                                                              (Prims.of_int (229))
+                                                              (Prims.of_int (227))
                                                               (Prims.of_int (117)))))
                                                      (FStar_Tactics_Effect.lift_div_tac
                                                         (fun uu___1 ->
@@ -1667,17 +1660,17 @@ let (check :
                                                                    (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.STApp.fst"
-                                                                    (Prims.of_int (205))
+                                                                    (Prims.of_int (203))
                                                                     (Prims.of_int (46))
-                                                                    (Prims.of_int (205))
+                                                                    (Prims.of_int (203))
                                                                     (Prims.of_int (52)))))
                                                                 (FStar_Sealed.seal
                                                                    (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.STApp.fst"
-                                                                    (Prims.of_int (203))
+                                                                    (Prims.of_int (201))
                                                                     (Prims.of_int (48))
-                                                                    (Prims.of_int (229))
+                                                                    (Prims.of_int (227))
                                                                     (Prims.of_int (117)))))
                                                                 (FStar_Tactics_Effect.lift_div_tac
                                                                    (fun
@@ -1705,17 +1698,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.STApp.fst"
-                                                                    (Prims.of_int (207))
+                                                                    (Prims.of_int (205))
                                                                     (Prims.of_int (45))
-                                                                    (Prims.of_int (207))
+                                                                    (Prims.of_int (205))
                                                                     (Prims.of_int (69)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.STApp.fst"
-                                                                    (Prims.of_int (205))
+                                                                    (Prims.of_int (203))
                                                                     (Prims.of_int (55))
-                                                                    (Prims.of_int (229))
+                                                                    (Prims.of_int (227))
                                                                     (Prims.of_int (117)))))
                                                                     (Obj.magic
                                                                     (Pulse_Checker_Pure.compute_term_type
@@ -1738,17 +1731,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.STApp.fst"
-                                                                    (Prims.of_int (209))
+                                                                    (Prims.of_int (207))
                                                                     (Prims.of_int (2))
-                                                                    (Prims.of_int (213))
+                                                                    (Prims.of_int (211))
                                                                     (Prims.of_int (43)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.STApp.fst"
-                                                                    (Prims.of_int (215))
+                                                                    (Prims.of_int (213))
                                                                     (Prims.of_int (2))
-                                                                    (Prims.of_int (229))
+                                                                    (Prims.of_int (227))
                                                                     (Prims.of_int (117)))))
                                                                     (Obj.magic
                                                                     (debug_log
@@ -1760,17 +1753,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.STApp.fst"
-                                                                    (Prims.of_int (210))
+                                                                    (Prims.of_int (208))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (213))
+                                                                    (Prims.of_int (211))
                                                                     (Prims.of_int (42)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.STApp.fst"
-                                                                    (Prims.of_int (210))
+                                                                    (Prims.of_int (208))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (213))
+                                                                    (Prims.of_int (211))
                                                                     (Prims.of_int (42)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1778,17 +1771,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.STApp.fst"
-                                                                    (Prims.of_int (213))
+                                                                    (Prims.of_int (211))
                                                                     (Prims.of_int (15))
-                                                                    (Prims.of_int (213))
+                                                                    (Prims.of_int (211))
                                                                     (Prims.of_int (41)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.STApp.fst"
-                                                                    (Prims.of_int (210))
+                                                                    (Prims.of_int (208))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (213))
+                                                                    (Prims.of_int (211))
                                                                     (Prims.of_int (42)))))
                                                                     (Obj.magic
                                                                     (Pulse_Syntax_Printer.term_to_string
@@ -1803,45 +1796,45 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.STApp.fst"
-                                                                    (Prims.of_int (210))
+                                                                    (Prims.of_int (208))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (213))
-                                                                    (Prims.of_int (42)))))
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.STApp.fst"
-                                                                    (Prims.of_int (210))
-                                                                    (Prims.of_int (12))
-                                                                    (Prims.of_int (213))
-                                                                    (Prims.of_int (42)))))
-                                                                    (Obj.magic
-                                                                    (FStar_Tactics_Effect.tac_bind
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.STApp.fst"
-                                                                    (Prims.of_int (210))
-                                                                    (Prims.of_int (12))
-                                                                    (Prims.of_int (213))
-                                                                    (Prims.of_int (42)))))
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.STApp.fst"
-                                                                    (Prims.of_int (210))
-                                                                    (Prims.of_int (12))
-                                                                    (Prims.of_int (213))
-                                                                    (Prims.of_int (42)))))
-                                                                    (Obj.magic
-                                                                    (FStar_Tactics_Effect.tac_bind
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.STApp.fst"
                                                                     (Prims.of_int (211))
+                                                                    (Prims.of_int (42)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.STApp.fst"
+                                                                    (Prims.of_int (208))
+                                                                    (Prims.of_int (12))
+                                                                    (Prims.of_int (211))
+                                                                    (Prims.of_int (42)))))
+                                                                    (Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.STApp.fst"
+                                                                    (Prims.of_int (208))
+                                                                    (Prims.of_int (12))
+                                                                    (Prims.of_int (211))
+                                                                    (Prims.of_int (42)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.STApp.fst"
+                                                                    (Prims.of_int (208))
+                                                                    (Prims.of_int (12))
+                                                                    (Prims.of_int (211))
+                                                                    (Prims.of_int (42)))))
+                                                                    (Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.STApp.fst"
+                                                                    (Prims.of_int (209))
                                                                     (Prims.of_int (15))
-                                                                    (Prims.of_int (211))
+                                                                    (Prims.of_int (209))
                                                                     (Prims.of_int (38)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -1928,17 +1921,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.STApp.fst"
-                                                                    (Prims.of_int (220))
+                                                                    (Prims.of_int (218))
                                                                     (Prims.of_int (28))
-                                                                    (Prims.of_int (220))
+                                                                    (Prims.of_int (218))
                                                                     (Prims.of_int (86)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.STApp.fst"
-                                                                    (Prims.of_int (219))
+                                                                    (Prims.of_int (217))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (229))
+                                                                    (Prims.of_int (227))
                                                                     (Prims.of_int (117)))))
                                                                     (Obj.magic
                                                                     (Pulse_Checker_Base.norm_typing
@@ -1973,17 +1966,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.STApp.fst"
-                                                                    (Prims.of_int (225))
+                                                                    (Prims.of_int (223))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (227))
+                                                                    (Prims.of_int (225))
                                                                     (Prims.of_int (39)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.STApp.fst"
-                                                                    (Prims.of_int (224))
+                                                                    (Prims.of_int (222))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (227))
+                                                                    (Prims.of_int (225))
                                                                     (Prims.of_int (39)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1991,17 +1984,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.STApp.fst"
-                                                                    (Prims.of_int (227))
+                                                                    (Prims.of_int (225))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (227))
+                                                                    (Prims.of_int (225))
                                                                     (Prims.of_int (38)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.STApp.fst"
-                                                                    (Prims.of_int (225))
+                                                                    (Prims.of_int (223))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (227))
+                                                                    (Prims.of_int (225))
                                                                     (Prims.of_int (39)))))
                                                                     (Obj.magic
                                                                     (Pulse_Syntax_Printer.term_to_string
@@ -2016,17 +2009,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.STApp.fst"
-                                                                    (Prims.of_int (225))
+                                                                    (Prims.of_int (223))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (227))
+                                                                    (Prims.of_int (225))
                                                                     (Prims.of_int (39)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.STApp.fst"
-                                                                    (Prims.of_int (225))
+                                                                    (Prims.of_int (223))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (227))
+                                                                    (Prims.of_int (225))
                                                                     (Prims.of_int (39)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -2034,9 +2027,9 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.STApp.fst"
-                                                                    (Prims.of_int (226))
+                                                                    (Prims.of_int (224))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (226))
+                                                                    (Prims.of_int (224))
                                                                     (Prims.of_int (35)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic


### PR DESCRIPTION
They no longer need to be at the end, some examples: https://github.com/FStarLang/steel/commit/fe5b6159fc2549fbf081f54d846db64f161a47dc