### PR TITLE
Revising the syntax of vprops in Pulse

### DIFF
--- a/Steel.fst.config.json
+++ b/Steel.fst.config.json
@@ -19,7 +19,6 @@
     "share/steel/examples/pulse/dice/l0",
     "share/steel/examples/pulse/dice/engine",
     "share/steel/examples/pulse/dice/common",
-    "share/steel/examples/pulse/dice/cbor",
-    "share/steel/examples/pulse/_output/cache"
+    "share/steel/examples/pulse/dice/cbor"
   ]
 }

--- a/share/steel/examples/pulse/ArrayTests.fst
+++ b/share/steel/examples/pulse/ArrayTests.fst
@@ -24,7 +24,7 @@ fn compare (#t:eqtype) (#p1 #p2:perm) (l:US.t) (#s1 #s2:elseq t l) (a1 a2:A.larr
 {
   let mut i = 0sz;
   while (let vi = !i; if US.(vi <^ l) { let v1 = a1.(vi); let v2 = a2.(vi); (v1 = v2) } else { false } )
-  invariant b. exists (vi:US.t). ( 
+  invariant b. exists* (vi:US.t). ( 
     R.pts_to i vi **
     A.pts_to a1 #p1 s1 **
     A.pts_to a2 #p2 s2 **
@@ -50,14 +50,14 @@ fn fill_array (#t:Type0) (l:US.t) (a:(a:A.array t{ US.v l == A.length a })) (v:t
               (#s:(s:Ghost.erased (Seq.seq t) { Seq.length s == US.v l }))
    requires (A.pts_to a s)
    ensures 
-      exists (s:Seq.seq t). (
+      exists* (s:Seq.seq t). (
          A.pts_to a s **
          pure (s `Seq.equal` Seq.create (US.v l) v)
       )
 {
    let mut i = 0sz;
    while (let vi = !i; US.(vi <^ l))
-   invariant b. exists (s:Seq.seq t) (vi:US.t). (
+   invariant b. exists* (s:Seq.seq t) (vi:US.t). (
       A.pts_to a s **
       R.pts_to i vi **
       pure ((b == US.(vi <^ l)) /\
@@ -270,7 +270,7 @@ fn sort3 (a:array U32.t)
          (#s:(s:Ghost.erased (Seq.seq U32.t) {Seq.length s == 3}))
    requires (A.pts_to a s)
    ensures 
-      exists s'. (
+      exists* s'. (
          A.pts_to a s' **
          pure (sorted s s')
       )
@@ -330,7 +330,7 @@ fn sort3_alt (a:array U32.t)
              (#s:(s:Ghost.erased (Seq.seq U32.t) {Seq.length s == 3}))
    requires (A.pts_to a s)
    ensures 
-      exists s'. (
+      exists* s'. (
          A.pts_to a s' **
          pure (sorted s s')
       )
@@ -435,7 +435,7 @@ fn test_array_swap
   (#s: Ghost.erased (Seq.seq U32.t))
 requires
   A.pts_to a s ** pure (A.length a == 2)
-ensures exists s' .
+ensures exists* s' .
   A.pts_to a s'
 {
   A.pts_to_len a;

--- a/share/steel/examples/pulse/Assert.fst
+++ b/share/steel/examples/pulse/Assert.fst
@@ -7,10 +7,10 @@ fn test_assert (r0 r1: ref nat)
                (#v0:nat)
     requires 
         pts_to r0 #p0 v0 **
-        (exists v1. pts_to r1 #p1 v1)
+        (exists* v1. pts_to r1 #p1 v1)
     ensures
         pts_to r0 #p0 v0 **
-        (exists v1. pts_to r1 #p1 v1)
+        (exists* v1. pts_to r1 #p1 v1)
 {
     //assert_ (pts_to r1 ?p1 ?v1); would be nice to have a version that also binds witnesses
     assert_ (pts_to r0 #p0 (v0 + 0));

--- a/share/steel/examples/pulse/AuxPredicate.fst
+++ b/share/steel/examples/pulse/AuxPredicate.fst
@@ -82,7 +82,7 @@ fn invar_introduces_ghost_alt (r:R.ref int)
 
   while (let vr = !r; (vr = 0))
   invariant b. 
-    exists v.
+    exists* v.
       R.pts_to r v **
       pure ( (v==0 \/ v == 1) /\ b == (v = 0) )
   {
@@ -96,13 +96,13 @@ fn invar_introduces_ghost_alt (r:R.ref int)
 ```pulse
 fn exists_introduces_ghost (r:R.ref int)
   requires R.pts_to r 0
-  ensures exists v. R.pts_to r v ** pure (v == 0 \/ v == 1)
+  ensures exists* v. R.pts_to r v ** pure (v == 0 \/ v == 1)
 {
   r := 0;
 
   fold (my_inv true r);
 
-  introduce exists b. (my_inv b r) with _; 
+  introduce exists* b. (my_inv b r) with _; 
   // once you hide the witness in the existential
   // you lose knowledge about it, i.e., we do not know that r = 0
   with b. unfold (my_inv b r)

--- a/share/steel/examples/pulse/CustomSyntax.fst
+++ b/share/steel/examples/pulse/CustomSyntax.fst
@@ -343,16 +343,16 @@ fn sum2 (r:ref nat) (n:nat)
 
 ```pulse
 fn if_then_else_in_specs (r:ref U32.t)
-  requires `@(if true
+  requires (if true
               then pts_to r 0ul
               else pts_to r 1ul)
-  ensures  `@(if true
+  ensures  (if true
               then pts_to r 1ul
               else pts_to r 0ul)
 {
   // need this for typechecking !r on the next line,
   //   with inference of implicits
-  rewrite `@(if true then pts_to r 0ul else pts_to r 1ul)
+  rewrite (if true then pts_to r 0ul else pts_to r 1ul)
        as (pts_to r 0ul);
   let x = !r;
   r := U32.add x 1ul

--- a/share/steel/examples/pulse/CustomSyntax.fst
+++ b/share/steel/examples/pulse/CustomSyntax.fst
@@ -127,11 +127,11 @@ fn if_example (r:ref U32.t)
 ghost
 fn elim_intro_exists2 (r:ref U32.t)
    requires 
-     exists n. pts_to r n
+     exists* n. pts_to r n
    ensures 
-     exists n. pts_to r n
+     exists* n. pts_to r n
 {
-  introduce exists n. pts_to r n with _
+  introduce exists* n. pts_to r n with _
 }
 ```
 
@@ -144,15 +144,15 @@ val read_pred () (#b:erased bool)
 ```pulse
 fn while_test_alt (r:ref U32.t)
   requires 
-    exists b n.
+    exists* b n.
       (pts_to r n  **
        pred b)
   ensures 
-    exists n. (pts_to r n  **
+    exists* n. (pts_to r n  **
               pred false)
 {
   while (read_pred ())
-  invariant b . exists n. (pts_to r n  ** pred b)
+  invariant b . exists* n. (pts_to r n  ** pred b)
   {
     ()
   }
@@ -162,8 +162,8 @@ fn while_test_alt (r:ref U32.t)
 ```pulse
 fn infer_read_ex (r:ref U32.t)
   requires
-    exists n. pts_to r n
-  ensures exists n. pts_to r n
+    exists* n. pts_to r n
+  ensures exists* n. pts_to r n
 {
   let x = !r;
   ()
@@ -173,13 +173,13 @@ fn infer_read_ex (r:ref U32.t)
 
 ```pulse
 fn while_count2 (r:ref U32.t)
-  requires exists (n:U32.t). (pts_to r n)
+  requires exists* (n:U32.t). (pts_to r n)
   ensures (pts_to r 10ul)
 {
   open FStar.UInt32;
   while (let x = !r; (x <> 10ul))
   invariant b. 
-    exists n. (pts_to r n  **
+    exists* n. (pts_to r n  **
           pure (b == (n <> 10ul)))
   {
     let x = !r;
@@ -255,7 +255,7 @@ fn count_local (r:ref int) (n:int)
   let mut i = 0;
   while
     (let m = !i; (m <> n))
-  invariant b. exists m. 
+  invariant b. exists* m. 
     (pts_to i m  **
      pure (b == (m <> n)))
   {
@@ -277,12 +277,12 @@ let zero : nat = 0
 
 ```pulse
 fn sum (r:ref nat) (n:nat)
-   requires exists i. (pts_to r i)
+   requires exists* i. (pts_to r i)
    ensures (pts_to r (sum_spec n))
 {
    let mut i = zero;
    let mut sum = zero;
-   introduce exists b m s. (
+   introduce exists* b m s. (
      pts_to i m  **
      pts_to sum s  **
      pure (s == sum_spec m /\
@@ -290,7 +290,7 @@ fn sum (r:ref nat) (n:nat)
    with (zero <> n);
         
    while (let m = !i; (m <> n))
-   invariant b . exists m s. (
+   invariant b . exists* m s. (
      pts_to i m  **
      pts_to sum s  **
      pure (s == sum_spec m /\
@@ -300,7 +300,7 @@ fn sum (r:ref nat) (n:nat)
      let s = !sum;
      i := (m + 1);
      sum := s + m + 1;
-     introduce exists b m s. (
+     introduce exists* b m s. (
        pts_to i m  **
        pts_to sum s  **
        pure (s == sum_spec m /\
@@ -309,22 +309,22 @@ fn sum (r:ref nat) (n:nat)
    };
    let s = !sum;
    r := s;
-   introduce exists m. (pts_to i m) 
+   introduce exists* m. (pts_to i m) 
    with _;
-   introduce exists s. (pts_to sum s)
+   introduce exists* s. (pts_to sum s)
    with _
 }
 ```
 
 ```pulse
 fn sum2 (r:ref nat) (n:nat)
-   requires exists i. pts_to r i
+   requires exists* i. pts_to r i
    ensures pts_to r (sum_spec n)
 {
    let mut i = zero;
    let mut sum = zero;
    while (let m = !i; (m <> n))
-   invariant b . exists m s.
+   invariant b . exists* m s.
      pts_to i m  **
      pts_to sum s **
      pure (s == sum_spec m /\ b == (m <> n))

--- a/share/steel/examples/pulse/Demo.MultiplyByRepeatedAddition.fst
+++ b/share/steel/examples/pulse/Demo.MultiplyByRepeatedAddition.fst
@@ -21,7 +21,7 @@ fn mult (x y:nat)
     let mut acc = 0;
     while ((ctr < x))
     invariant b.
-    exists c a.
+    exists* c a.
         pts_to ctr c **
         pts_to acc a **
         pure (a == (c * y) /\
@@ -48,7 +48,7 @@ fn mult32 (x y:U32.t)
     let mut acc = 0ul;
     while ((ctr < x))
     invariant b.
-    exists c a.
+    exists* c a.
         pts_to ctr c **
         pts_to acc a **
         pure (c <= x /\
@@ -75,7 +75,7 @@ fn mult32' (x y:U32.t)
     let mut acc = 0ul;
     while ((ctr <^ x))
     invariant b.
-    exists c a.
+    exists* c a.
         pts_to ctr c **
         pts_to acc a **
         pure (c <=^ x /\

--- a/share/steel/examples/pulse/ExistsWitness.fst
+++ b/share/steel/examples/pulse/ExistsWitness.fst
@@ -19,8 +19,8 @@ let assume_squash (p:prop) : squash p = assume p
 
 ```pulse
 fn sample (x:R.ref int)
-requires exists p y. R.pts_to x #p y
-ensures exists p y. R.pts_to x #p y ** pure (y == 17)
+requires exists* p y. R.pts_to x #p y
+ensures exists* p y. R.pts_to x #p y ** pure (y == 17)
 {
     let y' = get_witness x;
     assume_squash (y'==17);
@@ -30,8 +30,8 @@ ensures exists p y. R.pts_to x #p y ** pure (y == 17)
 
 ```pulse
 fn sample_ (x:R.ref int) (#p:perm)
-requires exists y. R.pts_to x #p y
-ensures exists y. R.pts_to x #p y ** pure (y == 17)
+requires exists* y. R.pts_to x #p y
+ensures exists* y. R.pts_to x #p y ** pure (y == 17)
 {
     let y = get_witness x;
     assume_squash (y==17);
@@ -41,8 +41,8 @@ ensures exists y. R.pts_to x #p y ** pure (y == 17)
 
 ```pulse
 fn sample2 (x:R.ref int) (#p:perm)
-requires exists y. R.pts_to x #p y
-ensures exists y. R.pts_to x #p y ** pure (y == 17)
+requires exists* y. R.pts_to x #p y
+ensures exists* y. R.pts_to x #p y ** pure (y == 17)
 {
     with (y:erased _).
     assert (R.pts_to x #p y);
@@ -55,7 +55,7 @@ assume val drop (p:vprop) : stt unit p (fun _ -> emp)
 
 ```pulse
 fn sample3 (x0:R.ref int) (x1:R.ref bool) (#p0 #p1:perm)
-requires exists v0 v1. R.pts_to x0 #p0 v0 ** R.pts_to x1 #p1 v1
+requires exists* v0 v1. R.pts_to x0 #p0 v0 ** R.pts_to x1 #p1 v1
 ensures emp
 {
     
@@ -68,7 +68,7 @@ ensures emp
 
 ```pulse
 fn sample4 (x0:R.ref int) (x1:R.ref bool) (#p0 #p1:perm)
-requires exists v0 v1. R.pts_to x0 #p0 v0 ** R.pts_to x1 #p1 v1
+requires exists* v0 v1. R.pts_to x0 #p0 v0 ** R.pts_to x1 #p1 v1
 ensures emp
 {
     
@@ -81,7 +81,7 @@ ensures emp
 
 ```pulse
 fn sample5 (x0:R.ref int) (x1:R.ref bool) (#p0 #p1:perm)
-requires exists v0 v1. R.pts_to x0 #p0 v0 ** R.pts_to x1 #p1 v1
+requires exists* v0 v1. R.pts_to x0 #p0 v0 ** R.pts_to x1 #p1 v1
 ensures emp
 {
     
@@ -96,7 +96,7 @@ ensures emp
 
 ```pulse
 fn sample6 (x0:R.ref int) (x1:R.ref bool)
-requires exists p0 p1 v0 v1. R.pts_to x0 #p0 v0 ** R.pts_to x1 #p1 v1
+requires exists* p0 p1 v0 v1. R.pts_to x0 #p0 v0 ** R.pts_to x1 #p1 v1
 ensures emp
 {
     

--- a/share/steel/examples/pulse/ExtractionTest.fst
+++ b/share/steel/examples/pulse/ExtractionTest.fst
@@ -38,7 +38,7 @@ fn write10 (x:ref U32.t)
   let mut ctr = 10ul;
   while ((ctr >^ 0ul))
   invariant b.
-    exists n i.
+    exists* n i.
       pts_to x n **
       pts_to ctr i **
       pure (i <=^ 10ul /\ 
@@ -57,13 +57,13 @@ module A = Pulse.Lib.Array
 ```pulse
 fn fill_array (x:array U32.t) (n:SZ.t) (v:U32.t)
   requires A.pts_to x 's ** pure (A.length x == SZ.v n)
-  ensures exists s. A.pts_to x s ** pure (Seq.equal s (Seq.create (SZ.v n) v))
+  ensures exists* s. A.pts_to x s ** pure (Seq.equal s (Seq.create (SZ.v n) v))
 {
   A.pts_to_len x;
   let mut i : SZ.t = 0sz;
   while (SZ.(i `SZ.lt` n))
   invariant b.
-    exists (vi:SZ.t) (s:Seq.seq U32.t).
+    exists* (vi:SZ.t) (s:Seq.seq U32.t).
       pts_to i vi **
       A.pts_to x s **
       pure (SZ.(vi <=^ n) /\

--- a/share/steel/examples/pulse/Fibo32.fst
+++ b/share/steel/examples/pulse/Fibo32.fst
@@ -27,7 +27,7 @@ fn fibo32 (k:U32.t) (_:squash(0ul < k /\ fits #U32.t (fib (v k))))
   let mut j = 1ul;
   let mut ctr = 1ul;
   while (let vctr = !ctr; (vctr < k))
-  invariant b . exists vi vj vctr. (
+  invariant b . exists* vi vj vctr. (
      pts_to i vi **
      pts_to j vj **
      pts_to ctr vctr **     

--- a/share/steel/examples/pulse/Fibonacci.fst
+++ b/share/steel/examples/pulse/Fibonacci.fst
@@ -28,7 +28,7 @@ fn fibonacci (k:pos)
   let mut ctr = 1;
   while ((ctr < k))
   invariant b . 
-    exists vi vj vctr. 
+    exists* vi vj vctr. 
     pts_to i vi **
     pts_to j vj **
     pts_to ctr vctr **
@@ -58,7 +58,7 @@ fn fibonacci32 (k:U32.t)
   let mut ctr = 1ul;
   while ((ctr < k))
   invariant b . 
-    exists vi vj vctr. 
+    exists* vi vj vctr. 
      pts_to i vi **
      pts_to j vj **
      pts_to ctr vctr **
@@ -88,7 +88,7 @@ fn fibo (n:pos)
   let mut j = 1;
   let mut ctr = 1;
   while ((ctr < n))
-  invariant b . exists vi vj vctr. (
+  invariant b . exists* vi vj vctr. (
      pts_to i vi **
      pts_to j vj **
      pts_to ctr vctr **
@@ -118,7 +118,7 @@ fn fibo2 (n:pos)
   let mut j : nat = 1;
   let mut ctr : nat = 1;
   while ((ctr < n))
-  invariant b . exists vi vj vctr. (
+  invariant b . exists* vi vj vctr. (
      pts_to i vi **
      pts_to j vj **
      pts_to ctr vctr **     
@@ -148,7 +148,7 @@ fn fibo3 (n:pos)
   let mut j : nat = 1;
   let mut ctr : nat = 1;
   while ((ctr < n))
-  invariant b . exists vi vj vctr. (
+  invariant b . exists* vi vj vctr. (
      pts_to i vi **
      pts_to j vj **
      pts_to ctr vctr **     

--- a/share/steel/examples/pulse/Pulse.fst.config.json
+++ b/share/steel/examples/pulse/Pulse.fst.config.json
@@ -1,0 +1,26 @@
+{
+  "fstar_exe": "fstar.exe",
+  "options": [
+    "--load_cmxs",
+    "steel",
+    "--cache_dir",
+    "_output/cache",
+    "--using_facts_from",
+    "* -FStar.Tactics -FStar.Reflection"
+  ],
+  "include_dirs": [
+    "../../../../lib/steel/pulse",
+    "../../../../lib/steel",
+    "bug-reports",
+    "by-example",
+    "lib",
+    "parallel",
+    "dice",
+    "dice/cbor",
+    "dice/dpe",
+    "dice/l0",
+    "dice/engine",
+    "dice/common",
+    "dice/cbor"
+  ]
+}

--- a/share/steel/examples/pulse/QuicksortParallel.fst
+++ b/share/steel/examples/pulse/QuicksortParallel.fst
@@ -134,7 +134,7 @@ let op_Array_Assignment
 fn swap (a: A.array int) (i j: nat_fits) (#l:(l:nat{l <= i /\ l <= j})) (#r:(r:nat{i < r /\ j < r}))
   (#s0: Ghost.erased (Seq.seq int))
   requires A.pts_to_range a l r s0
-  ensures exists s. (A.pts_to_range a l r s
+  ensures exists* s. (A.pts_to_range a l r s
     ** pure (Seq.length s0 = r - l /\ Seq.length s = r - l /\
       s = seq_swap s0 (i - l) (j - l) /\ permutation s0 s
     ))
@@ -170,7 +170,7 @@ fn partition (a: A.array int) (lo: nat) (hi:(hi:nat{lo < hi - 1})) (n: nat) (lb 
       )
   )
   returns r: nat & nat & int // left, right, pivot
-  ensures exists s. (
+  ensures exists* s. (
     A.pts_to_range a lo hi s
      **
     pure (
@@ -189,7 +189,7 @@ fn partition (a: A.array int) (lo: nat) (hi:(hi:nat{lo < hi - 1})) (n: nat) (lb 
   let mut j = lo - 1;
   let mut k = lo;
   while (let vk = !k; (vk < hi - 1))
-    invariant b . exists s vi vj vk. (
+    invariant b . exists* s vi vj vk. (
       A.pts_to_range a lo hi s **
       R.pts_to i vi **
       R.pts_to j vj **
@@ -272,7 +272,7 @@ fn partition_wrapper (a: A.array int) (lo: nat) (hi:(hi:nat{lo < hi - 1})) (n: n
       /\ Seq.length s0 = hi - lo)
   )
   returns r: nat & nat & int // left, right, pivot
-  ensures exists s1 s2 s3. (
+  ensures exists* s1 s2 s3. (
     A.pts_to_range a lo r._1 s1 **
     A.pts_to_range a r._1 r._2 s2 **
     A.pts_to_range a r._2 hi s3 **
@@ -336,7 +336,7 @@ fn quicksort' (a: A.array int) (lo: nat)
 (hi:(hi:int{-1 <= hi - 1 /\ lo <= hi}))
 (lb rb: int) (n: nat) (#s0: Ghost.erased (Seq.seq int))
   requires A.pts_to_range a lo hi s0 ** pure (pure_pre_quicksort a lo hi lb rb n s0)
-  ensures exists s. (A.pts_to_range a lo hi s ** pure (pure_post_quicksort a lo hi lb rb n s0 s))
+  ensures exists* s. (A.pts_to_range a lo hi s ** pure (pure_post_quicksort a lo hi lb rb n s0 s))
 { admit() }
 ```
 
@@ -344,7 +344,7 @@ fn quicksort' (a: A.array int) (lo: nat)
 ```pulse
 fn quicksort (a: A.array int) (lo: nat) (hi:(hi:int{-1 <= hi - 1 /\ lo <= hi})) (lb rb: int) (n: nat) (#s0: Ghost.erased (Seq.seq int))
   requires A.pts_to_range a lo hi s0 ** pure (pure_pre_quicksort a lo hi lb rb n s0)
-  ensures exists s. (A.pts_to_range a lo hi s ** pure (pure_post_quicksort a lo hi lb rb n s0 s))
+  ensures exists* s. (A.pts_to_range a lo hi s ** pure (pure_post_quicksort a lo hi lb rb n s0 s))
   // decreases hi + 1 - lo
 {
   if (lo < hi - 1)
@@ -361,8 +361,8 @@ fn quicksort (a: A.array int) (lo: nat) (hi:(hi:int{-1 <= hi - 1 /\ lo <= hi})) 
       parallel
       requires (A.pts_to_range a lo r._1 s1 ** pure (pure_pre_quicksort a lo r._1 lb pivot n s1))
           and (A.pts_to_range a r._2 hi s3 ** pure (pure_pre_quicksort a r._2 hi pivot rb n s3))
-      ensures (exists s. (A.pts_to_range a lo r._1 s ** pure (pure_post_quicksort a lo r._1 lb pivot n s1 s)))
-          and (exists s. (A.pts_to_range a r._2 hi s ** pure (pure_post_quicksort a r._2 hi pivot rb n s3 s)))
+      ensures (exists* s. (A.pts_to_range a lo r._1 s ** pure (pure_post_quicksort a lo r._1 lb pivot n s1 s)))
+          and (exists* s. (A.pts_to_range a r._2 hi s ** pure (pure_post_quicksort a r._2 hi pivot rb n s3 s)))
       {
         // termination check
         assert_prop (hi - lo > (r._1 - 1) + 1 - lo);

--- a/share/steel/examples/pulse/QuicksortSequential.fst
+++ b/share/steel/examples/pulse/QuicksortSequential.fst
@@ -63,7 +63,7 @@ fn swap
   (i j: nat_smaller n)
   (#s0: Ghost.erased (Seq.seq int))
   requires A.pts_to a s0 ** pure (Seq.length s0 == n)
-  ensures exists s. (A.pts_to a #full_perm s **
+  ensures exists* s. (A.pts_to a #full_perm s **
     pure (Seq.length s0 = n /\ Seq.length s = n /\ s = seq_swap s0 i j
     /\ permutation s0 s))
 {
@@ -98,7 +98,7 @@ fn partition (a: A.array int) (lo hi: int) (n: nat) (lb rb: int) (#s0: Ghost.era
       )
   )
   returns r: int & int & int // left, right, pivot
-  ensures exists s. (
+  ensures exists* s. (
     A.pts_to a s **
     pure (
       Seq.length s = n /\ Seq.length s0 = n /\ A.length a = n
@@ -117,7 +117,7 @@ fn partition (a: A.array int) (lo hi: int) (n: nat) (lb rb: int) (#s0: Ghost.era
   let mut j = lo - 1;
   let mut k = lo;
   while (let vk = !k; (vk < hi))
-    invariant b . exists s vi vj vk. (
+    invariant b . exists* s vi vj vk. (
       A.pts_to a s **
       R.pts_to i vi **
       R.pts_to j vj **
@@ -189,7 +189,7 @@ fn quicksort' (a: A.array int) (lo hi: int) (lb rb: int) (n: nat) (#s0: (s0:Ghos
     /\ hi >= -1 /\ lo <= n /\ lb <= rb
     /\ between_bounds n s0 lo hi lb rb
     )
-  ensures exists s. (
+  ensures exists* s. (
     A.pts_to a s ** pure (
       0 <= lo /\ hi < n /\ Seq.length s0 = n /\ Seq.length s = n /\ SZ.fits n /\ A.length a = n
       /\ same_between n s0 s 0 (lo - 1) /\ same_between n s0 s (hi + 1) (n - 1)
@@ -208,7 +208,7 @@ fn quicksort (a: A.array int) (lo hi: int) (lb rb: int) (n: nat) (#s0: (s0:Ghost
     /\ hi >= -1 /\ lo <= n /\ lb <= rb
     /\ between_bounds n s0 lo hi lb rb
     )
-  ensures exists s. (
+  ensures exists* s. (
     A.pts_to a s ** pure (
       0 <= lo /\ hi < n /\ Seq.length s0 = n /\ Seq.length s = n /\ SZ.fits n /\ A.length a = n
       /\ same_between n s0 s 0 (lo - 1) /\ same_between n s0 s (hi + 1) (n - 1)

--- a/share/steel/examples/pulse/ZetaHashAccumulator.fst
+++ b/share/steel/examples/pulse/ZetaHashAccumulator.fst
@@ -360,7 +360,7 @@ fn aggregate_raw_hashes (#s1 #s2:e_raw_hash_value_t)
     assert (pure (s1 `Seq.equal` xor_bytes_pfx s1 s2 0));
     while ((i < 32sz))
     invariant b.
-        exists wi.
+        exists* wi.
             pts_to i wi **
             A.pts_to b1 (xor_bytes_pfx s1 s2 (v wi)) **
             A.pts_to b2 s2 **

--- a/share/steel/examples/pulse/bug-reports/Bug29.fst
+++ b/share/steel/examples/pulse/bug-reports/Bug29.fst
@@ -35,8 +35,8 @@ ensures
 [@@expect_failure]
 ```pulse
 fn test_assert_with_duplicates(r: ref nat)
-    requires exists v. pts_to r v
-    ensures exists v. pts_to r v
+    requires exists* v. pts_to r v
+    ensures exists* v. pts_to r v
 {
     with v. assert (pts_to r v ** pts_to r v);
     ()

--- a/share/steel/examples/pulse/bug-reports/DependentTuples.fst
+++ b/share/steel/examples/pulse/bug-reports/DependentTuples.fst
@@ -24,7 +24,7 @@ fn tuple ()
   unfold exists_n global_tup._1;  // this unfold affects the type of the dependent 
                                   // tuple, so we lost syntactic equality and the 
                                   // following assertion fails
-  assert (`@(exists* n. pts_to global_tup._1 n));
+  assert ((exists* n. pts_to global_tup._1 n));
   admit()
 }
 ```

--- a/share/steel/examples/pulse/bug-reports/DependentTuples.fst
+++ b/share/steel/examples/pulse/bug-reports/DependentTuples.fst
@@ -47,7 +47,7 @@ fn record ()
   acquire global_rec.lk;
   assert (exists_n global_rec.r);
   unfold exists_n global_rec.r;
-  assert (exists n. pts_to global_rec.r n);
+  assert (exists* n. pts_to global_rec.r n);
   admit()
 }
 ```

--- a/share/steel/examples/pulse/bug-reports/ExistsErasedAndPureEqualities.fst
+++ b/share/steel/examples/pulse/bug-reports/ExistsErasedAndPureEqualities.fst
@@ -5,14 +5,14 @@ module R = Pulse.Lib.Reference
 assume
 val some_pred (x:R.ref int) (v:int) : vprop
 
-//Intro exists with an erased variable fails
+//Intro exists* with an erased variable fails
 [@@expect_failure]
 ```pulse
 fn test1 (x:R.ref int) (#v:Ghost.erased int)
   requires some_pred x v
   ensures some_pred x v
 {
-    introduce exists (v_:erased int). (
+    introduce exists* (v_:erased int). (
         pure (v == v_)
     ) with _;
   
@@ -20,17 +20,17 @@ fn test1 (x:R.ref int) (#v:Ghost.erased int)
 }
 ```
 
-//Intro exists with an erased variable in an equality bound on the left,
+//Intro exists* with an erased variable in an equality bound on the left,
 //fails weirdly with an SMT failure, where it tries to prove earsed int == int
 //and hide v == v
-//Intro exists with an erased variable fails
+//Intro exists* with an erased variable fails
 [@@expect_failure]
 ```pulse
 fn test2 (x:R.ref int) (#v:Ghost.erased int)
   requires some_pred x v
   ensures some_pred x v
 {
-    introduce exists (v_:erased int). (
+    introduce exists* (v_:erased int). (
         pure (v == v_)
     ) with _;
   
@@ -44,7 +44,7 @@ fn test3 (x:R.ref int) (#v:Ghost.erased int)
   requires some_pred x v
   ensures emp
 {
-    introduce exists (v_:int). (
+    introduce exists* (v_:int). (
         pure (v_ == v)
     ) with _;
   
@@ -59,7 +59,7 @@ fn test4 (x:R.ref int) (#v:Ghost.erased int)
   requires some_pred x v
   ensures emp
 {
-    introduce exists (v_:int). (
+    introduce exists* (v_:int). (
         pure (v == v_)
     ) with _;
   

--- a/share/steel/examples/pulse/bug-reports/ExistsSyntax.fst
+++ b/share/steel/examples/pulse/bug-reports/ExistsSyntax.fst
@@ -7,7 +7,7 @@ module R = Pulse.Lib.Reference
 fn some_function (r0:ref U8.t) (r1:ref U8.t) (#s:erased U8.t)
    requires 
       R.pts_to r0 s **
-      exists (s1:U8.t). R.pts_to r1 s1
+      (exists* (s1:U8.t). R.pts_to r1 s1)
    ensures
         emp
 {

--- a/share/steel/examples/pulse/bug-reports/IntroGhost.fst
+++ b/share/steel/examples/pulse/bug-reports/IntroGhost.fst
@@ -36,7 +36,7 @@ fn invar_introduces_ghost (r:R.ref int)
 ```
 
 (* 
-  intro exists pattern exhibits the 
+  intro exists* pattern exhibits the 
   same issue as the invariant pattern 
 *)
 [@@expect_failure]
@@ -49,7 +49,7 @@ fn exists_introduces_ghost (r:R.ref int)
 
   fold (my_inv true r);
 
-  introduce exists b. (my_inv b r) with _;  // FAILS: trying to prove: my_inv (reveal (hide true)) r
+  introduce exists* b. (my_inv b r) with _;  // FAILS: trying to prove: my_inv (reveal (hide true)) r
                                             // but typing context has: my_inv true r
   ()
 }
@@ -69,7 +69,7 @@ fn exists_with_witness_introduces_ghost (r:R.ref int)
 
   fold (my_inv true r);
 
-  introduce exists b. (my_inv b r) with true; // this is OK but then we lose access
+  introduce exists* b. (my_inv b r) with true; // this is OK but then we lose access
                                               // to witness b=true
 
   assert (my_inv true r); // FAILS

--- a/share/steel/examples/pulse/bug-reports/JoinIf.fst
+++ b/share/steel/examples/pulse/bug-reports/JoinIf.fst
@@ -17,8 +17,8 @@ fn sort3_alt (a:array U32.t)
              (#s:(s:Ghost.erased (Seq.seq U32.t) {Seq.length s == 3}))
    requires (A.pts_to a s)
    ensures 
-      exists s'. (
-         A.pts_to a s' `star`
+      exists* s'. (
+         A.pts_to a s' **
          pure (sorted s s')
       )
 {
@@ -60,8 +60,8 @@ fn sort3_alt (a:array U32.t)
              (#s:(s:Ghost.erased (Seq.seq U32.t) {Seq.length s == 3}))
    requires (A.pts_to a s)
    ensures 
-      exists s'. (
-         A.pts_to a s' `star`
+      exists* s'. (
+         A.pts_to a s' **
          pure (sorted s s')
       )
 {

--- a/share/steel/examples/pulse/bug-reports/RecordOfArrays.fst
+++ b/share/steel/examples/pulse/bug-reports/RecordOfArrays.fst
@@ -45,7 +45,7 @@ fn fold_rec_array_perm (r:rec_array) (#v1 #v2:erased (Seq.seq U8.t))
 ```pulse
 fn mutate_r2 (r:rec_array) (#v:(v:Ghost.erased rec_array_repr { Seq.length v.v2 > 0 }))
   requires rec_array_perm r v
-  ensures exists (v_:rec_array_repr) .
+  ensures exists* (v_:rec_array_repr) .
     rec_array_perm r v_ ** pure (v_.v2 `Seq.equal` Seq.upd v.v2 0 0uy /\ v_.v1 == v.v1)
 {
   unfold (rec_array_perm r v); //1. unfolding the predicate
@@ -75,7 +75,7 @@ fn mutate_rec_get_witness (l:US.t) (r:rec_array) (#v:Ghost.erased rec_array_repr
     rec_array_perm r v **
     pure (US.v l > 0 /\ A.length r.r2 == (US.v l) /\ Seq.length v.v2 == (US.v l))
   )
-  ensures exists v_.
+  ensures exists* v_.
     rec_array_perm r v_ **
     pure (Seq.length v.v2 > 0 /\ v_.v2 `Seq.equal` Seq.upd v.v2 0 0uy /\ v_.v1 == v.v1)
 {

--- a/share/steel/examples/pulse/bug-reports/Records.fst
+++ b/share/steel/examples/pulse/bug-reports/Records.fst
@@ -48,7 +48,7 @@ fn fold_rec_perm (r:rec2) (#v1 #v2:erased U8.t)
 ```pulse
 fn mutate_r2 (r:rec2) (#v:Ghost.erased rec_repr)
   requires rec_perm r v
-  ensures exists (v_:rec_repr) .
+  ensures exists* (v_:rec_repr) .
     rec_perm r v_ ** pure (v_.v2 == 0uy /\ v_.v1 == v.v1)
 {
   unfold (rec_perm r v); //1. unfolding the predicate
@@ -130,7 +130,7 @@ ensures R.pts_to x y ** pure (y==z)
 ```pulse
 fn unfold_and_fold_manually (r:rec2) (#v:Ghost.erased rec_repr)
   requires rec_perm r v
-  ensures exists (v_:rec_repr) . rec_perm r v_
+  ensures exists* (v_:rec_repr) . rec_perm r v_
 {
   rewrite (rec_perm r v)
     as (R.pts_to r.r1 v.v1 **
@@ -151,7 +151,7 @@ let rec_repr_with_v2 (v:rec_repr) (v2:U8.t) = { v1=v.v1; v2=v2 }
 ```pulse
 fn explicit_unfold_witness_taking_and_fold (r:rec2) (#v:Ghost.erased rec_repr)
   requires rec_perm r v
-  ensures exists (v_:rec_repr) . rec_perm r v_
+  ensures exists* (v_:rec_repr) . rec_perm r v_
 {
   rewrite (rec_perm r v)
     as (R.pts_to r.r1 v.v1 **
@@ -171,7 +171,7 @@ fn explicit_unfold_witness_taking_and_fold (r:rec2) (#v:Ghost.erased rec_repr)
 ```pulse
 fn explicit_unfold_slightly_better_witness_taking_and_fold (r:rec2) (#v:Ghost.erased rec_repr)
   requires rec_perm r v
-  ensures exists (v_:rec_repr) . rec_perm r v_
+  ensures exists* (v_:rec_repr) . rec_perm r v_
 {
   rewrite (rec_perm r v)
     as (R.pts_to r.r1 v.v1 **

--- a/share/steel/examples/pulse/bug-reports/UnificationVariableEscapes.fst
+++ b/share/steel/examples/pulse/bug-reports/UnificationVariableEscapes.fst
@@ -10,14 +10,14 @@ fn fill_array (#t:Type0) (a:A.array t) (l:(l:US.t { US.v l == A.length a })) (v:
               (#s:(s:Ghost.erased (Seq.seq t) { Seq.length s == A.length a }))
    requires (A.pts_to a s)
    ensures 
-      exists (s:Seq.seq t). (
+      exists* (s:Seq.seq t). (
          A.pts_to a s **
          pure (s `Seq.equal` Seq.create (US.v l) v)
       )
 {
    let mut i = 0sz;
    while (let vi = !i; US.(vi <^ l))
-   invariant b. exists (s:Seq.seq t) (vi:US.t). ( 
+   invariant b. exists* (s:Seq.seq t) (vi:US.t). ( 
       A.pts_to a s **
       R.pts_to i vi **
       pure ((b == US.(vi <^ l)) /\

--- a/share/steel/examples/pulse/by-example/PulseByExample.fst
+++ b/share/steel/examples/pulse/by-example/PulseByExample.fst
@@ -16,7 +16,7 @@ let my_list : list int = [1;2;3]
 fn five ()
   requires emp
   returns n:int
-  ensures  pure (n == 5)
+  ensures pure (n == 5)
 { 
   5
 }
@@ -34,10 +34,13 @@ module R = Pulse.Lib.Reference
 *)
 ```pulse
 fn ref_swap (r1 r2:ref int)
-  requires R.pts_to r1 'n1 
-        ** R.pts_to r2 'n2
-  ensures  R.pts_to r1 'n2
-        ** R.pts_to r2 'n1
+  requires
+    R.pts_to r1 'n1 **
+    R.pts_to r2 'n2
+  ensures
+    R.pts_to r1 'n2 **
+    R.pts_to r2 'n1
+
 {
   let v1 = !r1;
   let v2 = !r2;
@@ -60,15 +63,16 @@ open Pulse.Lib.BoundedIntegers
 
 ```pulse
 fn arr_swap (#t:Type0) (n i j:SZ.t) (a:larray t (v n))
-  requires 
+  requires
     A.pts_to a 's0 **
     pure (Seq.length 's0 == v n /\ i < n /\ j < n)
-  ensures exists s. 
+  ensures
+    exists* s. 
     A.pts_to a s **
     pure (Seq.length 's0 == v n /\ Seq.length s == v n /\ i < n /\ j < n
        /\ (forall (k:nat). k < v n /\ k <> v i /\ k <> v j ==> Seq.index 's0 k == Seq.index s k)
        /\ Seq.index 's0 (v i) == Seq.index s (v j)
-       /\ Seq.index 's0 (v j) == Seq.index s (v i))
+       /\ Seq.index 's0 (v j) == Seq.index s (v i))  
 {
   let vi = a.(i);
   let vj = a.(j);
@@ -85,16 +89,19 @@ fn arr_swap (#t:Type0) (n i j:SZ.t) (a:larray t (v n))
 *)
 ```pulse
 fn max (n:SZ.t) (a:larray nat (v n))
-  requires A.pts_to a #'p 's ** pure (Seq.length 's == v n)
+  requires
+    A.pts_to a #'p 's **
+    pure (Seq.length 's == v n)
   returns r:nat
-  ensures A.pts_to a #'p 's
-       ** pure (Seq.length 's == v n
-             /\ (forall (i:nat). i < v n ==> Seq.index 's i <= r))
+  ensures
+    A.pts_to a #'p 's **
+    pure (Seq.length 's == v n /\
+          (forall (i:nat). i < v n ==> Seq.index 's i <= r))
 {
   let mut i : SZ.t = 0sz;
   let mut max : nat = 0; //Note: without that `nat` annotation, this fails with very poor feedback. "SMT query failed"
   while (let vi = !i; (vi < n))
-  invariant b. exists (vi:SZ.t) (vmax:nat).
+  invariant b. exists* (vi:SZ.t) (vmax:nat).
     A.pts_to a #'p 's **
     R.pts_to i vi **
     R.pts_to max vmax **
@@ -124,16 +131,19 @@ fn max (n:SZ.t) (a:larray nat (v n))
 #push-options "--ext 'pulse:rvalues'"
 ```pulse
 fn max_alt (n:SZ.t) (a:larray nat (v n))
-  requires A.pts_to a #'p 's ** pure (Seq.length 's == v n)
+  requires
+    A.pts_to a #'p 's **
+    pure (Seq.length 's == v n)
   returns r:nat
-  ensures A.pts_to a #'p 's
-       ** pure (Seq.length 's == v n
-             /\ (forall (i:nat). i < v n ==> Seq.index 's i <= r))
+  ensures
+    A.pts_to a #'p 's **
+    pure (Seq.length 's == v n /\
+          (forall (i:nat). i < v n ==> Seq.index 's i <= r))
 {
   let mut i = 0sz;
   let mut max : nat = 0;
   while ((i < n))
-  invariant b. exists (vi:SZ.t) (vmax:nat).
+  invariant b. exists* (vi:SZ.t) (vmax:nat).
     A.pts_to a #'p 's **
     R.pts_to i vi **
     R.pts_to max vmax **

--- a/share/steel/examples/pulse/by-example/PulseByExample.fst
+++ b/share/steel/examples/pulse/by-example/PulseByExample.fst
@@ -57,7 +57,7 @@ open Pulse.Lib.BoundedIntegers
 (* 
   Things to note:
   - heap array, read and write
-  - exists and forall in spec
+  - exists* and forall in spec
   - machine integers, ops on bounded integers
 *)
 

--- a/share/steel/examples/pulse/dice/cbor/CBOR.Pulse.fst
+++ b/share/steel/examples/pulse/dice/cbor/CBOR.Pulse.fst
@@ -229,8 +229,8 @@ ensures
                     pts_to pi1 i1 ** pts_to pi2 i2 ** pts_to pdone done ** pts_to pres res **
                     cbor_array_iterator_match p1 i1 l1 **
                     cbor_array_iterator_match p2 i2 l2 **
-                    `@(cbor_array_iterator_match p1 i1 l1 @==> raw_data_item_match p1 a1 v1) **
-                    `@(cbor_array_iterator_match p2 i2 l2 @==> raw_data_item_match p2 a2 v2) **
+                    (cbor_array_iterator_match p1 i1 l1 @==> raw_data_item_match p1 a1 v1) **
+                    (cbor_array_iterator_match p2 i2 l2 @==> raw_data_item_match p2 a2 v2) **
                     pure (
                         List.Tot.length l1 == List.Tot.length l2 /\
                         Cbor.cbor_compare v1 v2 == (if res = 0s then Cbor.cbor_compare_array l1 l2 else I16.v res) /\
@@ -307,8 +307,8 @@ ensures
                     pts_to pi1 i1 ** pts_to pi2 i2 ** pts_to pdone done ** pts_to pres res **
                     cbor_map_iterator_match p1 i1 l1 **
                     cbor_map_iterator_match p2 i2 l2 **
-                    `@(cbor_map_iterator_match p1 i1 l1 @==> raw_data_item_match p1 a1 v1) **
-                    `@(cbor_map_iterator_match p2 i2 l2 @==> raw_data_item_match p2 a2 v2) **
+                    (cbor_map_iterator_match p1 i1 l1 @==> raw_data_item_match p1 a1 v1) **
+                    (cbor_map_iterator_match p2 i2 l2 @==> raw_data_item_match p2 a2 v2) **
                     pure (
                         List.Tot.length l1 == List.Tot.length l2 /\
                         (Cbor.cbor_compare v1 v2 == (if res = 0s then Cbor.cbor_compare_map l1 l2 else I16.v res)) /\
@@ -337,8 +337,8 @@ ensures
                         raw_data_item_match p2 (cbor_map_entry_value x2) (sndp v2') **
                         cbor_map_iterator_match p1 gi1' l1' **
                         cbor_map_iterator_match p2 gi2' l2' **
-                        `@((raw_data_item_map_entry_match p1 x1 v1' ** cbor_map_iterator_match p1 gi1' l1') @==> raw_data_item_match p1 a1 v1) **
-                        `@((raw_data_item_map_entry_match p2 x2 v2' ** cbor_map_iterator_match p2 gi2' l2') @==> raw_data_item_match p2 a2 v2) **
+                        ((raw_data_item_map_entry_match p1 x1 v1' ** cbor_map_iterator_match p1 gi1' l1') @==> raw_data_item_match p1 a1 v1) **
+                        ((raw_data_item_map_entry_match p2 x2 v2' ** cbor_map_iterator_match p2 gi2' l2') @==> raw_data_item_match p2 a2 v2) **
                         pts_to pres res ** pure ((I16.v res <: int) == (if Cbor.cbor_compare (fstp v1') (fstp v2') <> 0 then Cbor.cbor_compare (fstp v1') (fstp v2') else Cbor.cbor_compare (sndp v1') (sndp v2')))
                     {
                         let test = cbor_compare (cbor_map_entry_value x1) (cbor_map_entry_value x2);
@@ -843,7 +843,7 @@ requires
     A.pts_to_range a (SZ.v lo) (SZ.v hi) c **
     SM.seq_list_match c l (raw_data_item_map_entry_match full_perm)
 returns res: bool
-ensures `@(exists* (c': Seq.seq cbor_map_entry) (l': list (Cbor.raw_data_item & Cbor.raw_data_item)).
+ensures (exists* (c': Seq.seq cbor_map_entry) (l': list (Cbor.raw_data_item & Cbor.raw_data_item)).
     // FIXME: WHY WHY WHY do I need to use exists_ instead of Pulse exists? Error message is: "IOU"
     A.pts_to_range a (SZ.v lo) (SZ.v hi) c' **
     SM.seq_list_match c' l' (raw_data_item_map_entry_match full_perm) **

--- a/share/steel/examples/pulse/dice/cbor/CBOR.Pulse.fst
+++ b/share/steel/examples/pulse/dice/cbor/CBOR.Pulse.fst
@@ -129,7 +129,7 @@ ensures
     let prf1 : squash (Ghost.reveal va1 `Seq.equal` Seq.slice va1 0 (SZ.v sz)) = ();
     let prf2 : squash (Ghost.reveal va2 `Seq.equal` Seq.slice va2 0 (SZ.v sz)) = ();
     while (let i = !pi; let res = !pres; ((i `SZ.lt` sz) && (res = 0s)))
-    invariant cont . exists i res .
+    invariant cont . exists* i res .
         A.pts_to a1 #p1 va1 ** A.pts_to a2 #p2 va2 **
         pts_to pi i ** pts_to pres res **
         pure (
@@ -225,7 +225,7 @@ ensures
                     let res = !pres;
                     (res = 0s && not done)
                 )
-                invariant cont . exists i1 i2 done res l1 l2 .
+                invariant cont . exists* i1 i2 done res l1 l2 .
                     pts_to pi1 i1 ** pts_to pi2 i2 ** pts_to pdone done ** pts_to pres res **
                     cbor_array_iterator_match p1 i1 l1 **
                     cbor_array_iterator_match p2 i2 l2 **
@@ -303,7 +303,7 @@ ensures
                     let res = !pres;
                     (res = 0s && not done)
                 )
-                invariant cont . exists i1 i2 done res l1 l2 .
+                invariant cont . exists* i1 i2 done res l1 l2 .
                     pts_to pi1 i1 ** pts_to pi2 i2 ** pts_to pdone done ** pts_to pres res **
                     cbor_map_iterator_match p1 i1 l1 **
                     cbor_map_iterator_match p2 i2 l2 **
@@ -329,7 +329,7 @@ ensures
                     unfold (raw_data_item_map_entry_match p1 x1 v1');
                     unfold (raw_data_item_map_entry_match p2 x2 v2');
                     let test = cbor_compare (cbor_map_entry_key x1) (cbor_map_entry_key x2);
-                    if (test = 0s) ensures exists res done . // FIXME: HOW HOW HOW can I frame some things out?
+                    if (test = 0s) ensures exists* res done . // FIXME: HOW HOW HOW can I frame some things out?
                         pts_to pi1 gi1' ** pts_to pi2 gi2' ** pts_to pdone done **
                         raw_data_item_match p1 (cbor_map_entry_key x1) (fstp v1') **
                         raw_data_item_match p2 (cbor_map_entry_key x2) (fstp v2') **
@@ -555,7 +555,7 @@ ensures
         assert (pts_to pres gres ** cbor_map_get_invariant pmap vkey vmap map gres i l); // FIXME: WHY WHY WHY?
         not (done || Found? res)
     )
-    invariant cont . exists (done: bool) (res: cbor_map_get_t) (i: cbor_map_iterator_t) (l: list (Cbor.raw_data_item & Cbor.raw_data_item)) .
+    invariant cont . exists* (done: bool) (res: cbor_map_get_t) (i: cbor_map_iterator_t) (l: list (Cbor.raw_data_item & Cbor.raw_data_item)) .
         raw_data_item_match pkey key vkey ** 
         pts_to pdone done **
         pts_to pi i **
@@ -680,7 +680,7 @@ requires
     SM.seq_list_match c1 l1_0 (raw_data_item_map_entry_match full_perm) **
     SM.seq_list_match c2 l2_0 (raw_data_item_map_entry_match full_perm)
 returns res: bool
-ensures exists c l .
+ensures exists* c l .
     A.pts_to_range a (SZ.v lo) (SZ.v hi) c **
     SM.seq_list_match c l (raw_data_item_map_entry_match full_perm) **
     pure (
@@ -714,7 +714,7 @@ ensures exists c l .
         fold (cbor_map_sort_merge_invariant a lo hi l1_0 l2_0 pi1 pi2 pres cont gi1 gi2 gres c c1 c2 accu l1 l2);
         cont
     )
-    invariant cont . exists i1 i2 res c c1 c2 accu l1 l2 .
+    invariant cont . exists* i1 i2 res c c1 c2 accu l1 l2 .
         cbor_map_sort_merge_invariant a lo hi l1_0 l2_0 pi1 pi2 pres cont i1 i2 res c c1 c2 accu l1 l2
     {
         with gi1 gi2 gres c c1 c2 accu l1 l2 .
@@ -843,13 +843,12 @@ requires
     A.pts_to_range a (SZ.v lo) (SZ.v hi) c **
     SM.seq_list_match c l (raw_data_item_map_entry_match full_perm)
 returns res: bool
-ensures (exists* (c': Seq.seq cbor_map_entry) (l': list (Cbor.raw_data_item & Cbor.raw_data_item)).
-    // FIXME: WHY WHY WHY do I need to use exists_ instead of Pulse exists? Error message is: "IOU"
+ensures exists* (c': Seq.seq cbor_map_entry) (l': list (Cbor.raw_data_item & Cbor.raw_data_item)).
     A.pts_to_range a (SZ.v lo) (SZ.v hi) c' **
     SM.seq_list_match c' l' (raw_data_item_map_entry_match full_perm) **
     pure (
         Cbor.cbor_map_sort l == (res, l')
-    ))
+    )
 {
     Cbor.cbor_map_sort_eq l;
     A.pts_to_range_prop a;
@@ -903,7 +902,7 @@ requires
     SM.seq_list_match c l (raw_data_item_map_entry_match full_perm) **
     pure (SZ.v len == A.length a \/ SZ.v len == Seq.length c \/ SZ.v len == List.Tot.length l)
 returns res: bool
-ensures exists c' l' .
+ensures exists* c' l' .
     A.pts_to a c' **
     SM.seq_list_match c' l' (raw_data_item_map_entry_match full_perm) **
     pure (

--- a/share/steel/examples/pulse/dice/cbor/CDDL.Pulse.fst
+++ b/share/steel/examples/pulse/dice/cbor/CDDL.Pulse.fst
@@ -214,7 +214,7 @@ requires
     (
             R.pts_to pi i' **
             cbor_array_iterator_match p i' l' **
-            `@(cbor_array_iterator_match p i' l' @==> cbor_array_iterator_match p i l) **
+            (cbor_array_iterator_match p i' l' @==> cbor_array_iterator_match p i l) **
             pure (
                 opt_precedes (Ghost.reveal l) b /\
                 res == Some? (g l) /\
@@ -222,7 +222,7 @@ requires
             )
     )
 ensures
-        `@(exists* i' l'.
+        (exists* i' l'.
             R.pts_to pi i' **
             cbor_array_iterator_match p i' l' **
             (cbor_array_iterator_match p i' l' @==> cbor_array_iterator_match p i l) **
@@ -290,7 +290,7 @@ fn impl_array_group3_item
         with gc i' l' . assert (
             raw_data_item_match p c gc **
             cbor_array_iterator_match p i' l' **
-            `@((raw_data_item_match p c gc ** cbor_array_iterator_match p i' l') @==> cbor_array_iterator_match p gi l)
+            ((raw_data_item_match p c gc ** cbor_array_iterator_match p i' l') @==> cbor_array_iterator_match p gi l)
         ); // this is needed for the explicit arguments to split_consume_l below
         let test = fty c;
         if (test) {
@@ -895,7 +895,7 @@ fn impl_matches_map_group_no_restricted
         pts_to pres res **
         pts_to pi i **
         cbor_map_iterator_match p i l **
-        `@(cbor_map_iterator_match p i l @==> raw_data_item_match p c v) **
+        (cbor_map_iterator_match p i l @==> raw_data_item_match p c v) **
         pure (
             list_ghost_forall_exists matches_map_group_entry' (Map?.v v) g.zero_or_more ==
                 (res && list_ghost_forall_exists matches_map_group_entry' l g.zero_or_more) /\
@@ -907,7 +907,7 @@ fn impl_matches_map_group_no_restricted
         let x = cbor_map_iterator_next pi;
         stick_trans ();
         let res = ig x;
-        with vx gi l . assert (pts_to pi gi ** raw_data_item_map_entry_match p x vx ** cbor_map_iterator_match p gi l ** `@((raw_data_item_map_entry_match p x vx ** cbor_map_iterator_match p gi l) @==> raw_data_item_match p c v)) ;
+        with vx gi l . assert (pts_to pi gi ** raw_data_item_map_entry_match p x vx ** cbor_map_iterator_match p gi l ** ((raw_data_item_map_entry_match p x vx ** cbor_map_iterator_match p gi l) @==> raw_data_item_match p c v)) ;
         stick_consume_l ()
             #(raw_data_item_map_entry_match p x vx)
             #(cbor_map_iterator_match p gi l);

--- a/share/steel/examples/pulse/dice/cbor/CDDL.Pulse.fst
+++ b/share/steel/examples/pulse/dice/cbor/CDDL.Pulse.fst
@@ -890,7 +890,7 @@ fn impl_matches_map_group_no_restricted
     let done0 = cbor_map_iterator_is_done i0;
     let mut pcont = not done0;
     while (let cont = !pcont ; cont)
-    invariant cont . exists (i: cbor_map_iterator_t) . exists (l: list (raw_data_item & raw_data_item)) . exists (res: bool) . (
+    invariant cont . exists* (i: cbor_map_iterator_t) (l: list (raw_data_item & raw_data_item)) (res: bool) . (
         pts_to pcont cont **
         pts_to pres res **
         pts_to pi i **

--- a/share/steel/examples/pulse/dice/dpe/DPE.Messages.Parse.fst
+++ b/share/steel/examples/pulse/dice/dpe/DPE.Messages.Parse.fst
@@ -24,11 +24,11 @@ let emp_inames_disjoint (t:inames)
 ```pulse
 ghost
 fn elim_implies (#p #q:vprop) ()
-   requires `@(p @==> q) ** p
+   requires (p @==> q) ** p
    ensures q
 {
   open Pulse.Lib.Stick;
-  rewrite `@(p @==> q) as (stick #emp_inames p q);
+  rewrite (p @==> q) as (stick #emp_inames p q);
   elim_stick #emp_inames p q;
 }
 ```
@@ -283,8 +283,8 @@ fn parse_dpe_cmd (#s:erased (Seq.seq U8.t))
                 dpe_cmd_args = cmd_args;
               };
 *)              
-              rewrite (raw_data_item_match full_perm cmd_args vargs ** `@(raw_data_item_match full_perm cmd_args vargs @==> A.pts_to input #p s)) // FIXME: should `fold` honor projectors and not just `match`?
-                as (raw_data_item_match full_perm res.dpe_cmd_args vargs ** `@(raw_data_item_match full_perm res.dpe_cmd_args vargs @==> A.pts_to input #p s));
+              rewrite (raw_data_item_match full_perm cmd_args vargs ** (raw_data_item_match full_perm cmd_args vargs @==> A.pts_to input #p s)) // FIXME: should `fold` honor projectors and not just `match`?
+                as (raw_data_item_match full_perm res.dpe_cmd_args vargs ** (raw_data_item_match full_perm res.dpe_cmd_args vargs @==> A.pts_to input #p s));
               fold (parse_dpe_cmd_post len input s p (Some res));
               Some res
             }

--- a/share/steel/examples/pulse/dice/dpe/DPE.fst
+++ b/share/steel/examples/pulse/dice/dpe/DPE.fst
@@ -75,7 +75,7 @@ fn intro_session_state_perm_available
 ghost
 fn elim_session_state_perm_available (s:(s:session_state { Available? s }))
   requires session_state_perm s 
-  ensures exists r. context_perm (ctxt_of s) r 
+  ensures exists* r. context_perm (ctxt_of s) r 
 {
   match s
   {
@@ -287,7 +287,7 @@ fn insert (#kt:eqtype) (#vt:Type0)
     models ht pht
   returns b:bool
   ensures
-    exists pht'.
+    exists* pht'.
       models ht pht' **
       pure (if b
             then (PHT.not_full (reveal pht).repr /\
@@ -690,7 +690,7 @@ fn init_l0_ctxt (cdi:A.larray U8.t (US.v dice_digest_len))
   requires A.pts_to cdi s
         ** pure (A.is_full_array cdi)
   returns ctxt:context_t
-  ensures exists repr.
+  ensures exists* repr.
     context_perm ctxt repr **
     pure (repr == L0_context_repr (mk_l0_context_repr_t uds_bytes s engine_repr))
 {
@@ -755,7 +755,7 @@ fn init_l1_ctxt (deviceIDCSR_len: US.t) (aliasKeyCRT_len: US.t)
     A.pts_to aliasKey_pub aliasKey_pub0 ** 
     A.pts_to deviceIDCSR deviceIDCSR0 **
     A.pts_to aliasKeyCRT aliasKeyCRT0 **
-    exists l1repr. (
+    (exists* l1repr. 
       context_perm ctxt l1repr **
       pure (l1repr ==
             L1_context_repr (mk_l1_context_repr_t 
@@ -931,7 +931,7 @@ fn intro_maybe_context_perm (c:context_t)
 ghost
 fn elim_maybe_context_perm (c:context_t)
   requires maybe_context_perm (Some c)
-  ensures exists repr. context_perm c repr
+  ensures exists* repr. context_perm c repr
 {
   unfold (maybe_context_perm (Some c));
   with x y. rewrite (context_perm x y) as (context_perm c y)

--- a/share/steel/examples/pulse/dice/dpe/DPE_CBOR.fst
+++ b/share/steel/examples/pulse/dice/dpe/DPE_CBOR.fst
@@ -31,11 +31,11 @@ let emp_inames_disjoint (t:inames)
 ```pulse
 ghost
 fn elim_implies () (#p #q:vprop)
-   requires `@(p @==> q) ** p
+   requires (p @==> q) ** p
    ensures q
 {
   open Pulse.Lib.Stick;
-  rewrite `@(p @==> q) as (stick #emp_inames p q);
+  rewrite (p @==> q) as (stick #emp_inames p q);
   elim_stick #emp_inames p q;
 }
 ```
@@ -46,7 +46,7 @@ fn finish (c:cbor_read_t)
           (#v:erased (raw_data_item))
           (#s:erased (Seq.seq U8.t))
           (#rem:erased (Seq.seq U8.t))
-  requires `@((raw_data_item_match full_perm c.cbor_read_payload v **
+  requires ((raw_data_item_match full_perm c.cbor_read_payload v **
                A.pts_to c.cbor_read_remainder #p rem) @==>
               A.pts_to input #p s) **
             raw_data_item_match full_perm c.cbor_read_payload v **

--- a/share/steel/examples/pulse/dice/engine/EngineCore.fst
+++ b/share/steel/examples/pulse/dice/engine/EngineCore.fst
@@ -65,9 +65,9 @@ fn compute_cdi (cdi:cdi_t) (uds:A.larray U8.t (US.v uds_len)) (record:engine_rec
         ** engine_record_perm record p 'repr
   ensures engine_record_perm record p 'repr
        ** A.pts_to uds #uds_perm uds_bytes
-       ** exists (c1:Seq.seq U8.t). 
+       ** (exists* (c1:Seq.seq U8.t). 
             A.pts_to cdi c1 **
-            pure (cdi_functional_correctness c1 uds_bytes 'repr)
+            pure (cdi_functional_correctness c1 uds_bytes 'repr))
 {
   A.pts_to_len uds;
   let mut uds_digest = [| 0uy; dice_digest_len |];
@@ -97,9 +97,9 @@ fn engine_main' (cdi:cdi_t) (uds:A.larray U8.t (US.v uds_len)) (record:engine_re
   returns  r:dice_return_code
   ensures  engine_record_perm record p repr **
            A.pts_to uds #uds_perm uds_bytes **
-           exists (c1:Seq.seq U8.t).
+          (exists* (c1:Seq.seq U8.t).
              A.pts_to cdi c1 **
-             pure (r = DICE_SUCCESS ==> l0_is_authentic repr /\ cdi_functional_correctness c1 uds_bytes repr)
+             pure (r = DICE_SUCCESS ==> l0_is_authentic repr /\ cdi_functional_correctness c1 uds_bytes repr))
 {
   let b = authenticate_l0_image record;
   if b 

--- a/share/steel/examples/pulse/dice/l0/L0Core.fst
+++ b/share/steel/examples/pulse/dice/l0/L0Core.fst
@@ -30,7 +30,7 @@ fn create_deviceIDCRI
                           deviceIDCSR_ingredients.s_country
     )
   ensures
-    exists (buf:Seq.seq U8.t).
+    exists* (buf:Seq.seq U8.t).
       A.pts_to deviceID_pub #pub_perm pub **
       A.pts_to deviceIDCRI_buf buf **
       pure (
@@ -83,7 +83,7 @@ fn sign_and_finalize_deviceIDCSR
       deviceIDCSR_len == length_of_deviceIDCSR deviceIDCRI_len
     ))
   ensures (
-    exists (csr_buf:Seq.seq U8.t).
+    exists* (csr_buf:Seq.seq U8.t).
     A.pts_to deviceID_priv #priv_perm priv **
     A.pts_to deviceIDCRI_buf _cri_buf **
     A.pts_to deviceIDCSR_buf csr_buf **
@@ -141,7 +141,7 @@ fn create_aliasKeyTBS
                           aliasKeyCRT_ingredients.s_country
                           aliasKeyCRT_ingredients.l0_version
     )
-  ensures exists (buf:Seq.seq U8.t).
+  ensures exists* (buf:Seq.seq U8.t).
     A.pts_to fwid #fwid_perm fwid0 **
     A.pts_to authKeyID #authKey_perm authKeyID0 **
     A.pts_to deviceID_pub #device_perm deviceID_pub0 **
@@ -197,7 +197,7 @@ fn sign_and_finalize_aliasKeyCRT
       aliasKeyCRT_len == length_of_aliasKeyCRT aliasKeyTBS_len
     ))
   ensures (
-    exists (crt_buf:Seq.seq U8.t). 
+    exists* (crt_buf:Seq.seq U8.t). 
     A.pts_to deviceID_priv #priv_perm priv **
     A.pts_to aliasKeyTBS_buf _tbs_buf **
     A.pts_to aliasKeyCRT_buf crt_buf **
@@ -325,7 +325,7 @@ fn l0_main'
   ensures (
       l0_record_perm record p repr **
       A.pts_to cdi #cdi_perm cdi0 **
-      exists (deviceID_pub1 deviceID_priv1 aliasKey_pub1 aliasKey_priv1
+      (exists* (deviceID_pub1 deviceID_priv1 aliasKey_pub1 aliasKey_priv1
               aliasKeyCRT1 deviceIDCSR1:Seq.seq U8.t). (
         A.pts_to deviceID_pub deviceID_pub1 **
         A.pts_to deviceID_priv deviceID_priv1 **
@@ -347,7 +347,7 @@ fn l0_main'
             dice_hash_alg dice_digest_len cdi0 repr.fwid
             record.deviceID_label_len repr.deviceID_label record.aliasKeyCRT_ingredients 
             aliasKeyCRT_len aliasKeyCRT1 aliasKey_pub1
-      )))
+      ))))
 {
   unfold (l0_record_perm record p repr);
   dice_digest_len_is_hkdf_ikm;

--- a/share/steel/examples/pulse/dice/l0/L0Crypto.fst
+++ b/share/steel/examples/pulse/dice/l0/L0Crypto.fst
@@ -74,7 +74,7 @@ val derive_key_pair'
 //   ensures (
 //     A.pts_to ikm #ikm_perm ikm_seq ** 
 //     A.pts_to lbl #lbl_perm lbl_seq **
-//     exists (pub_seq priv_seq:Seq.seq U8.t). (
+//     exists* (pub_seq priv_seq:Seq.seq U8.t). (
 //       A.pts_to pub pub_seq ** 
 //       A.pts_to priv priv_seq **
 //       pure ((pub_seq, priv_seq) == derive_key_pair_spec ikm_len ikm_seq lbl_len lbl_seq)
@@ -105,7 +105,7 @@ fn derive_DeviceID'
   ensures (
     A.pts_to cdi #cdi_perm cdi0 **
     A.pts_to deviceID_label #p deviceID_label0 **
-    (exists (deviceID_pub1 deviceID_priv1:Seq.seq U8.t). (
+    (exists* (deviceID_pub1 deviceID_priv1:Seq.seq U8.t). (
         A.pts_to deviceID_pub deviceID_pub1 **
         A.pts_to deviceID_priv deviceID_priv1 **
         pure (
@@ -150,7 +150,7 @@ fn derive_AliasKey'
     A.pts_to cdi #cdi_perm cdi0 **
     A.pts_to fwid #p fwid0 **
     A.pts_to aliasKey_label #p aliasKey_label0 **
-    (exists (aliasKey_pub1 aliasKey_priv1:Seq.seq U8.t). (
+    (exists* (aliasKey_pub1 aliasKey_priv1:Seq.seq U8.t). (
         A.pts_to aliasKey_pub aliasKey_pub1 **
         A.pts_to aliasKey_priv aliasKey_priv1 **
         pure (
@@ -185,17 +185,14 @@ fn derive_AuthKeyID'
   (deviceID_pub: A.larray U8.t (US.v v32us))
   (#authKeyID0 #deviceID_pub0:erased (Seq.seq U8.t))
   (#p:perm)
-  requires (
+  requires
     A.pts_to deviceID_pub #p deviceID_pub0 **
     A.pts_to authKeyID authKeyID0 
-  )
-  ensures (
+  ensures
     A.pts_to deviceID_pub #p deviceID_pub0 **
-    exists (authKeyID1:Seq.seq U8.t). (
+    (exists* (authKeyID1:Seq.seq U8.t). 
       A.pts_to authKeyID authKeyID1 **
-      pure (Seq.equal (derive_AuthKeyID_spec alg deviceID_pub0) authKeyID1)
-    )
-  )
+      pure (Seq.equal (derive_AuthKeyID_spec alg deviceID_pub0) authKeyID1))
 {
   is_hashable_len_32;
   hacl_hash alg v32us deviceID_pub authKeyID;

--- a/share/steel/examples/pulse/lib/Pulse.Lib.Array.fst
+++ b/share/steel/examples/pulse/lib/Pulse.Lib.Array.fst
@@ -28,7 +28,7 @@ fn compare' (#t:eqtype) (l:US.t) (a1 a2:larray t (US.v l))
       let v2 = a2.(vi); 
       (v1 = v2) } 
     else { false } )
-  invariant b. exists (vi:US.t). ( 
+  invariant b. exists* (vi:US.t). ( 
     R.pts_to i vi **
     A.pts_to a1 #p1 's1 **
     A.pts_to a2 #p2 's2 **
@@ -58,7 +58,7 @@ fn memcpy' (#t:eqtype) (l:US.t) (src dst:larray t (US.v l))
   pts_to_len dst #full_perm #dst0;
   let mut i = 0sz;
   while (let vi = !i; (vi < l) )
-  invariant b. exists (vi:US.t) (s:Seq.seq t). ( 
+  invariant b. exists* (vi:US.t) (s:Seq.seq t). ( 
     R.pts_to i vi **
     A.pts_to src #p src0 **
     A.pts_to dst s **
@@ -83,14 +83,14 @@ let memcpy = memcpy'
 ```pulse
 fn fill' (#t:Type0) (l:US.t) (a:larray t (US.v l)) (v:t)
   requires A.pts_to a 's
-  ensures exists (s:Seq.seq t).
+  ensures exists* (s:Seq.seq t).
     A.pts_to a s **
     pure (s `Seq.equal` Seq.create (US.v l) v)
 {
   pts_to_len a #full_perm #'s;
   let mut i = 0sz;
   while (let vi = !i; (vi < l))
-  invariant b. exists (vi:US.t) (s:Seq.seq t). ( 
+  invariant b. exists* (vi:US.t) (s:Seq.seq t). ( 
     R.pts_to i vi **
     A.pts_to a s **
     pure (vi <= l
@@ -109,7 +109,7 @@ let fill = fill'
 ```pulse
 fn zeroize' (l:US.t) (a:larray U8.t (US.v l))
   requires A.pts_to a 's
-  ensures exists (s:Seq.seq U8.t).
+  ensures exists* (s:Seq.seq U8.t).
     A.pts_to a s **
     pure (s `Seq.equal` Seq.create (US.v l) 0uy)
 {

--- a/share/steel/examples/pulse/lib/Pulse.Lib.ArraySwap.fst
+++ b/share/steel/examples/pulse/lib/Pulse.Lib.ArraySwap.fst
@@ -19,7 +19,7 @@ fn gcd (n0: SZ.t) (l0: SZ.t)
   let mut pn = n0;
   let mut pl = l0;
   while (let l = !pl ; (l `SZ.gt` 0sz))
-  invariant b . exists n l . (
+  invariant b . exists* n l . (
     pts_to pn n **
     pts_to pl l **
     pure (
@@ -99,7 +99,7 @@ fn array_swap_aux(#t: Type0) (a: A.array t) (lb: SZ.t) (rb: SZ.t) (mb: (mb: SZ.t
       SZ.v q == bz.q_n
     )
   )
-  ensures exists s . (
+  ensures exists* s . (
     A.pts_to_range a (Ghost.reveal (SZ.v lb)) (Ghost.reveal (SZ.v rb)) s **
     pure (Prf.array_swap_post s0 (SZ.v rb - SZ.v lb) (SZ.v mb - SZ.v lb) s) // hoisted out because of the SMT pattern on array_as_ring_buffer_swap
   )
@@ -107,7 +107,7 @@ fn array_swap_aux(#t: Type0) (a: A.array t) (lb: SZ.t) (rb: SZ.t) (mb: (mb: SZ.t
     A.pts_to_range_prop a;
     let mut pi = lb;
     while (let i = !pi; ((i `SZ.sub` lb) `size_lt` d))
-    invariant b . exists s i . (
+    invariant b . exists* s i . (
       A.pts_to_range a (Ghost.reveal (SZ.v lb)) (Ghost.reveal (SZ.v rb)) s **
       R.pts_to pi i **
       pure (
@@ -121,7 +121,7 @@ fn array_swap_aux(#t: Type0) (a: A.array t) (lb: SZ.t) (rb: SZ.t) (mb: (mb: SZ.t
       let mut pj = 0sz;
       let mut pidx = i;
       while (let j = !pj; (j `size_lt` (size_sub q 1sz ())))
-      invariant b . exists s j idx . (
+      invariant b . exists* s j idx . (
         A.pts_to_range a (Ghost.reveal (SZ.v lb)) (Ghost.reveal (SZ.v rb)) s **
         R.pts_to pi i **
         R.pts_to pj j **

--- a/share/steel/examples/pulse/lib/Pulse.Lib.FlippableInv.fst
+++ b/share/steel/examples/pulse/lib/Pulse.Lib.FlippableInv.fst
@@ -24,7 +24,7 @@ fn __mk_finv (p:vprop)
    let r = GR.alloc false;
    GR.share2 r;
    rewrite emp
-        as `@(if false then p else emp);
+        as (if false then p else emp);
    fold finv_p p r;
    let i = new_invariant' (finv_p p r);
    let fi = Mkfinv r i; // See #121
@@ -52,7 +52,7 @@ fn __flip_on (#p:vprop) (fi : finv p)
 
     GR.gather2 fi.r;
 
-    rewrite `@(if false then p else emp)
+    rewrite (if false then p else emp)
          as emp;
 
     fi.r := true;
@@ -85,7 +85,7 @@ fn __flip_off (#p:vprop) (fi : finv p)
     GR.share2 fi.r;
     
     rewrite emp
-         as `@(if false then p else emp);
+         as (if false then p else emp);
          
     fold finv_p p fi.r;
     fold (off fi)

--- a/share/steel/examples/pulse/lib/Pulse.Lib.HashTable.fst
+++ b/share/steel/examples/pulse/lib/Pulse.Lib.HashTable.fst
@@ -26,7 +26,7 @@ let models #kt #vt (ht:ht_t kt vt) (pht:pht_t kt vt) : vprop
 fn alloc' (#k:eqtype) (#v:Type0) (hashf:(k -> US.t)) (l:pos_us)
   requires emp
   returns ht:ht_t k v
-  ensures exists pht. models ht pht ** pure (pht == mk_init_pht hashf l)
+  ensures exists* pht. models ht pht ** pure (pht == mk_init_pht hashf l)
 {
   let contents = A.alloc #(cell k v) Clean l;
   let ht = mk_ht l hashf contents;
@@ -41,7 +41,7 @@ let alloc = alloc'
 
 ```pulse
 fn dealloc' (#k:eqtype) (#v:Type0) (ht:ht_t k v)
-  requires exists pht. models ht pht
+  requires exists* pht. models ht pht
   ensures emp
 {
   open SZ;
@@ -90,7 +90,7 @@ fn pulse_lookup_index (#kt:eqtype) (#vt:Type0)
          let vcont = !cont;
          let verr = !err; 
          (voff <=^ ht.sz && vcont = true && verr = false)) 
-  invariant b. exists (voff:SZ.t) (vcont verr:bool). (
+  invariant b. exists* (voff:SZ.t) (vcont verr:bool). (
     A.pts_to ht.contents pht.repr.seq **
     R.pts_to off voff **
     R.pts_to cont vcont **
@@ -206,7 +206,7 @@ fn insert' (#kt:eqtype) (#vt:Type0)
            (#pht:(p:erased (pht_t kt vt){PHT.not_full p.repr}))
   requires models ht pht
   returns b:bool
-  ensures exists pht'. 
+  ensures exists* pht'. 
     models ht pht' **
     pure (if b
           then pht'==PHT.insert pht k v
@@ -224,7 +224,7 @@ fn insert' (#kt:eqtype) (#vt:Type0)
     let verr = !err;
     (vcont = true && verr = false)
   ) 
-  invariant b. exists (voff:SZ.t) (vcont verr:bool). (
+  invariant b. exists* (voff:SZ.t) (vcont verr:bool). (
     R.pts_to off voff **
     R.pts_to cont vcont **
     R.pts_to err verr **
@@ -340,7 +340,7 @@ fn delete' (#kt:eqtype) (#vt:Type0)
            (#pht:erased (pht_t kt vt))
   requires models ht pht
   returns b:bool
-  ensures exists pht'. 
+  ensures exists* pht'. 
     models ht pht' **
     pure (if b then pht' == PHT.delete pht k else pht' == pht)
 {
@@ -356,7 +356,7 @@ fn delete' (#kt:eqtype) (#vt:Type0)
     let verr = !err; 
     (vcont = true && verr = false)
   )
-  invariant b. exists (voff:SZ.t) (vcont verr:bool). (
+  invariant b. exists* (voff:SZ.t) (vcont verr:bool). (
     R.pts_to off voff **
     R.pts_to cont vcont **
     R.pts_to err verr **
@@ -461,7 +461,7 @@ fn not_full' (#kt:eqtype) (#vt:Type0)
       false
     }
   )
-  invariant b. exists (vi:SZ.t). (
+  invariant b. exists* (vi:SZ.t). (
     A.pts_to ht.contents pht.repr.seq **
     R.pts_to i vi **
     pure (

--- a/share/steel/examples/pulse/lib/Pulse.Lib.LinkedList.fst
+++ b/share/steel/examples/pulse/lib/Pulse.Lib.LinkedList.fst
@@ -80,13 +80,13 @@ fn intro_is_list_nil (#t:Type0) (x:(x:llist t { x == None }))
 ghost
 fn elim_is_list_cons (#t:Type0) (x:llist t) (head:t) (tl:list t)
   requires is_list x (head::tl)
-  ensures exists (v:node_ptr t) (tail:llist t).
+  ensures exists* (v:node_ptr t) (tail:llist t).
             pure (x == Some v) **
             pts_to v (mk_node head tail) **
             is_list tail tl
 {
 //   rewrite (is_list x (hd::tl))
-//     as exists (tail:llist t). pts_to x (Some (mk_ll hd tail)) ** is_list tail tl
+//     as exists* (tail:llist t). pts_to x (Some (mk_ll hd tail)) ** is_list tail tl
 //     (by T.norm ())
     //unfold (is_list #t x (head::tl));
     admit()
@@ -99,7 +99,7 @@ fn intro_is_list_cons (#t:Type0) (x:llist t) (v:node_ptr t) (#node:node t) (#tl:
     requires pts_to v node ** is_list node.tail tl ** pure (x == Some v)
     ensures is_list x (node.head::tl)
 {
-//     assert (exists (v:node_ptr t) (tail:llist t).
+//     assert (exists* (v:node_ptr t) (tail:llist t).
 //         pure (Some v == Some v) **
 //         pts_to v (mk_node hd tail) **
 //         is_list tail tl);
@@ -191,7 +191,7 @@ fn is_list_cases_none (#t:Type) (x:llist t) (#l:list t)
 ghost
 fn is_list_cases_some (#t:Type) (x:llist t) (v:node_ptr t) (#l:list t) 
     requires is_list x l ** pure (x == Some v)
-    ensures exists (node:node t) (tl:list t).
+    ensures exists* (node:node t) (tl:list t).
                 pts_to v node **
                 pure (l == node.head::tl) **
                 is_list node.tail tl
@@ -444,7 +444,7 @@ fn length_iter (#t:Type) (x: llist t)
         Some? v
     )
     invariant b.  
-    exists n ll suffix.
+    exists* n ll suffix.
         pts_to ctr n **
         pts_to cur ll **
         is_list ll suffix **

--- a/share/steel/examples/pulse/lib/Pulse.Lib.Par.Pledge.fst
+++ b/share/steel/examples/pulse/lib/Pulse.Lib.Par.Pledge.fst
@@ -212,12 +212,12 @@ fn __elim_l (#os0:inames) (#f:vprop) (v1:vprop) (v2:vprop) (r1 r2 : GR.ref bool)
       by the other subpledge, so we just extract our resource. *)
       assert (pts_to r1 false);
       r1 := true;
-      rewrite emp ** `@(match false, true with
+      rewrite emp ** (match false, true with
                  | false, false -> pledge os0 f (v1 ** v2)
                  | false, true -> v1
                  | true, false -> v2
                  | true, true -> emp)
-           as `@(match true, true with
+           as (match true, true with
                  | false, false -> pledge os0 f (v1 ** v2)
                  | false, true -> v1
                  | true, false -> v2
@@ -225,7 +225,7 @@ fn __elim_l (#os0:inames) (#f:vprop) (v1:vprop) (v2:vprop) (r1 r2 : GR.ref bool)
 
       (* I don't understand why this remains in the ctx, but get rid
       of it as it's just emp *)
-      rewrite `@(match true, true with
+      rewrite (match true, true with
                  | false, false -> pledge os0 f (v1 ** v2)
                  | false, true -> v1
                  | true, false -> v2
@@ -243,7 +243,7 @@ fn __elim_l (#os0:inames) (#f:vprop) (v1:vprop) (v2:vprop) (r1 r2 : GR.ref bool)
       Claim it, split it, and store the leftover in the invariant. *)
       assert (pts_to r1 false);
 
-      rewrite `@(match false, false with
+      rewrite (match false, false with
                  | false, false -> pledge os0 f (v1 ** v2)
                  | false, true -> v1
                  | true, false -> v2
@@ -257,7 +257,7 @@ fn __elim_l (#os0:inames) (#f:vprop) (v1:vprop) (v2:vprop) (r1 r2 : GR.ref bool)
       r1 := true;
 
       rewrite v2
-           as `@(match true, false with
+           as (match true, false with
                  | false, false -> pledge os0 f (v1 ** v2)
                  | false, true -> v1
                  | true, false -> v2
@@ -304,7 +304,7 @@ fn __split_pledge (#os:inames) (#f:vprop) (v1:vprop) (v2:vprop)
    GR.share2 r2;
 
    rewrite (pledge os f (v1 ** v2))
-        as `@(match false, false with
+        as (match false, false with
             | false, false -> pledge os f (v1 ** v2)
             | false, true -> v1
             | true, false -> v2
@@ -313,7 +313,7 @@ fn __split_pledge (#os:inames) (#f:vprop) (v1:vprop) (v2:vprop)
   assert (
      GR.pts_to r1 #one_half false
   ** GR.pts_to r2 #one_half false
-  ** `@(match false, false with
+  ** (match false, false with
       | false, false -> pledge os f (v1 ** v2)
       | false, true -> v1
       | true, false -> v2

--- a/share/steel/examples/pulse/lib/Pulse.Lib.Par.Pledge.fst
+++ b/share/steel/examples/pulse/lib/Pulse.Lib.Par.Pledge.fst
@@ -16,8 +16,8 @@ let pledge_sub_inv (os1:inames) (os2:inames{inames_subset os1 os2}) (f:vprop) (v
 ```pulse
 ghost
 fn return_pledge_aux (os:inames) (f v : vprop) ()
-    requires v ** f
-    ensures f ** v
+    requires (v ** f)
+    ensures (f ** v)
     opens os
 { () }
 ```

--- a/share/steel/examples/pulse/parallel/Domains.fst
+++ b/share/steel/examples/pulse/parallel/Domains.fst
@@ -114,7 +114,7 @@ fn acquire_queue_lock
   //(#q: HR.ref task_queue) (#c: ref int)
   //(l: Lock.lock (inv_task_queue q c))
   requires emp
-  ensures (exists vq vc. HR.pts_to (get_queue p) vq ** pts_to (get_counter p) vc)
+  ensures (exists* vq vc. HR.pts_to (get_queue p) vq ** pts_to (get_counter p) vc)
 {
   Lock.acquire (get_lock p);
   unfold (inv_task_queue (get_queue p) (get_counter p));
@@ -127,7 +127,7 @@ fn release_queue_lock
   //(#q: HR.ref task_queue) (#c: ref int)
   //(l: Lock.lock (inv_task_queue q c))
   (p: par_env)
-  requires (exists vq vc. HR.pts_to (get_queue p) vq ** pts_to (get_counter p) vc)
+  requires (exists* vq vc. HR.pts_to (get_queue p) vq ** pts_to (get_counter p) vc)
   ensures emp
 {
   fold (inv_task_queue (get_queue p) (get_counter p));
@@ -220,7 +220,7 @@ fn join_emp'
 {
   let r = Pulse.Lib.Reference.alloc #(option a) None;
   while (let res = !r; None? res)
-    invariant b. (exists res. pts_to r res ** pure (b == None? res)
+    invariant b. (exists* res. pts_to r res ** pure (b == None? res)
     ** pure (maybe_sat post res))
   {
     Lock.acquire h._2;
@@ -300,7 +300,7 @@ fn worker' //(#q: HR.ref task_queue) (#c: ref int) (l: Lock.lock (inv_task_queue
   let r_working = alloc #bool true;
   
   while (let working = !r_working; working)
-    invariant b. (exists w. pts_to r_working w ** pure (b == w))
+    invariant b. (exists* w. pts_to r_working w ** pure (b == w))
   {
     acquire_queue_lock p;
 

--- a/src/ocaml/plugin/FStar_Parser_Parse.mly
+++ b/src/ocaml/plugin/FStar_Parser_Parse.mly
@@ -1066,10 +1066,11 @@ calcStep:
          CalcStep (rel, justif, next)
      }
 
-typ:
-  | t=simpleTerm { t }
+%public
+typX(X,Y):
+  | t=Y { t }
 
-  | q=quantifier bs=binders DOT trigger=trigger e=noSeqTerm
+  | q=quantifier bs=binders DOT trigger=trigger e=X
       {
         match bs with
         | [] ->
@@ -1078,6 +1079,9 @@ typ:
           let idents = idents_of_binders bs (rr2 $loc(q) $loc($3)) in
           mk_term (q (bs, (idents, trigger), e)) (rr2 $loc(q) $loc(e)) Formula
       }
+
+typ:
+  | t=typX(noSeqTerm,simpleTerm) { t }
 
 %inline quantifier:
   | FORALL { fun x -> QForall x }
@@ -1194,6 +1198,8 @@ tmTuple:
       }
 
 
+
+%public
 tmEqWith(X):
   | e1=tmEqWith(X) tok=EQUALS e2=tmEqWith(X)
       { mk_term (Op(mk_ident("=", rr $loc(tok)), [e1; e2])) (rr $loc) Un}

--- a/src/ocaml/plugin/PulseSyntaxWrapper.ml
+++ b/src/ocaml/plugin/PulseSyntaxWrapper.ml
@@ -61,6 +61,11 @@ let tm_unknown r : term = wr r Tm_Unknown
 let tm_emp_inames :term = wr FStar_Range.range_0 Tm_EmpInames
 let tm_add_inv i is r : term = wr r (Tm_AddInv (i, is))
 
+let is_tm_exists (t:term) : bool =
+  match t.t with
+  | Tm_ExistsSL _ -> true
+  | _ -> false
+
 let mk_tot (t:term) : comp = C_Tot t
 
 let mk_st_comp (pre:term) (ret:binder) (post:term) : st_comp =

--- a/src/ocaml/plugin/generated/PulseDesugar.ml
+++ b/src/ocaml/plugin/generated/PulseDesugar.ml
@@ -24,6 +24,11 @@ let fail : 'a . Prims.string -> FStar_Compiler_Range_Type.range -> 'a err =
       fun ctr ->
         ((FStar_Pervasives.Inr
             (FStar_Pervasives_Native.Some (message, range))), ctr)
+let (fail_if :
+  Prims.bool -> Prims.string -> FStar_Compiler_Range_Type.range -> unit err)
+  =
+  fun b ->
+    fun message -> fun range -> if b then fail message range else return ()
 let just_fail : 'a . unit -> 'a err =
   fun uu___ ->
     fun ctr -> ((FStar_Pervasives.Inr FStar_Pervasives_Native.None), ctr)
@@ -330,6 +335,11 @@ let (pulse_lib_ref_lid : Prims.string -> FStar_Ident.lident) =
   fun l ->
     FStar_Ident.lid_of_path
       (FStar_List_Tot_Base.op_At ["Pulse"; "Lib"; "Reference"] [l]) r_
+let (prims_exists_lid : FStar_Ident.lident) =
+  FStar_Ident.lid_of_path ["Prims"; "l_Exists"] r_
+let (prims_forall_lid : FStar_Ident.lident) =
+  FStar_Ident.lid_of_path ["Prims"; "l_Forall"] r_
+let (exists_lid : FStar_Ident.lident) = pulse_lib_core_lid "op_exists_Star"
 let (star_lid : FStar_Ident.lident) = pulse_lib_core_lid "op_Star_Star"
 let (emp_lid : FStar_Ident.lident) = pulse_lib_core_lid "emp"
 let (pure_lid : FStar_Ident.lident) = pulse_lib_core_lid "pure"
@@ -526,8 +536,8 @@ let (desugar_term_opt :
               FStar_Compiler_Range_Type.dummyRange in
           return uu___
       | FStar_Pervasives_Native.Some e -> desugar_term env e
-let (interpret_vprop_constructors :
-  env_t -> FStar_Syntax_Syntax.term -> PulseSyntaxWrapper.term) =
+let rec (interpret_vprop_constructors :
+  env_t -> FStar_Syntax_Syntax.term -> PulseSyntaxWrapper.term err) =
   fun env ->
     fun v ->
       let uu___ = FStar_Syntax_Util.head_and_args_full v in
@@ -539,12 +549,59 @@ let (interpret_vprop_constructors :
                let res =
                  let uu___2 = as_term l in
                  PulseSyntaxWrapper.tm_pure uu___2 v.FStar_Syntax_Syntax.pos in
-               res
+               return res
            | (FStar_Syntax_Syntax.Tm_fvar fv, []) when
                FStar_Syntax_Syntax.fv_eq_lid fv emp_lid ->
-               PulseSyntaxWrapper.tm_emp v.FStar_Syntax_Syntax.pos
-           | uu___1 -> as_term v)
-let rec (desugar_vprop :
+               let uu___1 =
+                 PulseSyntaxWrapper.tm_emp v.FStar_Syntax_Syntax.pos in
+               return uu___1
+           | (FStar_Syntax_Syntax.Tm_fvar fv, (l, uu___1)::(r, uu___2)::[])
+               when FStar_Syntax_Syntax.fv_eq_lid fv star_lid ->
+               let uu___3 = interpret_vprop_constructors env l in
+               op_let_Question uu___3
+                 (fun l1 ->
+                    let uu___4 = interpret_vprop_constructors env r in
+                    op_let_Question uu___4
+                      (fun r1 ->
+                         let uu___5 =
+                           PulseSyntaxWrapper.tm_star l1 r1
+                             v.FStar_Syntax_Syntax.pos in
+                         return uu___5))
+           | (FStar_Syntax_Syntax.Tm_fvar fv, (l, uu___1)::[]) when
+               FStar_Syntax_Syntax.fv_eq_lid fv exists_lid ->
+               let uu___2 =
+                 let uu___3 = FStar_Syntax_Subst.compress l in
+                 uu___3.FStar_Syntax_Syntax.n in
+               (match uu___2 with
+                | FStar_Syntax_Syntax.Tm_abs
+                    { FStar_Syntax_Syntax.bs = b::[];
+                      FStar_Syntax_Syntax.body = body;
+                      FStar_Syntax_Syntax.rc_opt = uu___3;_}
+                    ->
+                    let b1 =
+                      let uu___4 =
+                        as_term
+                          (b.FStar_Syntax_Syntax.binder_bv).FStar_Syntax_Syntax.sort in
+                      PulseSyntaxWrapper.mk_binder
+                        (b.FStar_Syntax_Syntax.binder_bv).FStar_Syntax_Syntax.ppname
+                        uu___4 in
+                    let uu___4 = interpret_vprop_constructors env body in
+                    op_let_Question uu___4
+                      (fun body1 ->
+                         let uu___5 =
+                           PulseSyntaxWrapper.tm_exists b1 body1
+                             v.FStar_Syntax_Syntax.pos in
+                         return uu___5)
+                | uu___3 -> let uu___4 = as_term v in return uu___4)
+           | (FStar_Syntax_Syntax.Tm_fvar fv, (l, uu___1)::[]) when
+               (FStar_Syntax_Syntax.fv_eq_lid fv prims_exists_lid) ||
+                 (FStar_Syntax_Syntax.fv_eq_lid fv prims_forall_lid)
+               ->
+               fail
+                 "exists/forall are prop connectives; you probably meant to use exists*/forall*"
+                 v.FStar_Syntax_Syntax.pos
+           | uu___1 -> let uu___2 = as_term v in return uu___2)
+let (desugar_vprop :
   env_t -> PulseSugar.vprop -> PulseSyntaxWrapper.vprop err) =
   fun env ->
     fun v ->
@@ -552,43 +609,7 @@ let rec (desugar_vprop :
       | PulseSugar.VPropTerm t ->
           let uu___ = tosyntax env t in
           op_let_Question uu___
-            (fun t1 ->
-               let uu___1 = interpret_vprop_constructors env t1 in
-               return uu___1)
-      | PulseSugar.VPropStar (v1, v2) ->
-          let uu___ = desugar_vprop env v1 in
-          op_let_Question uu___
-            (fun v11 ->
-               let uu___1 = desugar_vprop env v2 in
-               op_let_Question uu___1
-                 (fun v21 ->
-                    let uu___2 =
-                      PulseSyntaxWrapper.tm_star v11 v21 v.PulseSugar.vrange in
-                    return uu___2))
-      | PulseSugar.VPropExists
-          { PulseSugar.binders = binders; PulseSugar.body = body;_} ->
-          let rec aux env1 binders1 =
-            match binders1 with
-            | [] -> desugar_vprop env1 body
-            | (uu___, i, t)::bs ->
-                let uu___1 = desugar_term env1 t in
-                op_let_Question uu___1
-                  (fun t1 ->
-                     let uu___2 = push_bv env1 i in
-                     match uu___2 with
-                     | (env2, bv) ->
-                         let uu___3 = aux env2 bs in
-                         op_let_Question uu___3
-                           (fun body1 ->
-                              let body2 =
-                                PulseSyntaxWrapper.close_term body1
-                                  bv.FStar_Syntax_Syntax.index in
-                              let b = PulseSyntaxWrapper.mk_binder i t1 in
-                              let uu___4 =
-                                PulseSyntaxWrapper.tm_exists b body2
-                                  v.PulseSugar.vrange in
-                              return uu___4)) in
-          aux env binders
+            (fun t1 -> interpret_vprop_constructors env t1)
 let (mk_totbind :
   PulseSyntaxWrapper.binder ->
     PulseSyntaxWrapper.term ->
@@ -863,7 +884,7 @@ let rec (desugar_stmt :
                          return uu___3)))
       | PulseSugar.While
           { PulseSugar.guard = guard; PulseSugar.id1 = id;
-            PulseSugar.invariant = invariant; PulseSugar.body1 = body;_}
+            PulseSugar.invariant = invariant; PulseSugar.body = body;_}
           ->
           let uu___ = desugar_stmt env guard in
           op_let_Question uu___
@@ -890,21 +911,24 @@ let rec (desugar_stmt :
                          return uu___3)))
       | PulseSugar.Introduce
           { PulseSugar.vprop = vprop; PulseSugar.witnesses = witnesses;_} ->
-          (match vprop.PulseSugar.v with
-           | PulseSugar.VPropTerm uu___ ->
-               fail "introduce expects an existential formula"
-                 s.PulseSugar.range1
-           | PulseSugar.VPropExists uu___ ->
-               let uu___1 = desugar_vprop env vprop in
+          let uu___ = desugar_vprop env vprop in
+          op_let_Question uu___
+            (fun vp ->
+               let uu___1 =
+                 let uu___2 =
+                   let uu___3 = PulseSyntaxWrapper.is_tm_exists vp in
+                   Prims.op_Negation uu___3 in
+                 fail_if uu___2 "introduce expects an existential formula"
+                   s.PulseSugar.range1 in
                op_let_Question uu___1
-                 (fun vp ->
-                    let uu___2 = map_err (desugar_term env) witnesses in
-                    op_let_Question uu___2
+                 (fun uu___2 ->
+                    let uu___3 = map_err (desugar_term env) witnesses in
+                    op_let_Question uu___3
                       (fun witnesses1 ->
-                         let uu___3 =
+                         let uu___4 =
                            PulseSyntaxWrapper.tm_intro_exists vp witnesses1
                              s.PulseSugar.range1 in
-                         return uu___3)))
+                         return uu___4)))
       | PulseSugar.Parallel
           { PulseSugar.p1 = p1; PulseSugar.p2 = p2; PulseSugar.q1 = q1;
             PulseSugar.q2 = q2; PulseSugar.b1 = b1; PulseSugar.b2 = b2;_}
@@ -946,7 +970,7 @@ let rec (desugar_stmt :
       | PulseSugar.LetBinding uu___ ->
           fail "Terminal let binding" s.PulseSugar.range1
       | PulseSugar.WithInvariants
-          { PulseSugar.names = n1::names; PulseSugar.body2 = body;
+          { PulseSugar.names = n1::names; PulseSugar.body1 = body;
             PulseSugar.returns_ = returns_;_}
           ->
           let uu___ = tosyntax env n1 in
@@ -1218,7 +1242,7 @@ and (desugar_proof_hint_with_binders :
         fun r ->
           match s1.PulseSugar.s with
           | PulseSugar.ProofHintWithBinders
-              { PulseSugar.hint_type = hint_type; PulseSugar.binders1 = bs;_}
+              { PulseSugar.hint_type = hint_type; PulseSugar.binders = bs;_}
               ->
               let uu___ = desugar_binders env bs in
               op_let_Question uu___
@@ -1392,17 +1416,6 @@ and (free_vars_vprop :
     fun t ->
       match t.PulseSugar.v with
       | PulseSugar.VPropTerm t1 -> free_vars_term env t1
-      | PulseSugar.VPropStar (t0, t1) ->
-          let uu___ = free_vars_vprop env t0 in
-          let uu___1 = free_vars_vprop env t1 in
-          FStar_List_Tot_Base.op_At uu___ uu___1
-      | PulseSugar.VPropExists
-          { PulseSugar.binders = binders; PulseSugar.body = body;_} ->
-          let uu___ = free_vars_binders env binders in
-          (match uu___ with
-           | (env', fvs) ->
-               let uu___1 = free_vars_vprop env' body in
-               FStar_List_Tot_Base.op_At fvs uu___1)
 and (free_vars_binders :
   env_t -> PulseSugar.binders -> (env_t * FStar_Ident.ident Prims.list)) =
   fun env ->
@@ -2011,9 +2024,9 @@ let rec (transform_stmt_with_reads :
                                          len_needs), m2)))
             | FStar_Pervasives_Native.Some (PulseSugar.Lambda_initializer
                 { PulseSugar.id2 = uu___1; PulseSugar.is_rec = uu___2;
-                  PulseSugar.binders3 = uu___3;
+                  PulseSugar.binders2 = uu___3;
                   PulseSugar.ascription1 = uu___4;
-                  PulseSugar.measure = uu___5; PulseSugar.body4 = uu___6;
+                  PulseSugar.measure = uu___5; PulseSugar.body3 = uu___6;
                   PulseSugar.range3 = range;_})
                 -> fail "Lambdas are not yet supported" range in
           op_let_Question uu___
@@ -2129,7 +2142,7 @@ let rec (transform_stmt_with_reads :
                         return (p1, needs, m1)))
       | PulseSugar.While
           { PulseSugar.guard = guard; PulseSugar.id1 = id;
-            PulseSugar.invariant = invariant; PulseSugar.body1 = body;_}
+            PulseSugar.invariant = invariant; PulseSugar.body = body;_}
           ->
           let uu___ = transform_stmt m guard in
           op_let_Question uu___
@@ -2145,7 +2158,7 @@ let rec (transform_stmt_with_reads :
                                PulseSugar.guard = guard1;
                                PulseSugar.id1 = id;
                                PulseSugar.invariant = invariant;
-                               PulseSugar.body1 = body1
+                               PulseSugar.body = body1
                              });
                         PulseSugar.range1 = (p.PulseSugar.range1)
                       } in
@@ -2188,32 +2201,7 @@ and (transform_stmt : menv -> PulseSugar.stmt -> PulseSugar.stmt err) =
            | (p1, needs, m1) ->
                let uu___2 = add_derefs_in_scope needs p1 in return uu___2)
 let rec (vprop_to_ast_term : PulseSugar.vprop -> FStar_Parser_AST.term err) =
-  fun v ->
-    match v.PulseSugar.v with
-    | PulseSugar.VPropTerm t -> return t
-    | PulseSugar.VPropStar (v1, v2) ->
-        let t =
-          FStar_Parser_AST.mk_term (FStar_Parser_AST.Var star_lid)
-            v.PulseSugar.vrange FStar_Parser_AST.Expr in
-        let uu___ = vprop_to_ast_term v1 in
-        op_let_Question uu___
-          (fun vv1 ->
-             let t1 =
-               FStar_Parser_AST.mk_term
-                 (FStar_Parser_AST.App (t, vv1, FStar_Parser_AST.Nothing))
-                 v.PulseSugar.vrange FStar_Parser_AST.Expr in
-             let uu___1 = vprop_to_ast_term v2 in
-             op_let_Question uu___1
-               (fun vv2 ->
-                  let t2 =
-                    FStar_Parser_AST.mk_term
-                      (FStar_Parser_AST.App
-                         (t1, vv2, FStar_Parser_AST.Nothing))
-                      v.PulseSugar.vrange FStar_Parser_AST.Expr in
-                  return t2))
-    | PulseSugar.VPropExists
-        { PulseSugar.binders = binders; PulseSugar.body = body;_} ->
-        fail "IOU :(" v.PulseSugar.vrange
+  fun v -> match v.PulseSugar.v with | PulseSugar.VPropTerm t -> return t
 let (comp_to_ast_term :
   PulseSugar.computation_type -> FStar_Parser_AST.term err) =
   fun c ->
@@ -2385,8 +2373,8 @@ let (desugar_lambda :
     fun l ->
       let uu___ = l in
       match uu___ with
-      | { PulseSugar.binders2 = binders; PulseSugar.ascription = ascription;
-          PulseSugar.body3 = body; PulseSugar.range2 = range;_} ->
+      | { PulseSugar.binders1 = binders; PulseSugar.ascription = ascription;
+          PulseSugar.body2 = body; PulseSugar.range2 = range;_} ->
           let uu___1 = desugar_binders env binders in
           op_let_Question uu___1
             (fun uu___2 ->
@@ -2479,10 +2467,10 @@ let (desugar_decl' : env_t -> PulseSugar.decl -> PulseSyntaxWrapper.decl err)
       match d with
       | PulseSugar.FnDecl
           { PulseSugar.id2 = id; PulseSugar.is_rec = is_rec;
-            PulseSugar.binders3 = binders;
+            PulseSugar.binders2 = binders;
             PulseSugar.ascription1 = FStar_Pervasives.Inl ascription;
             PulseSugar.measure = measure;
-            PulseSugar.body4 = FStar_Pervasives.Inl body;
+            PulseSugar.body3 = FStar_Pervasives.Inl body;
             PulseSugar.range3 = range;_}
           ->
           let uu___ = desugar_binders env binders in
@@ -2571,10 +2559,10 @@ let (desugar_decl' : env_t -> PulseSugar.decl -> PulseSyntaxWrapper.decl err)
                                                               return uu___11))))))))
       | PulseSugar.FnDecl
           { PulseSugar.id2 = id; PulseSugar.is_rec = false;
-            PulseSugar.binders3 = binders;
+            PulseSugar.binders2 = binders;
             PulseSugar.ascription1 = FStar_Pervasives.Inr ascription;
             PulseSugar.measure = FStar_Pervasives_Native.None;
-            PulseSugar.body4 = FStar_Pervasives.Inr body;
+            PulseSugar.body3 = FStar_Pervasives.Inr body;
             PulseSugar.range3 = range;_}
           ->
           let uu___ = desugar_binders env binders in

--- a/src/ocaml/plugin/generated/PulseDesugar.ml
+++ b/src/ocaml/plugin/generated/PulseDesugar.ml
@@ -2200,7 +2200,7 @@ and (transform_stmt : menv -> PulseSugar.stmt -> PulseSugar.stmt err) =
            match uu___1 with
            | (p1, needs, m1) ->
                let uu___2 = add_derefs_in_scope needs p1 in return uu___2)
-let rec (vprop_to_ast_term : PulseSugar.vprop -> FStar_Parser_AST.term err) =
+let (vprop_to_ast_term : PulseSugar.vprop -> FStar_Parser_AST.term err) =
   fun v -> match v.PulseSugar.v with | PulseSugar.VPropTerm t -> return t
 let (comp_to_ast_term :
   PulseSugar.computation_type -> FStar_Parser_AST.term err) =

--- a/src/ocaml/plugin/generated/PulseSugar.ml
+++ b/src/ocaml/plugin/generated/PulseSugar.ml
@@ -5,39 +5,14 @@ let (dummyRange : FStar_Compiler_Range_Type.range) =
 type binder =
   (FStar_Parser_AST.aqual * FStar_Ident.ident * FStar_Parser_AST.term)
 type binders = binder Prims.list
-type vprop'__VPropExists__payload = {
-  binders: binders ;
-  body: vprop }
-and vprop' =
+type vprop' =
   | VPropTerm of FStar_Parser_AST.term 
-  | VPropStar of (vprop * vprop) 
-  | VPropExists of vprop'__VPropExists__payload 
 and vprop = {
   v: vprop' ;
   vrange: rng }
-let (__proj__Mkvprop'__VPropExists__payload__item__binders :
-  vprop'__VPropExists__payload -> binders) =
-  fun projectee ->
-    match projectee with | { binders = binders1; body;_} -> binders1
-let (__proj__Mkvprop'__VPropExists__payload__item__body :
-  vprop'__VPropExists__payload -> vprop) =
-  fun projectee ->
-    match projectee with | { binders = binders1; body;_} -> body
-let (uu___is_VPropTerm : vprop' -> Prims.bool) =
-  fun projectee ->
-    match projectee with | VPropTerm _0 -> true | uu___ -> false
+let (uu___is_VPropTerm : vprop' -> Prims.bool) = fun projectee -> true
 let (__proj__VPropTerm__item___0 : vprop' -> FStar_Parser_AST.term) =
   fun projectee -> match projectee with | VPropTerm _0 -> _0
-let (uu___is_VPropStar : vprop' -> Prims.bool) =
-  fun projectee ->
-    match projectee with | VPropStar _0 -> true | uu___ -> false
-let (__proj__VPropStar__item___0 : vprop' -> (vprop * vprop)) =
-  fun projectee -> match projectee with | VPropStar _0 -> _0
-let (uu___is_VPropExists : vprop' -> Prims.bool) =
-  fun projectee ->
-    match projectee with | VPropExists _0 -> true | uu___ -> false
-let (__proj__VPropExists__item___0 : vprop' -> vprop'__VPropExists__payload)
-  = fun projectee -> match projectee with | VPropExists _0 -> _0
 let (__proj__Mkvprop__item__v : vprop -> vprop') =
   fun projectee -> match projectee with | { v; vrange;_} -> v
 let (__proj__Mkvprop__item__vrange : vprop -> rng) =
@@ -210,7 +185,7 @@ and stmt'__While__payload =
   guard: stmt ;
   id1: FStar_Ident.ident ;
   invariant: vprop ;
-  body1: stmt }
+  body: stmt }
 and stmt'__Introduce__payload =
   {
   vprop: vprop ;
@@ -232,11 +207,11 @@ and stmt'__Rewrite__payload = {
 and stmt'__ProofHintWithBinders__payload =
   {
   hint_type: hint_type ;
-  binders1: binders }
+  binders: binders }
 and stmt'__WithInvariants__payload =
   {
   names: FStar_Parser_AST.term Prims.list ;
-  body2: stmt ;
+  body1: stmt ;
   returns_: vprop FStar_Pervasives_Native.option }
 and stmt' =
   | Open of FStar_Ident.lident 
@@ -259,21 +234,21 @@ and stmt = {
   range1: rng }
 and lambda =
   {
-  binders2: binders ;
+  binders1: binders ;
   ascription: computation_type FStar_Pervasives_Native.option ;
-  body3: stmt ;
+  body2: stmt ;
   range2: rng }
 and fn_decl =
   {
   id2: FStar_Ident.ident ;
   is_rec: Prims.bool ;
-  binders3: binders ;
+  binders2: binders ;
   ascription1:
     (computation_type, FStar_Parser_AST.term FStar_Pervasives_Native.option)
       FStar_Pervasives.either
     ;
   measure: FStar_Parser_AST.term FStar_Pervasives_Native.option ;
-  body4: (stmt, lambda) FStar_Pervasives.either ;
+  body3: (stmt, lambda) FStar_Pervasives.either ;
   range3: rng }
 and let_init =
   | Array_initializer of array_init 
@@ -358,23 +333,19 @@ let (__proj__Mkstmt'__Match__payload__item__branches :
 let (__proj__Mkstmt'__While__payload__item__guard :
   stmt'__While__payload -> stmt) =
   fun projectee ->
-    match projectee with
-    | { guard; id1 = id; invariant; body1 = body;_} -> guard
+    match projectee with | { guard; id1 = id; invariant; body;_} -> guard
 let (__proj__Mkstmt'__While__payload__item__id :
   stmt'__While__payload -> FStar_Ident.ident) =
   fun projectee ->
-    match projectee with
-    | { guard; id1 = id; invariant; body1 = body;_} -> id
+    match projectee with | { guard; id1 = id; invariant; body;_} -> id
 let (__proj__Mkstmt'__While__payload__item__invariant :
   stmt'__While__payload -> vprop) =
   fun projectee ->
-    match projectee with
-    | { guard; id1 = id; invariant; body1 = body;_} -> invariant
+    match projectee with | { guard; id1 = id; invariant; body;_} -> invariant
 let (__proj__Mkstmt'__While__payload__item__body :
   stmt'__While__payload -> stmt) =
   fun projectee ->
-    match projectee with
-    | { guard; id1 = id; invariant; body1 = body;_} -> body
+    match projectee with | { guard; id1 = id; invariant; body;_} -> body
 let (__proj__Mkstmt'__Introduce__payload__item__vprop :
   stmt'__Introduce__payload -> vprop) =
   fun projectee ->
@@ -417,23 +388,24 @@ let (__proj__Mkstmt'__ProofHintWithBinders__payload__item__hint_type :
   stmt'__ProofHintWithBinders__payload -> hint_type) =
   fun projectee ->
     match projectee with
-    | { hint_type = hint_type1; binders1;_} -> hint_type1
+    | { hint_type = hint_type1; binders = binders1;_} -> hint_type1
 let (__proj__Mkstmt'__ProofHintWithBinders__payload__item__binders :
   stmt'__ProofHintWithBinders__payload -> binders) =
   fun projectee ->
-    match projectee with | { hint_type = hint_type1; binders1;_} -> binders1
+    match projectee with
+    | { hint_type = hint_type1; binders = binders1;_} -> binders1
 let (__proj__Mkstmt'__WithInvariants__payload__item__names :
   stmt'__WithInvariants__payload -> FStar_Parser_AST.term Prims.list) =
   fun projectee ->
-    match projectee with | { names; body2 = body; returns_;_} -> names
+    match projectee with | { names; body1 = body; returns_;_} -> names
 let (__proj__Mkstmt'__WithInvariants__payload__item__body :
   stmt'__WithInvariants__payload -> stmt) =
   fun projectee ->
-    match projectee with | { names; body2 = body; returns_;_} -> body
+    match projectee with | { names; body1 = body; returns_;_} -> body
 let (__proj__Mkstmt'__WithInvariants__payload__item__returns_ :
   stmt'__WithInvariants__payload -> vprop FStar_Pervasives_Native.option) =
   fun projectee ->
-    match projectee with | { names; body2 = body; returns_;_} -> returns_
+    match projectee with | { names; body1 = body; returns_;_} -> returns_
 let (uu___is_Open : stmt' -> Prims.bool) =
   fun projectee -> match projectee with | Open _0 -> true | uu___ -> false
 let (__proj__Open__item___0 : stmt' -> FStar_Ident.lident) =
@@ -512,39 +484,35 @@ let (__proj__Mkstmt__item__range : stmt -> rng) =
 let (__proj__Mklambda__item__binders : lambda -> binders) =
   fun projectee ->
     match projectee with
-    | { binders2 = binders1; ascription; body3 = body; range2 = range;_} ->
-        binders1
+    | { binders1; ascription; body2 = body; range2 = range;_} -> binders1
 let (__proj__Mklambda__item__ascription :
   lambda -> computation_type FStar_Pervasives_Native.option) =
   fun projectee ->
     match projectee with
-    | { binders2 = binders1; ascription; body3 = body; range2 = range;_} ->
-        ascription
+    | { binders1; ascription; body2 = body; range2 = range;_} -> ascription
 let (__proj__Mklambda__item__body : lambda -> stmt) =
   fun projectee ->
     match projectee with
-    | { binders2 = binders1; ascription; body3 = body; range2 = range;_} ->
-        body
+    | { binders1; ascription; body2 = body; range2 = range;_} -> body
 let (__proj__Mklambda__item__range : lambda -> rng) =
   fun projectee ->
     match projectee with
-    | { binders2 = binders1; ascription; body3 = body; range2 = range;_} ->
-        range
+    | { binders1; ascription; body2 = body; range2 = range;_} -> range
 let (__proj__Mkfn_decl__item__id : fn_decl -> FStar_Ident.ident) =
   fun projectee ->
     match projectee with
-    | { id2 = id; is_rec; binders3 = binders1; ascription1 = ascription;
-        measure; body4 = body; range3 = range;_} -> id
+    | { id2 = id; is_rec; binders2 = binders1; ascription1 = ascription;
+        measure; body3 = body; range3 = range;_} -> id
 let (__proj__Mkfn_decl__item__is_rec : fn_decl -> Prims.bool) =
   fun projectee ->
     match projectee with
-    | { id2 = id; is_rec; binders3 = binders1; ascription1 = ascription;
-        measure; body4 = body; range3 = range;_} -> is_rec
+    | { id2 = id; is_rec; binders2 = binders1; ascription1 = ascription;
+        measure; body3 = body; range3 = range;_} -> is_rec
 let (__proj__Mkfn_decl__item__binders : fn_decl -> binders) =
   fun projectee ->
     match projectee with
-    | { id2 = id; is_rec; binders3 = binders1; ascription1 = ascription;
-        measure; body4 = body; range3 = range;_} -> binders1
+    | { id2 = id; is_rec; binders2 = binders1; ascription1 = ascription;
+        measure; body3 = body; range3 = range;_} -> binders1
 let (__proj__Mkfn_decl__item__ascription :
   fn_decl ->
     (computation_type, FStar_Parser_AST.term FStar_Pervasives_Native.option)
@@ -552,25 +520,25 @@ let (__proj__Mkfn_decl__item__ascription :
   =
   fun projectee ->
     match projectee with
-    | { id2 = id; is_rec; binders3 = binders1; ascription1 = ascription;
-        measure; body4 = body; range3 = range;_} -> ascription
+    | { id2 = id; is_rec; binders2 = binders1; ascription1 = ascription;
+        measure; body3 = body; range3 = range;_} -> ascription
 let (__proj__Mkfn_decl__item__measure :
   fn_decl -> FStar_Parser_AST.term FStar_Pervasives_Native.option) =
   fun projectee ->
     match projectee with
-    | { id2 = id; is_rec; binders3 = binders1; ascription1 = ascription;
-        measure; body4 = body; range3 = range;_} -> measure
+    | { id2 = id; is_rec; binders2 = binders1; ascription1 = ascription;
+        measure; body3 = body; range3 = range;_} -> measure
 let (__proj__Mkfn_decl__item__body :
   fn_decl -> (stmt, lambda) FStar_Pervasives.either) =
   fun projectee ->
     match projectee with
-    | { id2 = id; is_rec; binders3 = binders1; ascription1 = ascription;
-        measure; body4 = body; range3 = range;_} -> body
+    | { id2 = id; is_rec; binders2 = binders1; ascription1 = ascription;
+        measure; body3 = body; range3 = range;_} -> body
 let (__proj__Mkfn_decl__item__range : fn_decl -> rng) =
   fun projectee ->
     match projectee with
-    | { id2 = id; is_rec; binders3 = binders1; ascription1 = ascription;
-        measure; body4 = body; range3 = range;_} -> range
+    | { id2 = id; is_rec; binders2 = binders1; ascription1 = ascription;
+        measure; body3 = body; range3 = range;_} -> range
 let (uu___is_Array_initializer : let_init -> Prims.bool) =
   fun projectee ->
     match projectee with | Array_initializer _0 -> true | uu___ -> false
@@ -617,8 +585,6 @@ let (mk_comp :
                   opens;
                   range
                 }
-let (mk_vprop_exists : binders -> vprop -> vprop') =
-  fun binders1 -> fun body -> VPropExists { binders = binders1; body }
 let (mk_expr : FStar_Parser_AST.term -> stmt') = fun e -> Expr { e }
 let (mk_assignment : FStar_Parser_AST.term -> FStar_Parser_AST.term -> stmt')
   = fun id -> fun value -> Assignment { lhs = id; value }
@@ -658,8 +624,7 @@ let (mk_match :
 let (mk_while : stmt -> FStar_Ident.ident -> vprop -> stmt -> stmt') =
   fun guard ->
     fun id ->
-      fun invariant ->
-        fun body -> While { guard; id1 = id; invariant; body1 = body }
+      fun invariant -> fun body -> While { guard; id1 = id; invariant; body }
 let (mk_intro : vprop -> FStar_Parser_AST.term Prims.list -> stmt') =
   fun vprop1 -> fun witnesses -> Introduce { vprop = vprop1; witnesses }
 let (mk_sequence : stmt -> stmt -> stmt') =
@@ -686,10 +651,10 @@ let (mk_fn_decl :
                 {
                   id2 = id;
                   is_rec;
-                  binders3 = binders1;
+                  binders2 = binders1;
                   ascription1 = ascription;
                   measure;
-                  body4 = body;
+                  body3 = body;
                   range3 = range
                 }
 let (mk_open : FStar_Ident.lident -> stmt') = fun lid -> Open lid
@@ -701,7 +666,7 @@ let (mk_par : vprop -> vprop -> vprop -> vprop -> stmt -> stmt -> stmt') =
 let (mk_rewrite : vprop -> vprop -> stmt') =
   fun p1 -> fun p2 -> Rewrite { p11 = p1; p21 = p2 }
 let (mk_proof_hint_with_binders : hint_type -> binders -> stmt') =
-  fun ht -> fun bs -> ProofHintWithBinders { hint_type = ht; binders1 = bs }
+  fun ht -> fun bs -> ProofHintWithBinders { hint_type = ht; binders = bs }
 let (mk_lambda :
   binders ->
     computation_type FStar_Pervasives_Native.option -> stmt -> rng -> lambda)
@@ -710,11 +675,11 @@ let (mk_lambda :
     fun ascription ->
       fun body ->
         fun range ->
-          { binders2 = bs; ascription; body3 = body; range2 = range }
+          { binders1 = bs; ascription; body2 = body; range2 = range }
 let (mk_with_invs :
   FStar_Parser_AST.term Prims.list ->
     stmt -> vprop FStar_Pervasives_Native.option -> stmt')
   =
   fun names ->
     fun body ->
-      fun returns_ -> WithInvariants { names; body2 = body; returns_ }
+      fun returns_ -> WithInvariants { names; body1 = body; returns_ }

--- a/src/ocaml/plugin/pulseparser.mly
+++ b/src/ocaml/plugin/pulseparser.mly
@@ -258,10 +258,13 @@ mutOrRefQualifier:
   | MUT { MUT }
   | REF { REF }
 
+(*
 maybeHash:
   |      { Nothing }
   | HASH { Hash }
+*)
 
+(*
 atomicVprop:
   | LPAREN p=pulseVprop RPAREN
     { p }
@@ -273,19 +276,22 @@ atomicVprop:
       let app = mkApp head (map (fun (x,y) -> (y,x)) args) (rr2 $loc(head) $loc(args)) in
       PulseSugar.(as_vprop (VPropTerm app) (rr $loc))
     }
+*)
 
+(*
 %inline
 starOp:
   | o=OPINFIX3
     { if o = "**" then () else raise_error (Fatal_SyntaxError, "Unexpected infix operator; expected '**'") (rr $loc) }
   | BACKTICK id=IDENT BACKTICK
     { if id = "star" then () else raise_error (Fatal_SyntaxError, "Unexpected infix operator; expected '**'") (rr $loc) }
-
+*)
 
 pulseVprop:
-  | t=atomicVprop
-    { t }
-  | EXISTS bs=nonempty_list(pulseMultiBinder) DOT body=pulseVprop
+  | p=typX(tmEqWith(appTermNoRecordExp), tmEqWith(appTermNoRecordExp))
+    { PulseSugar.(as_vprop (VPropTerm p) (rr $loc)) }
+(*  | EXISTS bs=nonempty_list(pulseMultiBinder) DOT body=pulseVprop
     { PulseSugar.(as_vprop (mk_vprop_exists (List.flatten bs) body) (rr $loc)) }
   | l=pulseVprop starOp r=pulseVprop
     {  PulseSugar.(as_vprop (VPropStar (l, r)) (rr $loc)) }
+*)

--- a/src/ocaml/plugin/pulseparser.mly
+++ b/src/ocaml/plugin/pulseparser.mly
@@ -93,7 +93,7 @@ qual:
 pulseDecl:
   | q=option(qual)
     FN isRec=maybeRec lid=lident bs=pulseBinderList
-    body=fnBody
+    body=fnBody EOF
     {
       PulseSugar.FnDecl (mk_fn_decl q lid isRec bs body (rr $loc))
     }
@@ -258,40 +258,6 @@ mutOrRefQualifier:
   | MUT { MUT }
   | REF { REF }
 
-(*
-maybeHash:
-  |      { Nothing }
-  | HASH { Hash }
-*)
-
-(*
-atomicVprop:
-  | LPAREN p=pulseVprop RPAREN
-    { p }
-  | BACKTICK_AT p=atomicTerm
-    { PulseSugar.(as_vprop (VPropTerm p) (rr $loc)) }
-  | head=qlident args=list(argTerm)
-    {
-      let head = mk_term (Var head) (rr $loc(head)) Un in
-      let app = mkApp head (map (fun (x,y) -> (y,x)) args) (rr2 $loc(head) $loc(args)) in
-      PulseSugar.(as_vprop (VPropTerm app) (rr $loc))
-    }
-*)
-
-(*
-%inline
-starOp:
-  | o=OPINFIX3
-    { if o = "**" then () else raise_error (Fatal_SyntaxError, "Unexpected infix operator; expected '**'") (rr $loc) }
-  | BACKTICK id=IDENT BACKTICK
-    { if id = "star" then () else raise_error (Fatal_SyntaxError, "Unexpected infix operator; expected '**'") (rr $loc) }
-*)
-
 pulseVprop:
   | p=typX(tmEqWith(appTermNoRecordExp), tmEqWith(appTermNoRecordExp))
     { PulseSugar.(as_vprop (VPropTerm p) (rr $loc)) }
-(*  | EXISTS bs=nonempty_list(pulseMultiBinder) DOT body=pulseVprop
-    { PulseSugar.(as_vprop (mk_vprop_exists (List.flatten bs) body) (rr $loc)) }
-  | l=pulseVprop starOp r=pulseVprop
-    {  PulseSugar.(as_vprop (VPropStar (l, r)) (rr $loc)) }
-*)

--- a/src/syntax_extension/PulseDesugar.fst
+++ b/src/syntax_extension/PulseDesugar.fst
@@ -441,7 +441,7 @@ and desugar_branch (env:env_t) (br:A.pattern & Sugar.stmt)
     let? (p, vs) = desugar_pat env p in
     let env, bvs = push_bvs env vs in
     let? e = desugar_stmt env e in
-    let e = SW.close_st_term_n e (L.map (fun (v:S.bv) -> v.index) bvs) in
+    let e = SW.close_st_term_n e (L.map (fun (v:S.bv) -> v.index <: nat) bvs) in
     return (p,e)
 
 and desugar_pat (env:env_t) (p:A.pattern)
@@ -533,7 +533,7 @@ and desugar_proof_hint_with_binders (env:env_t) (s1:Sugar.stmt) (k:option Sugar.
   = match s1.s with
     | Sugar.ProofHintWithBinders { hint_type; binders=bs } -> //; vprop=v } ->
       let? env, binders, bvs = desugar_binders env bs in
-      let vars = L.map (fun bv -> bv.S.index) bvs in
+      let vars = L.map #_ #nat (fun bv -> bv.S.index) bvs in
       let? ht = desugar_hint_type env hint_type in
       let? s2 = 
         match k with

--- a/src/syntax_extension/PulseDesugar.fst
+++ b/src/syntax_extension/PulseDesugar.fst
@@ -254,25 +254,6 @@ let desugar_vprop (env:env_t) (v:Sugar.vprop)
     | Sugar.VPropTerm t -> 
       let? t = tosyntax env t in
       interpret_vprop_constructors env t
-    // | Sugar.VPropStar (v1, v2) ->
-    //   let? v1 = desugar_vprop env v1 in
-    //   let? v2 = desugar_vprop env v2 in
-    //   return (SW.tm_star v1 v2 v.vrange)
-    // | Sugar.VPropExists { binders; body } ->
-    //   let rec aux env binders
-    //     : err SW.vprop =
-    //     match binders with
-    //     | [] -> 
-    //       desugar_vprop env body
-    //     | (_, i, t)::bs ->
-    //       let? t = desugar_term env t in
-    //       let env, bv = push_bv env i in
-    //       let? body = aux env bs in
-    //       let body = SW.close_term body bv.index in
-    //       let b = SW.mk_binder i t in
-    //       return (SW.tm_exists b body v.vrange)
-    //   in
-    //   aux env binders
 
 let mk_totbind b s1 s2 r : SW.st_term =
   SW.tm_totbind b s1 s2 r
@@ -631,12 +612,7 @@ and free_vars_vprop (env:env_t) (t:Sugar.vprop) =
   let open Sugar in
   match t.v with
   | VPropTerm t -> free_vars_term env t
-  // | VPropStar (t0, t1) -> 
-  //   free_vars_vprop env t0 @
-  //   free_vars_vprop env t1
-  // | VPropExists { binders; body } ->
-  //   let env', fvs = free_vars_binders env binders in
-  //   fvs @ free_vars_vprop env' body
+
 and free_vars_binders (env:env_t) (bs:Sugar.binders)
   : env_t & list ident
   = match bs with
@@ -964,21 +940,11 @@ and transform_stmt (m:menv) (p:Sugar.stmt)
     let? p, needs, m = transform_stmt_with_reads m p in
     return (add_derefs_in_scope needs p)      
 
-let rec vprop_to_ast_term (v:Sugar.vprop)
+let vprop_to_ast_term (v:Sugar.vprop)
   : err A.term
   = let open FStar.Parser.AST in
     match v.v with
     | Sugar.VPropTerm t -> return t
-    // | Sugar.VPropStar (v1, v2) ->
-    //   let t = mk_term (Var star_lid) v.vrange Expr in
-    //   let? vv1 = vprop_to_ast_term v1 in
-    //   let t = mk_term (App (t, vv1, Nothing)) v.vrange Expr in
-    //   let? vv2 = vprop_to_ast_term v2 in
-    //   let t = mk_term (App (t, vv2, Nothing)) v.vrange Expr in
-    //   return t
-
-    // | Sugar.VPropExists { binders; body } ->
-    //   fail "IOU :(" v.vrange
 
 let comp_to_ast_term (c:Sugar.computation_type) : err A.term =
   let open FStar.Parser.AST in

--- a/src/syntax_extension/PulseDesugar.fst
+++ b/src/syntax_extension/PulseDesugar.fst
@@ -29,6 +29,9 @@ let return (x:'a) : err 'a = fun ctr -> Inl x, ctr
 let fail #a (message:string) (range:R.range) : err a =
   fun ctr -> Inr (Some (message, range)), ctr
 
+let fail_if (b:bool) (message:string) (range:R.range) : err unit =
+  if b then fail message range else return ()
+
 // Fail without logging another error
 let just_fail (#a:Type) () : err a =
   fun ctr -> Inr None, ctr
@@ -96,10 +99,14 @@ let desugar_const (c:FStar.Const.sconst) : SW.constant =
   SW.inspect_const c
 
 let r_ = FStar.Compiler.Range.dummyRange
-let admit_lid = Ident.lid_of_path ["Prims"; "admit"] r_
 open FStar.List.Tot
+#push-options "--warn_error -272" //intentional top-level effects
+let admit_lid = Ident.lid_of_path ["Prims"; "admit"] r_
 let pulse_lib_core_lid l = Ident.lid_of_path (["Pulse"; "Lib"; "Core"]@[l]) r_
 let pulse_lib_ref_lid l = Ident.lid_of_path (["Pulse"; "Lib"; "Reference"]@[l]) r_
+let prims_exists_lid = Ident.lid_of_path ["Prims"; "l_Exists"] r_
+let prims_forall_lid = Ident.lid_of_path ["Prims"; "l_Forall"] r_
+let exists_lid = pulse_lib_core_lid "op_exists_Star"
 let star_lid = pulse_lib_core_lid "op_Star_Star"
 let emp_lid = pulse_lib_core_lid "emp"
 let pure_lid = pulse_lib_core_lid "pure"
@@ -110,6 +117,7 @@ let stt_atomic_lid = pulse_lib_core_lid "stt_atomic"
 let op_colon_equals_lid r = Ident.lid_of_path ["op_Colon_Equals"] r
 let op_array_assignment_lid r = Ident.lid_of_path ["op_Array_Assignment"] r
 let op_bang_lid = pulse_lib_ref_lid "op_Bang"
+#pop-options
 let read (x:ident) = 
   let open A in
   let range = Ident.range_of_id x in
@@ -201,47 +209,70 @@ let desugar_term_opt (env:env_t) (t:option A.term)
     | None -> return (SW.tm_unknown FStar.Compiler.Range.dummyRange)
     | Some e -> desugar_term env e
 
-let interpret_vprop_constructors (env:env_t) (v:S.term)
-  : SW.term
+let rec interpret_vprop_constructors (env:env_t) (v:S.term)
+  : err SW.term
   = let head, args = U.head_and_args_full v in
     match head.n, args with
     | S.Tm_fvar fv, [(l, _)]
       when S.fv_eq_lid fv pure_lid ->
       let res = SW.tm_pure (as_term l) v.pos in
-      res
-      
-
+      return res
+    
     | S.Tm_fvar fv, []
       when S.fv_eq_lid fv emp_lid ->
-      SW.tm_emp v.pos
+      return <| SW.tm_emp v.pos
       
-    | _ -> as_term v
+    | S.Tm_fvar fv, [(l, _); (r, _)]
+      when S.fv_eq_lid fv star_lid ->
+      let? l = interpret_vprop_constructors env l in
+      let? r = interpret_vprop_constructors env r in
+      return <| SW.tm_star l r v.pos
+
+    | S.Tm_fvar fv, [(l, _)]
+      when S.fv_eq_lid fv exists_lid -> (
+        match (SS.compress l).n with
+        | S.Tm_abs {bs=[b]; body } ->
+          let b = SW.mk_binder b.S.binder_bv.ppname (as_term b.S.binder_bv.sort) in
+          let? body = interpret_vprop_constructors env body in
+          return <| SW.tm_exists b body v.pos
+        | _ ->
+          return <| as_term v
+      )
+      
+    | S.Tm_fvar fv, [(l, _)]
+      when S.fv_eq_lid fv prims_exists_lid
+      ||   S.fv_eq_lid fv prims_forall_lid -> (
+      fail "exists/forall are prop connectives; you probably meant to use exists*/forall*" v.pos  
+      )
+
+    | _ ->
+      return <| as_term v
   
-let rec desugar_vprop (env:env_t) (v:Sugar.vprop)
+let desugar_vprop (env:env_t) (v:Sugar.vprop)
   : err SW.vprop
   = match v.v with
     | Sugar.VPropTerm t -> 
       let? t = tosyntax env t in
-      return (interpret_vprop_constructors env t)
-    | Sugar.VPropStar (v1, v2) ->
-      let? v1 = desugar_vprop env v1 in
-      let? v2 = desugar_vprop env v2 in
-      return (SW.tm_star v1 v2 v.vrange)
-    | Sugar.VPropExists { binders; body } ->
-      let rec aux env binders
-        : err SW.vprop =
-        match binders with
-        | [] -> 
-          desugar_vprop env body
-        | (_, i, t)::bs ->
-          let? t = desugar_term env t in
-          let env, bv = push_bv env i in
-          let? body = aux env bs in
-          let body = SW.close_term body bv.index in
-          let b = SW.mk_binder i t in
-          return (SW.tm_exists b body v.vrange)
-      in
-      aux env binders
+      interpret_vprop_constructors env t
+    // | Sugar.VPropStar (v1, v2) ->
+    //   let? v1 = desugar_vprop env v1 in
+    //   let? v2 = desugar_vprop env v2 in
+    //   return (SW.tm_star v1 v2 v.vrange)
+    // | Sugar.VPropExists { binders; body } ->
+    //   let rec aux env binders
+    //     : err SW.vprop =
+    //     match binders with
+    //     | [] -> 
+    //       desugar_vprop env body
+    //     | (_, i, t)::bs ->
+    //       let? t = desugar_term env t in
+    //       let env, bv = push_bv env i in
+    //       let? body = aux env bs in
+    //       let body = SW.close_term body bv.index in
+    //       let b = SW.mk_binder i t in
+    //       return (SW.tm_exists b body v.vrange)
+    //   in
+    //   aux env binders
 
 let mk_totbind b s1 s2 r : SW.st_term =
   SW.tm_totbind b s1 s2 r
@@ -390,15 +421,11 @@ let rec desugar_stmt (env:env_t) (s:Sugar.stmt)
       return (SW.tm_while guard (id, invariant) body s.range)
 
     | Introduce { vprop; witnesses } -> (
-      match vprop.v with
-      | VPropTerm _ ->
-        fail "introduce expects an existential formula" s.range
-      | VPropExists _ ->
-        let? vp = desugar_vprop env vprop in
-        let? witnesses = map_err (desugar_term env) witnesses in
-        return (SW.tm_intro_exists vp witnesses s.range)
+      let? vp = desugar_vprop env vprop in
+      fail_if (not (SW.is_tm_exists vp)) "introduce expects an existential formula" s.range ;?
+      let? witnesses = map_err (desugar_term env) witnesses in
+      return (SW.tm_intro_exists vp witnesses s.range)
     )
-
 
     | Parallel { p1; p2; q1; q2; b1; b2 } ->
       let? p1 = desugar_vprop env p1 in
@@ -604,12 +631,12 @@ and free_vars_vprop (env:env_t) (t:Sugar.vprop) =
   let open Sugar in
   match t.v with
   | VPropTerm t -> free_vars_term env t
-  | VPropStar (t0, t1) -> 
-    free_vars_vprop env t0 @
-    free_vars_vprop env t1
-  | VPropExists { binders; body } ->
-    let env', fvs = free_vars_binders env binders in
-    fvs @ free_vars_vprop env' body
+  // | VPropStar (t0, t1) -> 
+  //   free_vars_vprop env t0 @
+  //   free_vars_vprop env t1
+  // | VPropExists { binders; body } ->
+  //   let env', fvs = free_vars_binders env binders in
+  //   fvs @ free_vars_vprop env' body
 and free_vars_binders (env:env_t) (bs:Sugar.binders)
   : env_t & list ident
   = match bs with
@@ -942,16 +969,16 @@ let rec vprop_to_ast_term (v:Sugar.vprop)
   = let open FStar.Parser.AST in
     match v.v with
     | Sugar.VPropTerm t -> return t
-    | Sugar.VPropStar (v1, v2) ->
-      let t = mk_term (Var star_lid) v.vrange Expr in
-      let? vv1 = vprop_to_ast_term v1 in
-      let t = mk_term (App (t, vv1, Nothing)) v.vrange Expr in
-      let? vv2 = vprop_to_ast_term v2 in
-      let t = mk_term (App (t, vv2, Nothing)) v.vrange Expr in
-      return t
+    // | Sugar.VPropStar (v1, v2) ->
+    //   let t = mk_term (Var star_lid) v.vrange Expr in
+    //   let? vv1 = vprop_to_ast_term v1 in
+    //   let t = mk_term (App (t, vv1, Nothing)) v.vrange Expr in
+    //   let? vv2 = vprop_to_ast_term v2 in
+    //   let t = mk_term (App (t, vv2, Nothing)) v.vrange Expr in
+    //   return t
 
-    | Sugar.VPropExists { binders; body } ->
-      fail "IOU :(" v.vrange
+    // | Sugar.VPropExists { binders; body } ->
+    //   fail "IOU :(" v.vrange
 
 let comp_to_ast_term (c:Sugar.computation_type) : err A.term =
   let open FStar.Parser.AST in

--- a/src/syntax_extension/PulseSugar.fst
+++ b/src/syntax_extension/PulseSugar.fst
@@ -10,11 +10,11 @@ type binders = list binder
 
 type vprop' =
   | VPropTerm of A.term
-  | VPropStar of vprop & vprop
-  | VPropExists {
-      binders:binders;
-      body:vprop
-    }
+  // | VPropStar of vprop & vprop
+  // | VPropExists {
+  //     binders:binders;
+  //     body:vprop
+  //   }
 and vprop = {
   v:vprop';
   vrange:rng
@@ -186,7 +186,7 @@ let mk_comp tag precondition return_name return_type postcondition opens range =
      range
   }
 
-let mk_vprop_exists binders body = VPropExists { binders; body }
+// let mk_vprop_exists binders body = VPropExists { binders; body }
 let mk_expr e = Expr { e }
 let mk_assignment id value = Assignment { lhs=id; value }
 let mk_array_assignment arr index value = ArrayAssignment { arr; index; value }

--- a/src/syntax_extension/PulseSyntaxWrapper.fsti
+++ b/src/syntax_extension/PulseSyntaxWrapper.fsti
@@ -46,6 +46,8 @@ val mk_comp (pre:term) (ret:binder) (post:term) : comp
 val ghost_comp (opens:term) (pre:term) (ret:binder) (post:term) : comp
 val atomic_comp (opens:term) (pre:term) (ret:binder) (post:term) : comp
 
+val is_tm_exists (x:term) : bool
+
 val hint_type : Type0
 val mk_assert_hint_type (vp:vprop) : hint_type
 val mk_unfold_hint_type (l:option (list string)) (vp:vprop) : hint_type

--- a/src/syntax_extension/Pulse_ASTBuilder.fst
+++ b/src/syntax_extension/Pulse_ASTBuilder.fst
@@ -60,8 +60,10 @@ let extension_parser
         let d = { d; drange = r; quals = [ Irreducible ]; attrs = [str "uninterpreted_by_smt"]  } in
         Inr d
 
+#push-options "--warn_error -272" //intentional top-level effect
 let _ = 
     register_extension_parser "pulse" extension_parser
+#pop-options
    
 module TcEnv = FStar.TypeChecker.Env
 module D = PulseDesugar

--- a/src/syntax_extension/SyntaxExtension.fst.config.json
+++ b/src/syntax_extension/SyntaxExtension.fst.config.json
@@ -9,6 +9,7 @@
   "include_dirs": [
     ".",
     "${FSTAR_HOME}/src/basic",
+    "${FSTAR_HOME}/src/data",
     "${FSTAR_HOME}/src/class",
     "${FSTAR_HOME}/src/extraction",
     "${FSTAR_HOME}/src/fstar",


### PR DESCRIPTION
The syntax of vprops in Pulse now coincides with their syntax in F*.

The main enabler was the addition of overloaded quantifier tokens in F*, i.e., https://github.com/FStarLang/FStar/pull/3149

Now, you can write

```fstar
exists* x y z. p ** q ** r
```
for vprops in both F* and Pulse contexts.

The Pulse parser no longer has special treatment for vprops. So, this also gets rid of the `@ syntax of embedding F* terms inside Pulse vprop, since the syntax of a Pulse vprop is now just the syntax of F* terms.

This fixes a couple of open issues: #50 #14 (and gets rid of some WHY WHY WHY remarks in Tahina's Pulse code).


