### PR TITLE
SteelC: Use compat option for running meta args in open ctxs

### DIFF
--- a/share/steel/examples/steelc/Makefile
+++ b/share/steel/examples/steelc/Makefile
@@ -4,6 +4,7 @@ all: verify test
 STEEL_HOME ?= ../../../..
 
 FSTAR_OPTIONS += --include $(STEEL_HOME)/lib/steel/c --warn_error @250
+FSTAR_OPTIONS += --ext compat:open_metas
 
 ifneq (,$(KRML_HOME))
 # We need to add some Low* files to the dependency roots, because


### PR DESCRIPTION
Will be needed if we merge FStarLang/FStar#3130 as it is right now. Commit message:


> After FStarLang/FStar#3130, F* will (by default) not run meta args in open contexts, breaking most SteelC modules.
>
> This seems to be very intended for, e.g., field_description_cons, which has no way of instantiating `fn` (when there's no expected type) without running the tactic. Setting this compat option makes everything work as before.
