### PR TITLE
unreachable: A primitive to discard infeasible paths

### DIFF
--- a/lib/steel/pulse/Pulse.Checker.Unreachable.fst
+++ b/lib/steel/pulse/Pulse.Checker.Unreachable.fst
@@ -1,0 +1,57 @@
+module Pulse.Checker.Unreachable
+
+module T = FStar.Tactics.V2
+
+open Pulse.Syntax
+open Pulse.Typing
+open Pulse.Checker.Pure
+open Pulse.Checker.Base
+open Pulse.Checker.Prover
+
+module P = Pulse.Syntax.Printer
+
+let check
+  (g:env)
+  (pre:term)
+  (pre_typing:tot_typing g pre tm_vprop)
+  (post_hint:post_hint_opt g)
+  (res_ppname:ppname)
+  (t:st_term { Tm_Unreachable? t.term })
+: T.Tac (checker_result_t g pre post_hint)
+= let rng = t.range in
+  match post_hint with
+  | None ->
+    fail g (Some t.range)
+        "Expected a postcondition to be annotated when unreachable is used"
+  | Some post ->
+    let x = fresh g in
+    let px = v_as_nv x in
+    let post : post_hint_t = post in
+    if x `Set.mem` freevars post.post
+    then fail g None "Impossible: unexpected freevar clash in Tm_Unreachable, please file a bug-report"
+    else
+        let ctag =
+            match post.ctag_hint with
+            | None -> STT
+            | Some ctag -> ctag
+        in
+        let post_typing_rec = post_hint_typing g post x in
+        let post_opened = open_term_nv post.post px in              
+        assume (close_term post_opened x == post.post);
+        let t : term = post.ret_ty in
+        let u = post.u in
+        let t_typing : universe_of g t u = post_typing_rec.ty_typing in
+        let post_typing = post_typing_rec.post_typing in
+        assume (close_term post_opened x == post.post);
+        let s : st_comp = {u; res=t; pre; post=post.post} in
+        let stc : st_comp_typing g s = (STC _ s x t_typing pre_typing post_typing) in
+        let ff = (tm_fstar (`False) rng) in
+        let (|eff, ff_typing |) = Pulse.Checker.Pure.core_check_term_at_type g ff tm_prop in
+        if eff <> T.E_Total then T.fail "Impossible: False has effect Ghost"
+        else
+            let ff_validity = Pulse.Checker.Pure.check_prop_validity g ff ff_typing in
+            let dt = T_Unreachable g s ctag stc ff_validity in
+            prove_post_hint (try_frame_pre pre_typing (match_comp_res_with_post_hint dt post_hint) res_ppname) post_hint t.range
+    
+
+  

--- a/lib/steel/pulse/Pulse.Checker.Unreachable.fsti
+++ b/lib/steel/pulse/Pulse.Checker.Unreachable.fsti
@@ -1,0 +1,20 @@
+module Pulse.Checker.Unreachable
+
+module T = FStar.Tactics.V2
+
+open Pulse.Syntax
+open Pulse.Typing
+open Pulse.Checker.Pure
+open Pulse.Checker.Base
+open Pulse.Checker.Prover
+
+module P = Pulse.Syntax.Printer
+
+val check
+  (g:env)
+  (pre:term)
+  (pre_typing:tot_typing g pre tm_vprop)
+  (post_hint:post_hint_opt g)
+  (res_ppname:ppname)
+  (t:st_term { Tm_Unreachable? t.term })
+: T.Tac (checker_result_t g pre post_hint)

--- a/lib/steel/pulse/Pulse.Checker.fst
+++ b/lib/steel/pulse/Pulse.Checker.fst
@@ -252,6 +252,9 @@ let rec check
     | Tm_Admit _ ->
       Admit.check g pre pre_typing post_hint res_ppname t
 
+    | Tm_Unreachable ->
+      Pulse.Checker.Unreachable.check g pre pre_typing post_hint res_ppname t
+
     | Tm_Rewrite _ ->
       Rewrite.check g pre pre_typing post_hint res_ppname t
 

--- a/lib/steel/pulse/Pulse.Elaborate.Core.fst
+++ b/lib/steel/pulse/Pulse.Elaborate.Core.fst
@@ -314,6 +314,9 @@ let rec elab_st_typing (#g:env)
        | STT_Atomic -> mk_stt_atomic_admit ru rres rpre rpost
        | STT_Ghost -> mk_stt_ghost_admit ru rres rpre rpost)
 
+    | T_Unreachable _ _ _ _ _ ->
+      `("IOU: elab_st_typing of T_Unreachable")
+
     | T_WithInv _ _ _ _ _ _ _ _ ->
       `("IOU: elab_st_typing of T_WithInv")
 

--- a/lib/steel/pulse/Pulse.Soundness.fst
+++ b/lib/steel/pulse/Pulse.Soundness.fst
@@ -404,6 +404,8 @@ let rec soundness (g:stt_env)
 
     | T_Admit _ _ _ _ -> Admit.admit_soundess d
 
+    | T_Unreachable _ _ _ _ _ -> RU.magic()
+
     | T_Sub _ _ _ _ _ _ -> Sub.sub_soundness d soundness
 
     | T_WithInv _ _ _ _ _ _ _ _ -> RU.magic() // IOU

--- a/lib/steel/pulse/Pulse.Syntax.Base.fst
+++ b/lib/steel/pulse/Pulse.Syntax.Base.fst
@@ -255,6 +255,8 @@ let rec eq_st_term (t1 t2:st_term)
       eq_tm t1 t2 &&
       eq_tm_opt post1 post2
       
+    | Tm_Unreachable, Tm_Unreachable -> true
+    
     | Tm_ProofHintWithBinders { hint_type=ht1; binders=bs1; t=t1 },
       Tm_ProofHintWithBinders { hint_type=ht2; binders=bs2; t=t2 } ->
       eq_hint_type ht1 ht2 &&

--- a/lib/steel/pulse/Pulse.Syntax.Base.fsti
+++ b/lib/steel/pulse/Pulse.Syntax.Base.fsti
@@ -272,6 +272,7 @@ type st_term' =
       typ:term;
       post:option term;
     }
+  | Tm_Unreachable
   | Tm_ProofHintWithBinders {
       hint_type:proof_hint_type;
       binders:list binder;

--- a/lib/steel/pulse/Pulse.Syntax.Builder.fst
+++ b/lib/steel/pulse/Pulse.Syntax.Builder.fst
@@ -22,6 +22,7 @@ let tm_with_local_array binder initializer length body = Tm_WithLocalArray { bin
 let tm_rewrite t1 t2 = Tm_Rewrite { t1; t2 }
 let tm_rename pairs t = Tm_ProofHintWithBinders { hint_type = RENAME { pairs; goal=None}; binders=[]; t}
 let tm_admit ctag u typ post = Tm_Admit { ctag; u; typ; post }
+let tm_unreachable = Tm_Unreachable
 let with_range t r = { term = t; range = r; effect_tag = default_effect_hint }
 let tm_assert_with_binders bs p t = Tm_ProofHintWithBinders { hint_type=ASSERT { p }; binders=bs; t }
 let mk_assert_hint_type p = ASSERT { p }

--- a/lib/steel/pulse/Pulse.Syntax.Naming.fst
+++ b/lib/steel/pulse/Pulse.Syntax.Naming.fst
@@ -227,6 +227,8 @@ let rec close_open_inverse_st'  (t:st_term)
       close_open_inverse' typ x i;
       close_open_inverse_opt' post x (i + 1)
 
+    | Tm_Unreachable -> ()
+    
     | Tm_ProofHintWithBinders { binders; hint_type; t} ->
       let n = L.length binders in
       close_open_inverse_proof_hint_type' hint_type x (i + n);

--- a/lib/steel/pulse/Pulse.Syntax.Naming.fsti
+++ b/lib/steel/pulse/Pulse.Syntax.Naming.fsti
@@ -145,6 +145,9 @@ let rec freevars_st (t:st_term)
       Set.union (freevars typ)
                 (freevars_term_opt post)
 
+    | Tm_Unreachable ->
+      Set.empty
+
     | Tm_ProofHintWithBinders { binders; hint_type; t } ->
       Set.union (freevars_proof_hint hint_type) (freevars_st t)
 
@@ -348,6 +351,9 @@ let rec ln_st' (t:st_term) (i:int)
     | Tm_Admit { typ; post } ->
       ln' typ i &&
       ln_opt' ln' post (i + 1)
+
+    | Tm_Unreachable ->
+      true
 
     | Tm_ProofHintWithBinders { binders; hint_type; t } ->
       let n = L.length binders in
@@ -639,6 +645,8 @@ let rec subst_st_term (t:st_term) (ss:subst)
                  typ=subst_term typ ss;
                  post=subst_term_opt post (shift_subst ss) }
 
+    | Tm_Unreachable -> Tm_Unreachable
+    
     | Tm_ProofHintWithBinders { hint_type; binders; t} ->
       let n = L.length binders in
       let ss = shift_subst_n n ss in

--- a/lib/steel/pulse/Pulse.Syntax.Printer.fst
+++ b/lib/steel/pulse/Pulse.Syntax.Printer.fst
@@ -307,6 +307,8 @@ let rec st_term_to_string' (level:string) (t:st_term)
          | None -> ""
          | Some post -> sprintf " %s" (term_to_string post))
 
+    | Tm_Unreachable -> "unreachable ()"
+
     | Tm_ProofHintWithBinders { binders; hint_type; t} ->
       let with_prefix =
         match binders with
@@ -406,6 +408,7 @@ let tag_of_st_term (t:st_term) =
   | Tm_WithLocalArray _ -> "Tm_WithLocalArray"
   | Tm_Rewrite _ -> "Tm_Rewrite"
   | Tm_Admit _ -> "Tm_Admit"
+  | Tm_Unreachable -> "Tm_Unreachable"
   | Tm_ProofHintWithBinders _ -> "Tm_ProofHintWithBinders"
   | Tm_WithInv _ -> "Tm_WithInv"
 
@@ -429,6 +432,7 @@ let rec print_st_head (t:st_term)
   | Tm_Match _ -> "Match"
   | Tm_While _ -> "While"
   | Tm_Admit _ -> "Admit"
+  | Tm_Unreachable -> "Unreachable"
   | Tm_Par _ -> "Par"
   | Tm_Rewrite _ -> "Rewrite"
   | Tm_WithLocal _ -> "WithLocal"
@@ -457,6 +461,7 @@ let rec print_skel (t:st_term) =
   | Tm_Match _ -> "Match"
   | Tm_While _ -> "While"
   | Tm_Admit _ -> "Admit"
+  | Tm_Unreachable -> "Unreachable"
   | Tm_Par _ -> "Par"
   | Tm_Rewrite _ -> "Rewrite"
   | Tm_WithLocal _ -> "WithLocal"

--- a/lib/steel/pulse/Pulse.Typing.FV.fst
+++ b/lib/steel/pulse/Pulse.Typing.FV.fst
@@ -207,6 +207,8 @@ let rec freevars_close_st_term' (t:st_term) (x:var) (i:index)
     | Tm_Admit { typ; post } ->
       freevars_close_term' typ x i;
       freevars_close_term_opt' post x (i + 1)
+    
+    | Tm_Unreachable -> ()
 
     | Tm_ProofHintWithBinders { binders; hint_type; t } ->
       let n = L.length binders in
@@ -660,7 +662,8 @@ let rec st_typing_freevars (#g:_) (#t:_) (#c:_)
     tot_or_ghost_typing_freevars u_typing;
     freevars_array init_t
 
-  | T_Admit _ s _ (STC _ _ x t_typing pre_typing post_typing) ->
+  | T_Admit _ s _ (STC _ _ x t_typing pre_typing post_typing)
+  | T_Unreachable _ s _ (STC _ _ x t_typing pre_typing post_typing) _ ->
     tot_or_ghost_typing_freevars t_typing;
     tot_or_ghost_typing_freevars pre_typing;
     tot_or_ghost_typing_freevars post_typing;

--- a/lib/steel/pulse/Pulse.Typing.LN.fst
+++ b/lib/steel/pulse/Pulse.Typing.LN.fst
@@ -289,6 +289,8 @@ let rec open_st_term_ln' (e:st_term)
       open_term_ln' typ x i;
       open_term_ln_opt' post x (i + 1)
 
+    | Tm_Unreachable -> ()
+
     | Tm_ProofHintWithBinders { binders; hint_type; t } ->
       let n = L.length binders in
       open_proof_hint_ln hint_type x (i + n);
@@ -521,7 +523,9 @@ let rec ln_weakening_st (t:st_term) (i j:int)
     | Tm_Admit { typ; post } ->
       ln_weakening typ i j;
       ln_weakening_opt post (i + 1) (j + 1)
-      
+    
+    | Tm_Unreachable -> ()
+
     | Tm_ProofHintWithBinders { binders; hint_type; t } ->
       let n = L.length binders in
       ln_weakening_proof_hint hint_type (i + n) (j + n);
@@ -729,6 +733,8 @@ let rec open_term_ln_inv_st' (t:st_term)
       open_term_ln_inv' typ x i;
       open_term_ln_inv_opt' post x (i + 1)
 
+    | Tm_Unreachable -> ()
+
     | Tm_ProofHintWithBinders { binders; hint_type; t } ->
       let n = L.length binders in
       open_proof_hint_ln_inv hint_type x (i + n);
@@ -929,6 +935,8 @@ let rec close_st_term_ln' (t:st_term) (x:var) (i:index)
     | Tm_Admit { typ; post } ->
       close_term_ln' typ x i;
       close_term_ln_opt' post x (i + 1)
+
+    | Tm_Unreachable -> ()
 
     | Tm_ProofHintWithBinders { binders; hint_type; t } ->
       let n = L.length binders in
@@ -1247,7 +1255,8 @@ let rec st_typing_ln (#g:_) (#t:_) (#c:_)
       tot_or_ghost_typing_ln init_t_typing;
       ln_mk_array init_t (-1)
 
-    | T_Admit _ s _ (STC _ _ x t_typing pre_typing post_typing) ->
+    | T_Admit _ s _ (STC _ _ x t_typing pre_typing post_typing)
+    | T_Unreachable _ s _ (STC _ _ x t_typing pre_typing post_typing) _ ->
       tot_or_ghost_typing_ln t_typing;
       tot_or_ghost_typing_ln pre_typing;
       tot_or_ghost_typing_ln post_typing;

--- a/lib/steel/pulse/Pulse.Typing.Metatheory.Base.fst
+++ b/lib/steel/pulse/Pulse.Typing.Metatheory.Base.fst
@@ -473,6 +473,9 @@ let rec st_typing_weakening g g' t c d g1
 
   | T_Admit _ s c d_s -> T_Admit _ s c (st_comp_typing_weakening g g' d_s g1)
 
+  | T_Unreachable _ s c d_s tok ->
+    T_Unreachable _ s c (st_comp_typing_weakening g g' d_s g1) (RU.magic())//weaken tok
+
   | T_WithInv  _ _ _ p_typing inv_typing _ _ body_typing ->
     T_WithInv _ _ _ (tot_typing_weakening g g' _ _ p_typing g1)
                     (tot_typing_weakening g g' _ _ inv_typing g1)

--- a/lib/steel/pulse/Pulse.Typing.fst
+++ b/lib/steel/pulse/Pulse.Typing.fst
@@ -1046,6 +1046,14 @@ type st_typing : env -> st_term -> comp -> Type =
       st_typing g (wtag (Some c) (Tm_Admit { ctag=c; u=s.u; typ=s.res; post=None }))
                   (comp_admit c s)
 
+  | T_Unreachable:
+      g:env ->
+      s:st_comp ->
+      c:ctag ->
+      st_comp_typing g s ->
+      prop_validity g (tm_fstar (`False) FStar.Range.range_0) -> 
+      st_typing g (wtag (Some c) Tm_Unreachable) (comp_admit c s)
+
   (* FAKE: takes an stt sub function, needs to check effects. Also it can be either
   atomic, unobservable, or ghost. *)
   | T_WithInv:

--- a/share/steel/examples/pulse/Example.Unreachable.fst
+++ b/share/steel/examples/pulse/Example.Unreachable.fst
@@ -1,11 +1,11 @@
 module Example.Unreachable
 open Pulse.Lib.Pervasives
 
-[@@expect_failure]
+
 ```pulse
 fn test (x:option bool)
     requires pure (Some? x)
-    returns b:bool
+    returns b:bool 
     ensures emp
 {
     match x {

--- a/src/ocaml/plugin/PulseSyntaxExtension_SyntaxWrapper.ml
+++ b/src/ocaml/plugin/PulseSyntaxExtension_SyntaxWrapper.ml
@@ -174,6 +174,8 @@ let tm_rename ps r : st_term = failwith ""
 
 let tm_admit r : st_term =
   PSB.(with_range (tm_admit STT u_zero (tm_unknown r) None) r)
+let tm_unreachable r : st_term =
+  PSB.(with_range (tm_unreachable) r)
   
 let close_term t v = Pulse_Syntax_Naming.close_term t v
 let close_st_term t v = Pulse_Syntax_Naming.close_st_term t v

--- a/src/ocaml/plugin/generated/PulseSyntaxExtension_Desugar.ml
+++ b/src/ocaml/plugin/generated/PulseSyntaxExtension_Desugar.ml
@@ -214,16 +214,25 @@ let (admit_or_return :
       let uu___ = FStar_Syntax_Util.head_and_args_full s in
       match uu___ with
       | (head, args) ->
-          (match head.FStar_Syntax_Syntax.n with
-           | FStar_Syntax_Syntax.Tm_fvar fv ->
-               let uu___1 =
+          (match ((head.FStar_Syntax_Syntax.n), args) with
+           | (FStar_Syntax_Syntax.Tm_fvar fv, uu___1::[]) ->
+               let uu___2 =
                  FStar_Syntax_Syntax.fv_eq_lid fv
                    PulseSyntaxExtension_Env.admit_lid in
-               if uu___1
+               if uu___2
                then
-                 let uu___2 = PulseSyntaxExtension_SyntaxWrapper.tm_admit r in
-                 STTerm uu___2
-               else Return s
+                 let uu___3 = PulseSyntaxExtension_SyntaxWrapper.tm_admit r in
+                 STTerm uu___3
+               else
+                 (let uu___4 =
+                    FStar_Syntax_Syntax.fv_eq_lid fv
+                      PulseSyntaxExtension_Env.unreachable_lid in
+                  if uu___4
+                  then
+                    let uu___5 =
+                      PulseSyntaxExtension_SyntaxWrapper.tm_unreachable r in
+                    STTerm uu___5
+                  else Return s)
            | uu___1 -> Return s)
 let (prepend_ctx_issue :
   FStar_Pprint.document -> FStar_Errors.issue -> FStar_Errors.issue) =

--- a/src/ocaml/plugin/generated/PulseSyntaxExtension_Env.ml
+++ b/src/ocaml/plugin/generated/PulseSyntaxExtension_Env.ml
@@ -15,6 +15,7 @@ let (prims_exists_lid : FStar_Ident.lident) =
   FStar_Ident.lid_of_path ["Prims"; "l_Exists"] r_
 let (prims_forall_lid : FStar_Ident.lident) =
   FStar_Ident.lid_of_path ["Prims"; "l_Forall"] r_
+let (unreachable_lid : FStar_Ident.lident) = pulse_lib_core_lid "unreachable"
 let (exists_lid : FStar_Ident.lident) = pulse_lib_core_lid "op_exists_Star"
 let (star_lid : FStar_Ident.lident) = pulse_lib_core_lid "op_Star_Star"
 let (emp_lid : FStar_Ident.lident) = pulse_lib_core_lid "emp"

--- a/src/ocaml/plugin/generated/Pulse_Checker.ml
+++ b/src/ocaml/plugin/generated/Pulse_Checker.ml
@@ -444,7 +444,7 @@ let rec (check : Pulse_Checker_Base.check_t) =
                    (Obj.magic
                       (FStar_Range.mk_range "Pulse.Checker.fst"
                          (Prims.of_int (141)) (Prims.of_int (55))
-                         (Prims.of_int (265)) (Prims.of_int (50)))))
+                         (Prims.of_int (268)) (Prims.of_int (50)))))
                 (if
                    Pulse_RuntimeUtils.debug_at_level
                      (Pulse_Typing_Env.fstar_env g0) "pulse.checker"
@@ -648,7 +648,7 @@ let rec (check : Pulse_Checker_Base.check_t) =
                               (Obj.magic
                                  (FStar_Range.mk_range "Pulse.Checker.fst"
                                     (Prims.of_int (141)) (Prims.of_int (55))
-                                    (Prims.of_int (265)) (Prims.of_int (50)))))
+                                    (Prims.of_int (268)) (Prims.of_int (50)))))
                            (Obj.magic
                               (Pulse_Checker_Prover_ElimPure.elim_pure g0
                                  pre0 ()))
@@ -665,15 +665,15 @@ let rec (check : Pulse_Checker_Base.check_t) =
                                                    "Pulse.Checker.fst"
                                                    (Prims.of_int (146))
                                                    (Prims.of_int (44))
-                                                   (Prims.of_int (261))
+                                                   (Prims.of_int (264))
                                                    (Prims.of_int (48)))))
                                           (FStar_Sealed.seal
                                              (Obj.magic
                                                 (FStar_Range.mk_range
                                                    "Pulse.Checker.fst"
-                                                   (Prims.of_int (262))
-                                                   (Prims.of_int (4))
                                                    (Prims.of_int (265))
+                                                   (Prims.of_int (4))
+                                                   (Prims.of_int (268))
                                                    (Prims.of_int (50)))))
                                           (Obj.magic
                                              (FStar_Tactics_Effect.tac_bind
@@ -691,7 +691,7 @@ let rec (check : Pulse_Checker_Base.check_t) =
                                                          "Pulse.Checker.fst"
                                                          (Prims.of_int (148))
                                                          (Prims.of_int (4))
-                                                         (Prims.of_int (261))
+                                                         (Prims.of_int (264))
                                                          (Prims.of_int (48)))))
                                                 (FStar_Tactics_Effect.lift_div_tac
                                                    (fun uu___2 ->
@@ -1385,6 +1385,15 @@ let rec (check : Pulse_Checker_Base.check_t) =
                                                           Obj.magic
                                                             (Obj.repr
                                                                (Pulse_Checker_Admit.check
+                                                                  g1 pre ()
+                                                                  post_hint
+                                                                  res_ppname
+                                                                  t))
+                                                      | Pulse_Syntax_Base.Tm_Unreachable
+                                                          ->
+                                                          Obj.magic
+                                                            (Obj.repr
+                                                               (Pulse_Checker_Unreachable.check
                                                                   g1 pre ()
                                                                   post_hint
                                                                   res_ppname

--- a/src/ocaml/plugin/generated/Pulse_Checker_Unreachable.ml
+++ b/src/ocaml/plugin/generated/Pulse_Checker_Unreachable.ml
@@ -1,0 +1,593 @@
+open Prims
+let (check :
+  Pulse_Typing_Env.env ->
+    Pulse_Syntax_Base.term ->
+      unit ->
+        unit Pulse_Typing.post_hint_opt ->
+          Pulse_Syntax_Base.ppname ->
+            Pulse_Syntax_Base.st_term ->
+              ((unit, unit, unit) Pulse_Checker_Base.checker_result_t, 
+                unit) FStar_Tactics_Effect.tac_repr)
+  =
+  fun g ->
+    fun pre ->
+      fun pre_typing ->
+        fun post_hint ->
+          fun res_ppname ->
+            fun t ->
+              FStar_Tactics_Effect.tac_bind
+                (FStar_Sealed.seal
+                   (Obj.magic
+                      (FStar_Range.mk_range "Pulse.Checker.Unreachable.fst"
+                         (Prims.of_int (21)) (Prims.of_int (12))
+                         (Prims.of_int (21)) (Prims.of_int (19)))))
+                (FStar_Sealed.seal
+                   (Obj.magic
+                      (FStar_Range.mk_range "Pulse.Checker.Unreachable.fst"
+                         (Prims.of_int (22)) (Prims.of_int (2))
+                         (Prims.of_int (54)) (Prims.of_int (128)))))
+                (FStar_Tactics_Effect.lift_div_tac
+                   (fun uu___ -> t.Pulse_Syntax_Base.range2))
+                (fun uu___ ->
+                   (fun rng ->
+                      match post_hint with
+                      | FStar_Pervasives_Native.None ->
+                          Obj.magic
+                            (Pulse_Typing_Env.fail g
+                               (FStar_Pervasives_Native.Some
+                                  (t.Pulse_Syntax_Base.range2))
+                               "Expected a postcondition to be annotated when unreachable is used")
+                      | FStar_Pervasives_Native.Some post ->
+                          Obj.magic
+                            (FStar_Tactics_Effect.tac_bind
+                               (FStar_Sealed.seal
+                                  (Obj.magic
+                                     (FStar_Range.mk_range
+                                        "Pulse.Checker.Unreachable.fst"
+                                        (Prims.of_int (27))
+                                        (Prims.of_int (12))
+                                        (Prims.of_int (27))
+                                        (Prims.of_int (19)))))
+                               (FStar_Sealed.seal
+                                  (Obj.magic
+                                     (FStar_Range.mk_range
+                                        "Pulse.Checker.Unreachable.fst"
+                                        (Prims.of_int (27))
+                                        (Prims.of_int (22))
+                                        (Prims.of_int (54))
+                                        (Prims.of_int (128)))))
+                               (FStar_Tactics_Effect.lift_div_tac
+                                  (fun uu___ -> Pulse_Typing_Env.fresh g))
+                               (fun uu___ ->
+                                  (fun x ->
+                                     Obj.magic
+                                       (FStar_Tactics_Effect.tac_bind
+                                          (FStar_Sealed.seal
+                                             (Obj.magic
+                                                (FStar_Range.mk_range
+                                                   "Pulse.Checker.Unreachable.fst"
+                                                   (Prims.of_int (28))
+                                                   (Prims.of_int (13))
+                                                   (Prims.of_int (28))
+                                                   (Prims.of_int (22)))))
+                                          (FStar_Sealed.seal
+                                             (Obj.magic
+                                                (FStar_Range.mk_range
+                                                   "Pulse.Checker.Unreachable.fst"
+                                                   (Prims.of_int (28))
+                                                   (Prims.of_int (25))
+                                                   (Prims.of_int (54))
+                                                   (Prims.of_int (128)))))
+                                          (FStar_Tactics_Effect.lift_div_tac
+                                             (fun uu___ ->
+                                                Pulse_Syntax_Base.v_as_nv x))
+                                          (fun uu___ ->
+                                             (fun px ->
+                                                Obj.magic
+                                                  (FStar_Tactics_Effect.tac_bind
+                                                     (FStar_Sealed.seal
+                                                        (Obj.magic
+                                                           (FStar_Range.mk_range
+                                                              "Pulse.Checker.Unreachable.fst"
+                                                              (Prims.of_int (29))
+                                                              (Prims.of_int (29))
+                                                              (Prims.of_int (29))
+                                                              (Prims.of_int (33)))))
+                                                     (FStar_Sealed.seal
+                                                        (Obj.magic
+                                                           (FStar_Range.mk_range
+                                                              "Pulse.Checker.Unreachable.fst"
+                                                              (Prims.of_int (30))
+                                                              (Prims.of_int (4))
+                                                              (Prims.of_int (54))
+                                                              (Prims.of_int (128)))))
+                                                     (FStar_Tactics_Effect.lift_div_tac
+                                                        (fun uu___ -> post))
+                                                     (fun uu___ ->
+                                                        (fun post1 ->
+                                                           if
+                                                             FStar_Set.mem x
+                                                               (Pulse_Syntax_Naming.freevars
+                                                                  post1.Pulse_Typing.post)
+                                                           then
+                                                             Obj.magic
+                                                               (Pulse_Typing_Env.fail
+                                                                  g
+                                                                  FStar_Pervasives_Native.None
+                                                                  "Impossible: unexpected freevar clash in Tm_Unreachable, please file a bug-report")
+                                                           else
+                                                             Obj.magic
+                                                               (FStar_Tactics_Effect.tac_bind
+                                                                  (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Unreachable.fst"
+                                                                    (Prims.of_int (34))
+                                                                    (Prims.of_int (12))
+                                                                    (Prims.of_int (36))
+                                                                    (Prims.of_int (31)))))
+                                                                  (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Unreachable.fst"
+                                                                    (Prims.of_int (37))
+                                                                    (Prims.of_int (10))
+                                                                    (Prims.of_int (54))
+                                                                    (Prims.of_int (128)))))
+                                                                  (FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___1 ->
+                                                                    match 
+                                                                    post1.Pulse_Typing.ctag_hint
+                                                                    with
+                                                                    | 
+                                                                    FStar_Pervasives_Native.None
+                                                                    ->
+                                                                    Pulse_Syntax_Base.STT
+                                                                    | 
+                                                                    FStar_Pervasives_Native.Some
+                                                                    ctag ->
+                                                                    ctag))
+                                                                  (fun uu___1
+                                                                    ->
+                                                                    (fun ctag
+                                                                    ->
+                                                                    Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Unreachable.fst"
+                                                                    (Prims.of_int (38))
+                                                                    (Prims.of_int (30))
+                                                                    (Prims.of_int (38))
+                                                                    (Prims.of_int (55)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Unreachable.fst"
+                                                                    (Prims.of_int (38))
+                                                                    (Prims.of_int (58))
+                                                                    (Prims.of_int (54))
+                                                                    (Prims.of_int (128)))))
+                                                                    (FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___1 ->
+                                                                    Pulse_Typing.post_hint_typing
+                                                                    g post1 x))
+                                                                    (fun
+                                                                    uu___1 ->
+                                                                    (fun
+                                                                    post_typing_rec
+                                                                    ->
+                                                                    Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Unreachable.fst"
+                                                                    (Prims.of_int (39))
+                                                                    (Prims.of_int (26))
+                                                                    (Prims.of_int (39))
+                                                                    (Prims.of_int (51)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Unreachable.fst"
+                                                                    (Prims.of_int (40))
+                                                                    (Prims.of_int (55))
+                                                                    (Prims.of_int (54))
+                                                                    (Prims.of_int (128)))))
+                                                                    (FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___1 ->
+                                                                    Pulse_Syntax_Naming.open_term_nv
+                                                                    post1.Pulse_Typing.post
+                                                                    px))
+                                                                    (fun
+                                                                    uu___1 ->
+                                                                    (fun
+                                                                    post_opened
+                                                                    ->
+                                                                    Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Unreachable.fst"
+                                                                    (Prims.of_int (41))
+                                                                    (Prims.of_int (23))
+                                                                    (Prims.of_int (41))
+                                                                    (Prims.of_int (34)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Unreachable.fst"
+                                                                    (Prims.of_int (41))
+                                                                    (Prims.of_int (37))
+                                                                    (Prims.of_int (54))
+                                                                    (Prims.of_int (128)))))
+                                                                    (FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___1 ->
+                                                                    post1.Pulse_Typing.ret_ty))
+                                                                    (fun
+                                                                    uu___1 ->
+                                                                    (fun t1
+                                                                    ->
+                                                                    Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Unreachable.fst"
+                                                                    (Prims.of_int (42))
+                                                                    (Prims.of_int (16))
+                                                                    (Prims.of_int (42))
+                                                                    (Prims.of_int (22)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Unreachable.fst"
+                                                                    (Prims.of_int (42))
+                                                                    (Prims.of_int (25))
+                                                                    (Prims.of_int (54))
+                                                                    (Prims.of_int (128)))))
+                                                                    (FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___1 ->
+                                                                    post1.Pulse_Typing.u))
+                                                                    (fun
+                                                                    uu___1 ->
+                                                                    (fun u ->
+                                                                    Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Unreachable.fst"
+                                                                    (Prims.of_int (43))
+                                                                    (Prims.of_int (43))
+                                                                    (Prims.of_int (43))
+                                                                    (Prims.of_int (68)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Unreachable.fst"
+                                                                    (Prims.of_int (43))
+                                                                    (Prims.of_int (71))
+                                                                    (Prims.of_int (54))
+                                                                    (Prims.of_int (128)))))
+                                                                    (FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___1 ->
+                                                                    ()))
+                                                                    (fun
+                                                                    uu___1 ->
+                                                                    (fun
+                                                                    t_typing
+                                                                    ->
+                                                                    Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Unreachable.fst"
+                                                                    (Prims.of_int (44))
+                                                                    (Prims.of_int (26))
+                                                                    (Prims.of_int (44))
+                                                                    (Prims.of_int (53)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Unreachable.fst"
+                                                                    (Prims.of_int (45))
+                                                                    (Prims.of_int (55))
+                                                                    (Prims.of_int (54))
+                                                                    (Prims.of_int (128)))))
+                                                                    (FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___1 ->
+                                                                    ()))
+                                                                    (fun
+                                                                    uu___1 ->
+                                                                    (fun
+                                                                    post_typing
+                                                                    ->
+                                                                    Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Unreachable.fst"
+                                                                    (Prims.of_int (46))
+                                                                    (Prims.of_int (27))
+                                                                    (Prims.of_int (46))
+                                                                    (Prims.of_int (56)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Unreachable.fst"
+                                                                    (Prims.of_int (46))
+                                                                    (Prims.of_int (60))
+                                                                    (Prims.of_int (54))
+                                                                    (Prims.of_int (128)))))
+                                                                    (FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___1 ->
+                                                                    {
+                                                                    Pulse_Syntax_Base.u
+                                                                    = u;
+                                                                    Pulse_Syntax_Base.res
+                                                                    = t1;
+                                                                    Pulse_Syntax_Base.pre
+                                                                    = pre;
+                                                                    Pulse_Syntax_Base.post
+                                                                    =
+                                                                    (post1.Pulse_Typing.post)
+                                                                    }))
+                                                                    (fun
+                                                                    uu___1 ->
+                                                                    (fun s ->
+                                                                    Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Unreachable.fst"
+                                                                    (Prims.of_int (47))
+                                                                    (Prims.of_int (39))
+                                                                    (Prims.of_int (47))
+                                                                    (Prims.of_int (82)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Unreachable.fst"
+                                                                    (Prims.of_int (47))
+                                                                    (Prims.of_int (85))
+                                                                    (Prims.of_int (54))
+                                                                    (Prims.of_int (128)))))
+                                                                    (FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___1 ->
+                                                                    Pulse_Typing.STC
+                                                                    (g, s, x,
+                                                                    (), (),
+                                                                    ())))
+                                                                    (fun
+                                                                    uu___1 ->
+                                                                    (fun stc
+                                                                    ->
+                                                                    Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Unreachable.fst"
+                                                                    (Prims.of_int (48))
+                                                                    (Prims.of_int (17))
+                                                                    (Prims.of_int (48))
+                                                                    (Prims.of_int (40)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Unreachable.fst"
+                                                                    (Prims.of_int (48))
+                                                                    (Prims.of_int (43))
+                                                                    (Prims.of_int (54))
+                                                                    (Prims.of_int (128)))))
+                                                                    (FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___1 ->
+                                                                    Pulse_Syntax_Base.tm_fstar
+                                                                    (FStar_Reflection_V2_Builtins.pack_ln
+                                                                    (FStar_Reflection_V2_Data.Tv_FVar
+                                                                    (FStar_Reflection_V2_Builtins.pack_fv
+                                                                    ["Prims";
+                                                                    "l_False"])))
+                                                                    rng))
+                                                                    (fun
+                                                                    uu___1 ->
+                                                                    (fun ff
+                                                                    ->
+                                                                    Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Unreachable.fst"
+                                                                    (Prims.of_int (49))
+                                                                    (Prims.of_int (34))
+                                                                    (Prims.of_int (49))
+                                                                    (Prims.of_int (89)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Unreachable.fst"
+                                                                    (Prims.of_int (48))
+                                                                    (Prims.of_int (43))
+                                                                    (Prims.of_int (54))
+                                                                    (Prims.of_int (128)))))
+                                                                    (Obj.magic
+                                                                    (Pulse_Checker_Pure.core_check_term_at_type
+                                                                    g ff
+                                                                    Pulse_Typing.tm_prop))
+                                                                    (fun
+                                                                    uu___1 ->
+                                                                    (fun
+                                                                    uu___1 ->
+                                                                    match uu___1
+                                                                    with
+                                                                    | 
+                                                                    Prims.Mkdtuple2
+                                                                    (eff,
+                                                                    ff_typing)
+                                                                    ->
+                                                                    if
+                                                                    eff <>
+                                                                    FStar_TypeChecker_Core.E_Total
+                                                                    then
+                                                                    Obj.magic
+                                                                    (Obj.repr
+                                                                    (FStar_Tactics_V2_Derived.fail
+                                                                    "Impossible: False has effect Ghost"))
+                                                                    else
+                                                                    Obj.magic
+                                                                    (Obj.repr
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Unreachable.fst"
+                                                                    (Prims.of_int (52))
+                                                                    (Prims.of_int (30))
+                                                                    (Prims.of_int (52))
+                                                                    (Prims.of_int (83)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Unreachable.fst"
+                                                                    (Prims.of_int (52))
+                                                                    (Prims.of_int (86))
+                                                                    (Prims.of_int (54))
+                                                                    (Prims.of_int (128)))))
+                                                                    (Obj.magic
+                                                                    (Pulse_Checker_Pure.check_prop_validity
+                                                                    g ff ()))
+                                                                    (fun
+                                                                    uu___3 ->
+                                                                    (fun
+                                                                    ff_validity
+                                                                    ->
+                                                                    Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Unreachable.fst"
+                                                                    (Prims.of_int (53))
+                                                                    (Prims.of_int (21))
+                                                                    (Prims.of_int (53))
+                                                                    (Prims.of_int (59)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Unreachable.fst"
+                                                                    (Prims.of_int (54))
+                                                                    (Prims.of_int (12))
+                                                                    (Prims.of_int (54))
+                                                                    (Prims.of_int (128)))))
+                                                                    (FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___3 ->
+                                                                    Pulse_Typing.T_Unreachable
+                                                                    (g, s,
+                                                                    ctag,
+                                                                    stc, ())))
+                                                                    (fun
+                                                                    uu___3 ->
+                                                                    (fun dt
+                                                                    ->
+                                                                    Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Unreachable.fst"
+                                                                    (Prims.of_int (54))
+                                                                    (Prims.of_int (28))
+                                                                    (Prims.of_int (54))
+                                                                    (Prims.of_int (110)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Unreachable.fst"
+                                                                    (Prims.of_int (54))
+                                                                    (Prims.of_int (12))
+                                                                    (Prims.of_int (54))
+                                                                    (Prims.of_int (128)))))
+                                                                    (Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Unreachable.fst"
+                                                                    (Prims.of_int (54))
+                                                                    (Prims.of_int (54))
+                                                                    (Prims.of_int (54))
+                                                                    (Prims.of_int (98)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Unreachable.fst"
+                                                                    (Prims.of_int (54))
+                                                                    (Prims.of_int (28))
+                                                                    (Prims.of_int (54))
+                                                                    (Prims.of_int (110)))))
+                                                                    (Obj.magic
+                                                                    (Pulse_Checker_Base.match_comp_res_with_post_hint
+                                                                    g
+                                                                    (Pulse_Typing.wtag
+                                                                    (FStar_Pervasives_Native.Some
+                                                                    ctag)
+                                                                    Pulse_Syntax_Base.Tm_Unreachable)
+                                                                    (Pulse_Typing.comp_admit
+                                                                    ctag s)
+                                                                    dt
+                                                                    post_hint))
+                                                                    (fun
+                                                                    uu___3 ->
+                                                                    (fun
+                                                                    uu___3 ->
+                                                                    Obj.magic
+                                                                    (Pulse_Checker_Prover.try_frame_pre
+                                                                    g pre ()
+                                                                    uu___3
+                                                                    res_ppname))
+                                                                    uu___3)))
+                                                                    (fun
+                                                                    uu___3 ->
+                                                                    (fun
+                                                                    uu___3 ->
+                                                                    Obj.magic
+                                                                    (Pulse_Checker_Prover.prove_post_hint
+                                                                    g pre
+                                                                    uu___3
+                                                                    post_hint
+                                                                    t1.Pulse_Syntax_Base.range1))
+                                                                    uu___3)))
+                                                                    uu___3)))
+                                                                    uu___3))))
+                                                                    uu___1)))
+                                                                    uu___1)))
+                                                                    uu___1)))
+                                                                    uu___1)))
+                                                                    uu___1)))
+                                                                    uu___1)))
+                                                                    uu___1)))
+                                                                    uu___1)))
+                                                                    uu___1)))
+                                                                    uu___1)))
+                                                                    uu___1)))
+                                                          uu___))) uu___)))
+                                    uu___))) uu___)

--- a/src/ocaml/plugin/generated/Pulse_Elaborate_Core.ml
+++ b/src/ocaml/plugin/generated/Pulse_Elaborate_Core.ml
@@ -618,6 +618,12 @@ let rec (elab_st_typing :
                | Pulse_Syntax_Base.STT_Ghost ->
                    Pulse_Reflection_Util.mk_stt_ghost_admit ru rres rpre
                      rpost1)
+          | Pulse_Typing.T_Unreachable
+              (uu___, uu___1, uu___2, uu___3, uu___4) ->
+              FStar_Reflection_V2_Builtins.pack_ln
+                (FStar_Reflection_V2_Data.Tv_Const
+                   (FStar_Reflection_V2_Data.C_String
+                      "IOU: elab_st_typing of T_Unreachable"))
           | Pulse_Typing.T_WithInv
               (uu___, uu___1, uu___2, uu___3, uu___4, uu___5, uu___6, uu___7)
               ->

--- a/src/ocaml/plugin/generated/Pulse_Extract_Main.ml
+++ b/src/ocaml/plugin/generated/Pulse_Extract_Main.ml
@@ -2380,7 +2380,7 @@ let rec (simplify_st_term :
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Extract.Main.fst"
                  (Prims.of_int (354)) (Prims.of_int (36))
-                 (Prims.of_int (416)) (Prims.of_int (27)))))
+                 (Prims.of_int (419)) (Prims.of_int (56)))))
         (FStar_Tactics_Effect.lift_div_tac
            (fun uu___ ->
               fun t ->
@@ -2403,7 +2403,7 @@ let rec (simplify_st_term :
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Extract.Main.fst"
                             (Prims.of_int (357)) (Prims.of_int (2))
-                            (Prims.of_int (416)) (Prims.of_int (27)))))
+                            (Prims.of_int (419)) (Prims.of_int (56)))))
                    (FStar_Tactics_Effect.lift_div_tac
                       (fun uu___ ->
                          fun b -> fun e1 -> with_open g b e1 simplify_st_term))
@@ -3283,7 +3283,12 @@ let rec (simplify_st_term :
                                Pulse_Syntax_Base.body6 = body;
                                Pulse_Syntax_Base.returns_inv = uu___1;_}
                              ->
-                             Obj.magic (Obj.repr (simplify_st_term g body)))
+                             Obj.magic (Obj.repr (simplify_st_term g body))
+                         | Pulse_Syntax_Base.Tm_Unreachable ->
+                             Obj.magic
+                               (Obj.repr
+                                  (FStar_Tactics_V2_Derived.fail
+                                     "Tm_Unreachable: Should have been eliminated")))
                         uu___))) uu___)
 and (simplify_branch :
   env ->
@@ -3296,13 +3301,13 @@ and (simplify_branch :
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Extract.Main.fst"
-                 (Prims.of_int (419)) (Prims.of_int (18))
-                 (Prims.of_int (419)) (Prims.of_int (19)))))
+                 (Prims.of_int (422)) (Prims.of_int (18))
+                 (Prims.of_int (422)) (Prims.of_int (19)))))
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Extract.Main.fst"
-                 (Prims.of_int (418)) (Prims.of_int (55))
-                 (Prims.of_int (423)) (Prims.of_int (62)))))
+                 (Prims.of_int (421)) (Prims.of_int (55))
+                 (Prims.of_int (426)) (Prims.of_int (62)))))
         (FStar_Tactics_Effect.lift_div_tac (fun uu___ -> b))
         (fun uu___ ->
            (fun uu___ ->
@@ -3313,13 +3318,13 @@ and (simplify_branch :
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Extract.Main.fst"
-                                (Prims.of_int (420)) (Prims.of_int (17))
-                                (Prims.of_int (420)) (Prims.of_int (37)))))
+                                (Prims.of_int (423)) (Prims.of_int (17))
+                                (Prims.of_int (423)) (Prims.of_int (37)))))
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Extract.Main.fst"
-                                (Prims.of_int (419)) (Prims.of_int (22))
-                                (Prims.of_int (423)) (Prims.of_int (62)))))
+                                (Prims.of_int (422)) (Prims.of_int (22))
+                                (Prims.of_int (426)) (Prims.of_int (62)))))
                        (Obj.magic (extend_env_pat g pat))
                        (fun uu___1 ->
                           (fun uu___1 ->
@@ -3331,17 +3336,17 @@ and (simplify_branch :
                                          (Obj.magic
                                             (FStar_Range.mk_range
                                                "Pulse.Extract.Main.fst"
-                                               (Prims.of_int (421))
+                                               (Prims.of_int (424))
                                                (Prims.of_int (13))
-                                               (Prims.of_int (421))
+                                               (Prims.of_int (424))
                                                (Prims.of_int (56)))))
                                       (FStar_Sealed.seal
                                          (Obj.magic
                                             (FStar_Range.mk_range
                                                "Pulse.Extract.Main.fst"
-                                               (Prims.of_int (421))
+                                               (Prims.of_int (424))
                                                (Prims.of_int (59))
-                                               (Prims.of_int (423))
+                                               (Prims.of_int (426))
                                                (Prims.of_int (62)))))
                                       (FStar_Tactics_Effect.lift_div_tac
                                          (fun uu___3 ->
@@ -3355,17 +3360,17 @@ and (simplify_branch :
                                                     (Obj.magic
                                                        (FStar_Range.mk_range
                                                           "Pulse.Extract.Main.fst"
-                                                          (Prims.of_int (422))
+                                                          (Prims.of_int (425))
                                                           (Prims.of_int (13))
-                                                          (Prims.of_int (422))
+                                                          (Prims.of_int (425))
                                                           (Prims.of_int (36)))))
                                                  (FStar_Sealed.seal
                                                     (Obj.magic
                                                        (FStar_Range.mk_range
                                                           "Pulse.Extract.Main.fst"
-                                                          (Prims.of_int (423))
+                                                          (Prims.of_int (426))
                                                           (Prims.of_int (2))
-                                                          (Prims.of_int (423))
+                                                          (Prims.of_int (426))
                                                           (Prims.of_int (62)))))
                                                  (Obj.magic
                                                     (simplify_st_term g1
@@ -3408,13 +3413,13 @@ let rec (erase_ghost_subterms :
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Extract.Main.fst"
-                 (Prims.of_int (433)) (Prims.of_int (22))
-                 (Prims.of_int (433)) (Prims.of_int (50)))))
+                 (Prims.of_int (436)) (Prims.of_int (22))
+                 (Prims.of_int (436)) (Prims.of_int (50)))))
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Extract.Main.fst"
-                 (Prims.of_int (433)) (Prims.of_int (53))
-                 (Prims.of_int (507)) (Prims.of_int (5)))))
+                 (Prims.of_int (436)) (Prims.of_int (53))
+                 (Prims.of_int (512)) (Prims.of_int (5)))))
         (FStar_Tactics_Effect.lift_div_tac
            (fun uu___ -> fun g1 -> Pulse_Typing_Env.fresh g1.coreenv))
         (fun uu___ ->
@@ -3424,13 +3429,13 @@ let rec (erase_ghost_subterms :
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Extract.Main.fst"
-                            (Prims.of_int (435)) (Prims.of_int (6))
-                            (Prims.of_int (435)) (Prims.of_int (77)))))
+                            (Prims.of_int (438)) (Prims.of_int (6))
+                            (Prims.of_int (438)) (Prims.of_int (77)))))
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Extract.Main.fst"
-                            (Prims.of_int (435)) (Prims.of_int (82))
-                            (Prims.of_int (507)) (Prims.of_int (5)))))
+                            (Prims.of_int (438)) (Prims.of_int (82))
+                            (Prims.of_int (512)) (Prims.of_int (5)))))
                    (FStar_Tactics_Effect.lift_div_tac
                       (fun uu___ ->
                          fun g1 ->
@@ -3451,17 +3456,17 @@ let rec (erase_ghost_subterms :
                                  (Obj.magic
                                     (FStar_Range.mk_range
                                        "Pulse.Extract.Main.fst"
-                                       (Prims.of_int (437))
+                                       (Prims.of_int (440))
                                        (Prims.of_int (71))
-                                       (Prims.of_int (441))
+                                       (Prims.of_int (444))
                                        (Prims.of_int (24)))))
                               (FStar_Sealed.seal
                                  (Obj.magic
                                     (FStar_Range.mk_range
                                        "Pulse.Extract.Main.fst"
-                                       (Prims.of_int (441))
+                                       (Prims.of_int (444))
                                        (Prims.of_int (27))
-                                       (Prims.of_int (507))
+                                       (Prims.of_int (512))
                                        (Prims.of_int (5)))))
                               (FStar_Tactics_Effect.lift_div_tac
                                  (fun uu___ ->
@@ -3473,17 +3478,17 @@ let rec (erase_ghost_subterms :
                                                (Obj.magic
                                                   (FStar_Range.mk_range
                                                      "Pulse.Extract.Main.fst"
-                                                     (Prims.of_int (438))
+                                                     (Prims.of_int (441))
                                                      (Prims.of_int (12))
-                                                     (Prims.of_int (438))
+                                                     (Prims.of_int (441))
                                                      (Prims.of_int (19)))))
                                             (FStar_Sealed.seal
                                                (Obj.magic
                                                   (FStar_Range.mk_range
                                                      "Pulse.Extract.Main.fst"
-                                                     (Prims.of_int (438))
-                                                     (Prims.of_int (22))
                                                      (Prims.of_int (441))
+                                                     (Prims.of_int (22))
+                                                     (Prims.of_int (444))
                                                      (Prims.of_int (24)))))
                                             (FStar_Tactics_Effect.lift_div_tac
                                                (fun uu___1 -> fresh1 g1))
@@ -3495,17 +3500,17 @@ let rec (erase_ghost_subterms :
                                                           (Obj.magic
                                                              (FStar_Range.mk_range
                                                                 "Pulse.Extract.Main.fst"
-                                                                (Prims.of_int (439))
+                                                                (Prims.of_int (442))
                                                                 (Prims.of_int (12))
-                                                                (Prims.of_int (439))
+                                                                (Prims.of_int (442))
                                                                 (Prims.of_int (84)))))
                                                        (FStar_Sealed.seal
                                                           (Obj.magic
                                                              (FStar_Range.mk_range
                                                                 "Pulse.Extract.Main.fst"
-                                                                (Prims.of_int (439))
+                                                                (Prims.of_int (442))
                                                                 (Prims.of_int (87))
-                                                                (Prims.of_int (441))
+                                                                (Prims.of_int (444))
                                                                 (Prims.of_int (24)))))
                                                        (FStar_Tactics_Effect.lift_div_tac
                                                           (fun uu___1 ->
@@ -3528,17 +3533,17 @@ let rec (erase_ghost_subterms :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (440))
+                                                                    (Prims.of_int (443))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (440))
+                                                                    (Prims.of_int (443))
                                                                     (Prims.of_int (55)))))
                                                                   (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (441))
+                                                                    (Prims.of_int (444))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (441))
+                                                                    (Prims.of_int (444))
                                                                     (Prims.of_int (24)))))
                                                                   (Obj.magic
                                                                     (erase_ghost_subterms
@@ -3561,17 +3566,17 @@ let rec (erase_ghost_subterms :
                                             (Obj.magic
                                                (FStar_Range.mk_range
                                                   "Pulse.Extract.Main.fst"
-                                                  (Prims.of_int (444))
+                                                  (Prims.of_int (447))
                                                   (Prims.of_int (6))
-                                                  (Prims.of_int (444))
+                                                  (Prims.of_int (447))
                                                   (Prims.of_int (80)))))
                                          (FStar_Sealed.seal
                                             (Obj.magic
                                                (FStar_Range.mk_range
                                                   "Pulse.Extract.Main.fst"
-                                                  (Prims.of_int (445))
+                                                  (Prims.of_int (448))
                                                   (Prims.of_int (4))
-                                                  (Prims.of_int (507))
+                                                  (Prims.of_int (512))
                                                   (Prims.of_int (5)))))
                                          (FStar_Tactics_Effect.lift_div_tac
                                             (fun uu___ ->
@@ -3601,17 +3606,17 @@ let rec (erase_ghost_subterms :
                                                        (Obj.magic
                                                           (FStar_Range.mk_range
                                                              "Pulse.Extract.Main.fst"
-                                                             (Prims.of_int (446))
+                                                             (Prims.of_int (449))
                                                              (Prims.of_int (27))
-                                                             (Prims.of_int (446))
+                                                             (Prims.of_int (449))
                                                              (Prims.of_int (42)))))
                                                     (FStar_Sealed.seal
                                                        (Obj.magic
                                                           (FStar_Range.mk_range
                                                              "Pulse.Extract.Main.fst"
-                                                             (Prims.of_int (447))
+                                                             (Prims.of_int (450))
                                                              (Prims.of_int (2))
-                                                             (Prims.of_int (507))
+                                                             (Prims.of_int (512))
                                                              (Prims.of_int (5)))))
                                                     (FStar_Tactics_Effect.lift_div_tac
                                                        (fun uu___ ->
@@ -3634,17 +3639,17 @@ let rec (erase_ghost_subterms :
                                                                   (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (447))
+                                                                    (Prims.of_int (450))
                                                                     (Prims.of_int (5))
-                                                                    (Prims.of_int (447))
+                                                                    (Prims.of_int (450))
                                                                     (Prims.of_int (18)))))
                                                                (FStar_Sealed.seal
                                                                   (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (447))
+                                                                    (Prims.of_int (450))
                                                                     (Prims.of_int (2))
-                                                                    (Prims.of_int (507))
+                                                                    (Prims.of_int (512))
                                                                     (Prims.of_int (5)))))
                                                                (Obj.magic
                                                                   (is_erasable
@@ -3717,17 +3722,17 @@ let rec (erase_ghost_subterms :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (457))
+                                                                    (Prims.of_int (460))
                                                                     (Prims.of_int (17))
-                                                                    (Prims.of_int (457))
+                                                                    (Prims.of_int (460))
                                                                     (Prims.of_int (42)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (458))
+                                                                    (Prims.of_int (461))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (458))
+                                                                    (Prims.of_int (461))
                                                                     (Prims.of_int (45)))))
                                                                     (Obj.magic
                                                                     (open_erase_close
@@ -3782,17 +3787,17 @@ let rec (erase_ghost_subterms :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (465))
+                                                                    (Prims.of_int (468))
                                                                     (Prims.of_int (9))
-                                                                    (Prims.of_int (465))
+                                                                    (Prims.of_int (468))
                                                                     (Prims.of_int (25)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (465))
+                                                                    (Prims.of_int (468))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (470))
+                                                                    (Prims.of_int (473))
                                                                     (Prims.of_int (47)))))
                                                                     (Obj.magic
                                                                     (is_erasable
@@ -3809,17 +3814,17 @@ let rec (erase_ghost_subterms :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (466))
+                                                                    (Prims.of_int (469))
                                                                     (Prims.of_int (22))
-                                                                    (Prims.of_int (466))
+                                                                    (Prims.of_int (469))
                                                                     (Prims.of_int (62)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (467))
+                                                                    (Prims.of_int (470))
                                                                     (Prims.of_int (11))
-                                                                    (Prims.of_int (467))
+                                                                    (Prims.of_int (470))
                                                                     (Prims.of_int (38)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -3845,17 +3850,17 @@ let rec (erase_ghost_subterms :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (468))
+                                                                    (Prims.of_int (471))
                                                                     (Prims.of_int (22))
-                                                                    (Prims.of_int (468))
+                                                                    (Prims.of_int (471))
                                                                     (Prims.of_int (49)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (468))
+                                                                    (Prims.of_int (471))
                                                                     (Prims.of_int (52))
-                                                                    (Prims.of_int (470))
+                                                                    (Prims.of_int (473))
                                                                     (Prims.of_int (47)))))
                                                                     (Obj.magic
                                                                     (erase_ghost_subterms
@@ -3870,17 +3875,17 @@ let rec (erase_ghost_subterms :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (469))
+                                                                    (Prims.of_int (472))
                                                                     (Prims.of_int (22))
-                                                                    (Prims.of_int (469))
+                                                                    (Prims.of_int (472))
                                                                     (Prims.of_int (52)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (470))
+                                                                    (Prims.of_int (473))
                                                                     (Prims.of_int (11))
-                                                                    (Prims.of_int (470))
+                                                                    (Prims.of_int (473))
                                                                     (Prims.of_int (47)))))
                                                                     (Obj.magic
                                                                     (open_erase_close
@@ -3919,17 +3924,17 @@ let rec (erase_ghost_subterms :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (473))
+                                                                    (Prims.of_int (476))
                                                                     (Prims.of_int (9))
-                                                                    (Prims.of_int (473))
+                                                                    (Prims.of_int (476))
                                                                     (Prims.of_int (53)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (473))
+                                                                    (Prims.of_int (476))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (477))
+                                                                    (Prims.of_int (480))
                                                                     (Prims.of_int (50)))))
                                                                     (Obj.magic
                                                                     (erase_type_for_extraction
@@ -3947,17 +3952,17 @@ let rec (erase_ghost_subterms :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (474))
+                                                                    (Prims.of_int (477))
                                                                     (Prims.of_int (22))
-                                                                    (Prims.of_int (474))
+                                                                    (Prims.of_int (477))
                                                                     (Prims.of_int (62)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (475))
+                                                                    (Prims.of_int (478))
                                                                     (Prims.of_int (11))
-                                                                    (Prims.of_int (475))
+                                                                    (Prims.of_int (478))
                                                                     (Prims.of_int (38)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -3983,17 +3988,17 @@ let rec (erase_ghost_subterms :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (476))
+                                                                    (Prims.of_int (479))
                                                                     (Prims.of_int (22))
-                                                                    (Prims.of_int (476))
+                                                                    (Prims.of_int (479))
                                                                     (Prims.of_int (52)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (477))
+                                                                    (Prims.of_int (480))
                                                                     (Prims.of_int (11))
-                                                                    (Prims.of_int (477))
+                                                                    (Prims.of_int (480))
                                                                     (Prims.of_int (50)))))
                                                                     (Obj.magic
                                                                     (open_erase_close
@@ -4033,17 +4038,17 @@ let rec (erase_ghost_subterms :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (480))
+                                                                    (Prims.of_int (483))
                                                                     (Prims.of_int (18))
-                                                                    (Prims.of_int (480))
+                                                                    (Prims.of_int (483))
                                                                     (Prims.of_int (46)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (480))
+                                                                    (Prims.of_int (483))
                                                                     (Prims.of_int (49))
-                                                                    (Prims.of_int (482))
+                                                                    (Prims.of_int (485))
                                                                     (Prims.of_int (43)))))
                                                                     (Obj.magic
                                                                     (erase_ghost_subterms
@@ -4058,17 +4063,17 @@ let rec (erase_ghost_subterms :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (481))
+                                                                    (Prims.of_int (484))
                                                                     (Prims.of_int (18))
-                                                                    (Prims.of_int (481))
+                                                                    (Prims.of_int (484))
                                                                     (Prims.of_int (46)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (482))
+                                                                    (Prims.of_int (485))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (482))
+                                                                    (Prims.of_int (485))
                                                                     (Prims.of_int (43)))))
                                                                     (Obj.magic
                                                                     (erase_ghost_subterms
@@ -4108,17 +4113,17 @@ let rec (erase_ghost_subterms :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (485))
+                                                                    (Prims.of_int (488))
                                                                     (Prims.of_int (16))
-                                                                    (Prims.of_int (485))
+                                                                    (Prims.of_int (488))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (486))
+                                                                    (Prims.of_int (489))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (486))
+                                                                    (Prims.of_int (489))
                                                                     (Prims.of_int (42)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Util.map
@@ -4161,17 +4166,17 @@ let rec (erase_ghost_subterms :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (489))
+                                                                    (Prims.of_int (492))
                                                                     (Prims.of_int (22))
-                                                                    (Prims.of_int (489))
+                                                                    (Prims.of_int (492))
                                                                     (Prims.of_int (54)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (489))
+                                                                    (Prims.of_int (492))
                                                                     (Prims.of_int (57))
-                                                                    (Prims.of_int (491))
+                                                                    (Prims.of_int (494))
                                                                     (Prims.of_int (66)))))
                                                                     (Obj.magic
                                                                     (erase_ghost_subterms
@@ -4188,17 +4193,17 @@ let rec (erase_ghost_subterms :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (490))
+                                                                    (Prims.of_int (493))
                                                                     (Prims.of_int (17))
-                                                                    (Prims.of_int (490))
+                                                                    (Prims.of_int (493))
                                                                     (Prims.of_int (44)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (491))
+                                                                    (Prims.of_int (494))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (491))
+                                                                    (Prims.of_int (494))
                                                                     (Prims.of_int (66)))))
                                                                     (Obj.magic
                                                                     (erase_ghost_subterms
@@ -4246,17 +4251,17 @@ let rec (erase_ghost_subterms :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (494))
+                                                                    (Prims.of_int (497))
                                                                     (Prims.of_int (18))
-                                                                    (Prims.of_int (494))
+                                                                    (Prims.of_int (497))
                                                                     (Prims.of_int (46)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (494))
+                                                                    (Prims.of_int (497))
                                                                     (Prims.of_int (49))
-                                                                    (Prims.of_int (496))
+                                                                    (Prims.of_int (499))
                                                                     (Prims.of_int (61)))))
                                                                     (Obj.magic
                                                                     (erase_ghost_subterms
@@ -4271,17 +4276,17 @@ let rec (erase_ghost_subterms :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (495))
+                                                                    (Prims.of_int (498))
                                                                     (Prims.of_int (18))
-                                                                    (Prims.of_int (495))
+                                                                    (Prims.of_int (498))
                                                                     (Prims.of_int (46)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (496))
+                                                                    (Prims.of_int (499))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (496))
+                                                                    (Prims.of_int (499))
                                                                     (Prims.of_int (61)))))
                                                                     (Obj.magic
                                                                     (erase_ghost_subterms
@@ -4325,17 +4330,17 @@ let rec (erase_ghost_subterms :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (499))
+                                                                    (Prims.of_int (502))
                                                                     (Prims.of_int (17))
-                                                                    (Prims.of_int (499))
+                                                                    (Prims.of_int (502))
                                                                     (Prims.of_int (47)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (500))
+                                                                    (Prims.of_int (503))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (500))
+                                                                    (Prims.of_int (503))
                                                                     (Prims.of_int (54)))))
                                                                     (Obj.magic
                                                                     (open_erase_close
@@ -4376,17 +4381,17 @@ let rec (erase_ghost_subterms :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (503))
+                                                                    (Prims.of_int (506))
                                                                     (Prims.of_int (17))
-                                                                    (Prims.of_int (503))
+                                                                    (Prims.of_int (506))
                                                                     (Prims.of_int (47)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (504))
+                                                                    (Prims.of_int (507))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (504))
+                                                                    (Prims.of_int (507))
                                                                     (Prims.of_int (67)))))
                                                                     (Obj.magic
                                                                     (open_erase_close
@@ -4411,6 +4416,14 @@ let rec (erase_ghost_subterms :
                                                                     = body1
                                                                     }))))
                                                                     | 
+                                                                    Pulse_Syntax_Base.Tm_Unreachable
+                                                                    ->
+                                                                    Obj.repr
+                                                                    (FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___2 ->
+                                                                    p))
+                                                                    | 
                                                                     uu___2 ->
                                                                     Obj.repr
                                                                     (FStar_Tactics_V2_Derived.fail
@@ -4429,13 +4442,13 @@ and (erase_ghost_subterms_branch :
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Extract.Main.fst"
-                 (Prims.of_int (510)) (Prims.of_int (18))
-                 (Prims.of_int (510)) (Prims.of_int (19)))))
+                 (Prims.of_int (515)) (Prims.of_int (18))
+                 (Prims.of_int (515)) (Prims.of_int (19)))))
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Extract.Main.fst"
-                 (Prims.of_int (509)) (Prims.of_int (67))
-                 (Prims.of_int (514)) (Prims.of_int (62)))))
+                 (Prims.of_int (514)) (Prims.of_int (67))
+                 (Prims.of_int (519)) (Prims.of_int (62)))))
         (FStar_Tactics_Effect.lift_div_tac (fun uu___ -> b))
         (fun uu___ ->
            (fun uu___ ->
@@ -4446,13 +4459,13 @@ and (erase_ghost_subterms_branch :
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Extract.Main.fst"
-                                (Prims.of_int (511)) (Prims.of_int (17))
-                                (Prims.of_int (511)) (Prims.of_int (37)))))
+                                (Prims.of_int (516)) (Prims.of_int (17))
+                                (Prims.of_int (516)) (Prims.of_int (37)))))
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Extract.Main.fst"
-                                (Prims.of_int (510)) (Prims.of_int (22))
-                                (Prims.of_int (514)) (Prims.of_int (62)))))
+                                (Prims.of_int (515)) (Prims.of_int (22))
+                                (Prims.of_int (519)) (Prims.of_int (62)))))
                        (Obj.magic (extend_env_pat g pat))
                        (fun uu___1 ->
                           (fun uu___1 ->
@@ -4464,17 +4477,17 @@ and (erase_ghost_subterms_branch :
                                          (Obj.magic
                                             (FStar_Range.mk_range
                                                "Pulse.Extract.Main.fst"
-                                               (Prims.of_int (512))
+                                               (Prims.of_int (517))
                                                (Prims.of_int (13))
-                                               (Prims.of_int (512))
+                                               (Prims.of_int (517))
                                                (Prims.of_int (56)))))
                                       (FStar_Sealed.seal
                                          (Obj.magic
                                             (FStar_Range.mk_range
                                                "Pulse.Extract.Main.fst"
-                                               (Prims.of_int (512))
+                                               (Prims.of_int (517))
                                                (Prims.of_int (59))
-                                               (Prims.of_int (514))
+                                               (Prims.of_int (519))
                                                (Prims.of_int (62)))))
                                       (FStar_Tactics_Effect.lift_div_tac
                                          (fun uu___3 ->
@@ -4488,17 +4501,17 @@ and (erase_ghost_subterms_branch :
                                                     (Obj.magic
                                                        (FStar_Range.mk_range
                                                           "Pulse.Extract.Main.fst"
-                                                          (Prims.of_int (513))
+                                                          (Prims.of_int (518))
                                                           (Prims.of_int (13))
-                                                          (Prims.of_int (513))
+                                                          (Prims.of_int (518))
                                                           (Prims.of_int (40)))))
                                                  (FStar_Sealed.seal
                                                     (Obj.magic
                                                        (FStar_Range.mk_range
                                                           "Pulse.Extract.Main.fst"
-                                                          (Prims.of_int (514))
+                                                          (Prims.of_int (519))
                                                           (Prims.of_int (2))
-                                                          (Prims.of_int (514))
+                                                          (Prims.of_int (519))
                                                           (Prims.of_int (62)))))
                                                  (Obj.magic
                                                     (erase_ghost_subterms g1
@@ -4525,12 +4538,12 @@ let rec (extract :
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Extract.Main.fst"
-                 (Prims.of_int (518)) (Prims.of_int (24))
-                 (Prims.of_int (518)) (Prims.of_int (48)))))
+                 (Prims.of_int (523)) (Prims.of_int (24))
+                 (Prims.of_int (523)) (Prims.of_int (48)))))
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Extract.Main.fst"
-                 (Prims.of_int (519)) (Prims.of_int (4)) (Prims.of_int (652))
+                 (Prims.of_int (524)) (Prims.of_int (4)) (Prims.of_int (661))
                  (Prims.of_int (7)))))
         (FStar_Tactics_Effect.lift_div_tac
            (fun uu___ ->
@@ -4543,13 +4556,13 @@ let rec (extract :
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Extract.Main.fst"
-                            (Prims.of_int (519)) (Prims.of_int (4))
-                            (Prims.of_int (521)) (Prims.of_int (36)))))
+                            (Prims.of_int (524)) (Prims.of_int (4))
+                            (Prims.of_int (526)) (Prims.of_int (36)))))
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Extract.Main.fst"
-                            (Prims.of_int (522)) (Prims.of_int (4))
-                            (Prims.of_int (652)) (Prims.of_int (7)))))
+                            (Prims.of_int (527)) (Prims.of_int (4))
+                            (Prims.of_int (661)) (Prims.of_int (7)))))
                    (Obj.magic
                       (debug g
                          (fun uu___ ->
@@ -4558,17 +4571,17 @@ let rec (extract :
                                  (Obj.magic
                                     (FStar_Range.mk_range
                                        "Pulse.Extract.Main.fst"
-                                       (Prims.of_int (521))
+                                       (Prims.of_int (526))
                                        (Prims.of_int (14))
-                                       (Prims.of_int (521))
+                                       (Prims.of_int (526))
                                        (Prims.of_int (35)))))
                               (FStar_Sealed.seal
                                  (Obj.magic
                                     (FStar_Range.mk_range
                                        "Pulse.Extract.Main.fst"
-                                       (Prims.of_int (519))
+                                       (Prims.of_int (524))
                                        (Prims.of_int (22))
-                                       (Prims.of_int (521))
+                                       (Prims.of_int (526))
                                        (Prims.of_int (35)))))
                               (Obj.magic
                                  (Pulse_Syntax_Printer.st_term_to_string p))
@@ -4580,17 +4593,17 @@ let rec (extract :
                                             (Obj.magic
                                                (FStar_Range.mk_range
                                                   "Pulse.Extract.Main.fst"
-                                                  (Prims.of_int (519))
+                                                  (Prims.of_int (524))
                                                   (Prims.of_int (22))
-                                                  (Prims.of_int (521))
+                                                  (Prims.of_int (526))
                                                   (Prims.of_int (35)))))
                                          (FStar_Sealed.seal
                                             (Obj.magic
                                                (FStar_Range.mk_range
                                                   "Pulse.Extract.Main.fst"
-                                                  (Prims.of_int (519))
+                                                  (Prims.of_int (524))
                                                   (Prims.of_int (22))
-                                                  (Prims.of_int (521))
+                                                  (Prims.of_int (526))
                                                   (Prims.of_int (35)))))
                                          (Obj.magic
                                             (FStar_Tactics_Effect.tac_bind
@@ -4598,9 +4611,9 @@ let rec (extract :
                                                   (Obj.magic
                                                      (FStar_Range.mk_range
                                                         "Pulse.Extract.Main.fst"
-                                                        (Prims.of_int (520))
+                                                        (Prims.of_int (525))
                                                         (Prims.of_int (14))
-                                                        (Prims.of_int (520))
+                                                        (Prims.of_int (525))
                                                         (Prims.of_int (41)))))
                                                (FStar_Sealed.seal
                                                   (Obj.magic
@@ -4636,17 +4649,17 @@ let rec (extract :
                                  (Obj.magic
                                     (FStar_Range.mk_range
                                        "Pulse.Extract.Main.fst"
-                                       (Prims.of_int (522))
+                                       (Prims.of_int (527))
                                        (Prims.of_int (7))
-                                       (Prims.of_int (522))
+                                       (Prims.of_int (527))
                                        (Prims.of_int (20)))))
                               (FStar_Sealed.seal
                                  (Obj.magic
                                     (FStar_Range.mk_range
                                        "Pulse.Extract.Main.fst"
-                                       (Prims.of_int (522))
+                                       (Prims.of_int (527))
                                        (Prims.of_int (4))
-                                       (Prims.of_int (652))
+                                       (Prims.of_int (661))
                                        (Prims.of_int (7)))))
                               (Obj.magic (is_erasable p))
                               (fun uu___1 ->
@@ -4700,17 +4713,17 @@ let rec (extract :
                                                         (Obj.magic
                                                            (FStar_Range.mk_range
                                                               "Pulse.Extract.Main.fst"
-                                                              (Prims.of_int (533))
+                                                              (Prims.of_int (538))
                                                               (Prims.of_int (37))
-                                                              (Prims.of_int (533))
+                                                              (Prims.of_int (538))
                                                               (Prims.of_int (51)))))
                                                      (FStar_Sealed.seal
                                                         (Obj.magic
                                                            (FStar_Range.mk_range
                                                               "Pulse.Extract.Main.fst"
-                                                              (Prims.of_int (532))
-                                                              (Prims.of_int (32))
                                                               (Prims.of_int (537))
+                                                              (Prims.of_int (32))
+                                                              (Prims.of_int (542))
                                                               (Prims.of_int (23)))))
                                                      (Obj.magic
                                                         (extend_env g b))
@@ -4726,18 +4739,18 @@ let rec (extract :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (534))
+                                                                    (Prims.of_int (539))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (534))
+                                                                    (Prims.of_int (539))
                                                                     (Prims.of_int (47)))))
                                                                     (
                                                                     FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (534))
+                                                                    (Prims.of_int (539))
                                                                     (Prims.of_int (50))
-                                                                    (Prims.of_int (537))
+                                                                    (Prims.of_int (542))
                                                                     (Prims.of_int (23)))))
                                                                     (
                                                                     FStar_Tactics_Effect.lift_div_tac
@@ -4757,17 +4770,17 @@ let rec (extract :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (535))
+                                                                    (Prims.of_int (540))
                                                                     (Prims.of_int (22))
-                                                                    (Prims.of_int (535))
+                                                                    (Prims.of_int (540))
                                                                     (Prims.of_int (36)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (534))
+                                                                    (Prims.of_int (539))
                                                                     (Prims.of_int (50))
-                                                                    (Prims.of_int (537))
+                                                                    (Prims.of_int (542))
                                                                     (Prims.of_int (23)))))
                                                                     (Obj.magic
                                                                     (extract
@@ -4806,17 +4819,17 @@ let rec (extract :
                                                         (Obj.magic
                                                            (FStar_Range.mk_range
                                                               "Pulse.Extract.Main.fst"
-                                                              (Prims.of_int (540))
+                                                              (Prims.of_int (545))
                                                               (Prims.of_int (8))
-                                                              (Prims.of_int (540))
+                                                              (Prims.of_int (545))
                                                               (Prims.of_int (29)))))
                                                      (FStar_Sealed.seal
                                                         (Obj.magic
                                                            (FStar_Range.mk_range
                                                               "Pulse.Extract.Main.fst"
-                                                              (Prims.of_int (540))
+                                                              (Prims.of_int (545))
                                                               (Prims.of_int (8))
-                                                              (Prims.of_int (541))
+                                                              (Prims.of_int (546))
                                                               (Prims.of_int (18)))))
                                                      (Obj.magic
                                                         (term_as_mlexpr g
@@ -4840,17 +4853,17 @@ let rec (extract :
                                                         (Obj.magic
                                                            (FStar_Range.mk_range
                                                               "Pulse.Extract.Main.fst"
-                                                              (Prims.of_int (544))
+                                                              (Prims.of_int (549))
                                                               (Prims.of_int (14))
-                                                              (Prims.of_int (544))
+                                                              (Prims.of_int (549))
                                                               (Prims.of_int (37)))))
                                                      (FStar_Sealed.seal
                                                         (Obj.magic
                                                            (FStar_Range.mk_range
                                                               "Pulse.Extract.Main.fst"
-                                                              (Prims.of_int (543))
+                                                              (Prims.of_int (548))
                                                               (Prims.of_int (34))
-                                                              (Prims.of_int (552))
+                                                              (Prims.of_int (557))
                                                               (Prims.of_int (7)))))
                                                      (Obj.magic
                                                         (maybe_inline g head
@@ -4867,18 +4880,18 @@ let rec (extract :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (546))
+                                                                    (Prims.of_int (551))
                                                                     (Prims.of_int (21))
-                                                                    (Prims.of_int (546))
+                                                                    (Prims.of_int (551))
                                                                     (Prims.of_int (42)))))
                                                                     (
                                                                     FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (546))
+                                                                    (Prims.of_int (551))
                                                                     (Prims.of_int (45))
-                                                                    (Prims.of_int (548))
+                                                                    (Prims.of_int (553))
                                                                     (Prims.of_int (42)))))
                                                                     (
                                                                     Obj.magic
@@ -4895,17 +4908,17 @@ let rec (extract :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (547))
+                                                                    (Prims.of_int (552))
                                                                     (Prims.of_int (20))
-                                                                    (Prims.of_int (547))
+                                                                    (Prims.of_int (552))
                                                                     (Prims.of_int (40)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (548))
+                                                                    (Prims.of_int (553))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (548))
+                                                                    (Prims.of_int (553))
                                                                     (Prims.of_int (42)))))
                                                                     (Obj.magic
                                                                     (term_as_mlexpr
@@ -4929,18 +4942,18 @@ let rec (extract :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (550))
+                                                                    (Prims.of_int (555))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (550))
+                                                                    (Prims.of_int (555))
                                                                     (Prims.of_int (84)))))
                                                                     (
                                                                     FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (551))
+                                                                    (Prims.of_int (556))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (551))
+                                                                    (Prims.of_int (556))
                                                                     (Prims.of_int (21)))))
                                                                     (
                                                                     Obj.magic
@@ -4952,9 +4965,9 @@ let rec (extract :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (550))
+                                                                    (Prims.of_int (555))
                                                                     (Prims.of_int (62))
-                                                                    (Prims.of_int (550))
+                                                                    (Prims.of_int (555))
                                                                     (Prims.of_int (83)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -5002,17 +5015,17 @@ let rec (extract :
                                                         (Obj.magic
                                                            (FStar_Range.mk_range
                                                               "Pulse.Extract.Main.fst"
-                                                              (Prims.of_int (555))
+                                                              (Prims.of_int (560))
                                                               (Prims.of_int (11))
-                                                              (Prims.of_int (555))
+                                                              (Prims.of_int (560))
                                                               (Prims.of_int (27)))))
                                                      (FStar_Sealed.seal
                                                         (Obj.magic
                                                            (FStar_Range.mk_range
                                                               "Pulse.Extract.Main.fst"
-                                                              (Prims.of_int (555))
+                                                              (Prims.of_int (560))
                                                               (Prims.of_int (8))
-                                                              (Prims.of_int (571))
+                                                              (Prims.of_int (576))
                                                               (Prims.of_int (9)))))
                                                      (Obj.magic
                                                         (is_erasable head))
@@ -5026,17 +5039,17 @@ let rec (extract :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (557))
+                                                                    (Prims.of_int (562))
                                                                     (Prims.of_int (21))
-                                                                    (Prims.of_int (557))
+                                                                    (Prims.of_int (562))
                                                                     (Prims.of_int (61)))))
                                                                   (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (558))
+                                                                    (Prims.of_int (563))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (561))
+                                                                    (Prims.of_int (566))
                                                                     (Prims.of_int (24)))))
                                                                   (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -5057,17 +5070,17 @@ let rec (extract :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (558))
+                                                                    (Prims.of_int (563))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (560))
+                                                                    (Prims.of_int (565))
                                                                     (Prims.of_int (55)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (561))
+                                                                    (Prims.of_int (566))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (561))
+                                                                    (Prims.of_int (566))
                                                                     (Prims.of_int (24)))))
                                                                     (Obj.magic
                                                                     (debug g
@@ -5078,17 +5091,17 @@ let rec (extract :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (560))
+                                                                    (Prims.of_int (565))
                                                                     (Prims.of_int (30))
-                                                                    (Prims.of_int (560))
+                                                                    (Prims.of_int (565))
                                                                     (Prims.of_int (54)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (558))
+                                                                    (Prims.of_int (563))
                                                                     (Prims.of_int (28))
-                                                                    (Prims.of_int (560))
+                                                                    (Prims.of_int (565))
                                                                     (Prims.of_int (54)))))
                                                                     (Obj.magic
                                                                     (Pulse_Syntax_Printer.st_term_to_string
@@ -5103,17 +5116,17 @@ let rec (extract :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (558))
+                                                                    (Prims.of_int (563))
                                                                     (Prims.of_int (28))
-                                                                    (Prims.of_int (560))
+                                                                    (Prims.of_int (565))
                                                                     (Prims.of_int (54)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (558))
+                                                                    (Prims.of_int (563))
                                                                     (Prims.of_int (28))
-                                                                    (Prims.of_int (560))
+                                                                    (Prims.of_int (565))
                                                                     (Prims.of_int (54)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -5121,9 +5134,9 @@ let rec (extract :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (559))
+                                                                    (Prims.of_int (564))
                                                                     (Prims.of_int (30))
-                                                                    (Prims.of_int (559))
+                                                                    (Prims.of_int (564))
                                                                     (Prims.of_int (54)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -5174,17 +5187,17 @@ let rec (extract :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (564))
+                                                                    (Prims.of_int (569))
                                                                     (Prims.of_int (24))
-                                                                    (Prims.of_int (564))
+                                                                    (Prims.of_int (569))
                                                                     (Prims.of_int (38)))))
                                                                   (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (563))
+                                                                    (Prims.of_int (568))
                                                                     (Prims.of_int (13))
-                                                                    (Prims.of_int (571))
+                                                                    (Prims.of_int (576))
                                                                     (Prims.of_int (9)))))
                                                                   (Obj.magic
                                                                     (extract
@@ -5205,17 +5218,17 @@ let rec (extract :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (565))
+                                                                    (Prims.of_int (570))
                                                                     (Prims.of_int (39))
-                                                                    (Prims.of_int (565))
+                                                                    (Prims.of_int (570))
                                                                     (Prims.of_int (58)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (564))
+                                                                    (Prims.of_int (569))
                                                                     (Prims.of_int (41))
-                                                                    (Prims.of_int (570))
+                                                                    (Prims.of_int (575))
                                                                     (Prims.of_int (49)))))
                                                                     (Obj.magic
                                                                     (extend_env
@@ -5237,17 +5250,17 @@ let rec (extract :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (566))
+                                                                    (Prims.of_int (571))
                                                                     (Prims.of_int (21))
-                                                                    (Prims.of_int (566))
+                                                                    (Prims.of_int (571))
                                                                     (Prims.of_int (49)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (566))
+                                                                    (Prims.of_int (571))
                                                                     (Prims.of_int (52))
-                                                                    (Prims.of_int (570))
+                                                                    (Prims.of_int (575))
                                                                     (Prims.of_int (49)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -5265,17 +5278,17 @@ let rec (extract :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (567))
+                                                                    (Prims.of_int (572))
                                                                     (Prims.of_int (24))
-                                                                    (Prims.of_int (567))
+                                                                    (Prims.of_int (572))
                                                                     (Prims.of_int (38)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (566))
+                                                                    (Prims.of_int (571))
                                                                     (Prims.of_int (52))
-                                                                    (Prims.of_int (570))
+                                                                    (Prims.of_int (575))
                                                                     (Prims.of_int (49)))))
                                                                     (Obj.magic
                                                                     (extract
@@ -5321,17 +5334,17 @@ let rec (extract :
                                                         (Obj.magic
                                                            (FStar_Range.mk_range
                                                               "Pulse.Extract.Main.fst"
-                                                              (Prims.of_int (575))
+                                                              (Prims.of_int (580))
                                                               (Prims.of_int (19))
-                                                              (Prims.of_int (575))
+                                                              (Prims.of_int (580))
                                                               (Prims.of_int (40)))))
                                                      (FStar_Sealed.seal
                                                         (Obj.magic
                                                            (FStar_Range.mk_range
                                                               "Pulse.Extract.Main.fst"
-                                                              (Prims.of_int (575))
+                                                              (Prims.of_int (580))
                                                               (Prims.of_int (43))
-                                                              (Prims.of_int (581))
+                                                              (Prims.of_int (586))
                                                               (Prims.of_int (47)))))
                                                      (Obj.magic
                                                         (term_as_mlexpr g
@@ -5344,17 +5357,17 @@ let rec (extract :
                                                                    (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (576))
+                                                                    (Prims.of_int (581))
                                                                     (Prims.of_int (37))
-                                                                    (Prims.of_int (576))
+                                                                    (Prims.of_int (581))
                                                                     (Prims.of_int (56)))))
                                                                 (FStar_Sealed.seal
                                                                    (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (575))
+                                                                    (Prims.of_int (580))
                                                                     (Prims.of_int (43))
-                                                                    (Prims.of_int (581))
+                                                                    (Prims.of_int (586))
                                                                     (Prims.of_int (47)))))
                                                                 (Obj.magic
                                                                    (extend_env
@@ -5376,17 +5389,17 @@ let rec (extract :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (577))
+                                                                    (Prims.of_int (582))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (577))
+                                                                    (Prims.of_int (582))
                                                                     (Prims.of_int (47)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (577))
+                                                                    (Prims.of_int (582))
                                                                     (Prims.of_int (50))
-                                                                    (Prims.of_int (581))
+                                                                    (Prims.of_int (586))
                                                                     (Prims.of_int (47)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -5404,17 +5417,17 @@ let rec (extract :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (578))
+                                                                    (Prims.of_int (583))
                                                                     (Prims.of_int (22))
-                                                                    (Prims.of_int (578))
+                                                                    (Prims.of_int (583))
                                                                     (Prims.of_int (36)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (577))
+                                                                    (Prims.of_int (582))
                                                                     (Prims.of_int (50))
-                                                                    (Prims.of_int (581))
+                                                                    (Prims.of_int (586))
                                                                     (Prims.of_int (47)))))
                                                                     (Obj.magic
                                                                     (extract
@@ -5459,17 +5472,17 @@ let rec (extract :
                                                         (Obj.magic
                                                            (FStar_Range.mk_range
                                                               "Pulse.Extract.Main.fst"
-                                                              (Prims.of_int (584))
+                                                              (Prims.of_int (589))
                                                               (Prims.of_int (16))
-                                                              (Prims.of_int (584))
+                                                              (Prims.of_int (589))
                                                               (Prims.of_int (34)))))
                                                      (FStar_Sealed.seal
                                                         (Obj.magic
                                                            (FStar_Range.mk_range
                                                               "Pulse.Extract.Main.fst"
-                                                              (Prims.of_int (584))
+                                                              (Prims.of_int (589))
                                                               (Prims.of_int (37))
-                                                              (Prims.of_int (587))
+                                                              (Prims.of_int (592))
                                                               (Prims.of_int (49)))))
                                                      (Obj.magic
                                                         (term_as_mlexpr g b))
@@ -5481,17 +5494,17 @@ let rec (extract :
                                                                    (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (585))
+                                                                    (Prims.of_int (590))
                                                                     (Prims.of_int (23))
-                                                                    (Prims.of_int (585))
+                                                                    (Prims.of_int (590))
                                                                     (Prims.of_int (38)))))
                                                                 (FStar_Sealed.seal
                                                                    (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (584))
+                                                                    (Prims.of_int (589))
                                                                     (Prims.of_int (37))
-                                                                    (Prims.of_int (587))
+                                                                    (Prims.of_int (592))
                                                                     (Prims.of_int (49)))))
                                                                 (Obj.magic
                                                                    (extract g
@@ -5512,17 +5525,17 @@ let rec (extract :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (586))
+                                                                    (Prims.of_int (591))
                                                                     (Prims.of_int (23))
-                                                                    (Prims.of_int (586))
+                                                                    (Prims.of_int (591))
                                                                     (Prims.of_int (38)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (585))
+                                                                    (Prims.of_int (590))
                                                                     (Prims.of_int (41))
-                                                                    (Prims.of_int (587))
+                                                                    (Prims.of_int (592))
                                                                     (Prims.of_int (49)))))
                                                                     (Obj.magic
                                                                     (extract
@@ -5557,17 +5570,17 @@ let rec (extract :
                                                         (Obj.magic
                                                            (FStar_Range.mk_range
                                                               "Pulse.Extract.Main.fst"
-                                                              (Prims.of_int (590))
+                                                              (Prims.of_int (595))
                                                               (Prims.of_int (17))
-                                                              (Prims.of_int (590))
+                                                              (Prims.of_int (595))
                                                               (Prims.of_int (36)))))
                                                      (FStar_Sealed.seal
                                                         (Obj.magic
                                                            (FStar_Range.mk_range
                                                               "Pulse.Extract.Main.fst"
-                                                              (Prims.of_int (590))
+                                                              (Prims.of_int (595))
                                                               (Prims.of_int (39))
-                                                              (Prims.of_int (602))
+                                                              (Prims.of_int (607))
                                                               (Prims.of_int (38)))))
                                                      (Obj.magic
                                                         (term_as_mlexpr g sc))
@@ -5579,17 +5592,17 @@ let rec (extract :
                                                                    (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (591))
+                                                                    (Prims.of_int (596))
                                                                     (Prims.of_int (41))
-                                                                    (Prims.of_int (599))
+                                                                    (Prims.of_int (604))
                                                                     (Prims.of_int (19)))))
                                                                 (FStar_Sealed.seal
                                                                    (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (600))
+                                                                    (Prims.of_int (605))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (602))
+                                                                    (Prims.of_int (607))
                                                                     (Prims.of_int (38)))))
                                                                 (FStar_Tactics_Effect.lift_div_tac
                                                                    (fun
@@ -5606,17 +5619,17 @@ let rec (extract :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (592))
+                                                                    (Prims.of_int (597))
                                                                     (Prims.of_int (27))
-                                                                    (Prims.of_int (592))
+                                                                    (Prims.of_int (597))
                                                                     (Prims.of_int (48)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (591))
+                                                                    (Prims.of_int (596))
                                                                     (Prims.of_int (41))
-                                                                    (Prims.of_int (599))
+                                                                    (Prims.of_int (604))
                                                                     (Prims.of_int (19)))))
                                                                     (Obj.magic
                                                                     (extend_env_pat
@@ -5636,17 +5649,17 @@ let rec (extract :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (593))
+                                                                    (Prims.of_int (598))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (596))
+                                                                    (Prims.of_int (601))
                                                                     (Prims.of_int (21)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (596))
+                                                                    (Prims.of_int (601))
                                                                     (Prims.of_int (22))
-                                                                    (Prims.of_int (599))
+                                                                    (Prims.of_int (604))
                                                                     (Prims.of_int (19)))))
                                                                     (Obj.magic
                                                                     (debug g1
@@ -5657,9 +5670,9 @@ let rec (extract :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (600))
                                                                     (Prims.of_int (20))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (600))
                                                                     (Prims.of_int (65)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -5692,17 +5705,17 @@ let rec (extract :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (597))
+                                                                    (Prims.of_int (602))
                                                                     (Prims.of_int (21))
-                                                                    (Prims.of_int (597))
+                                                                    (Prims.of_int (602))
                                                                     (Prims.of_int (64)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (597))
+                                                                    (Prims.of_int (602))
                                                                     (Prims.of_int (67))
-                                                                    (Prims.of_int (599))
+                                                                    (Prims.of_int (604))
                                                                     (Prims.of_int (19)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -5719,17 +5732,17 @@ let rec (extract :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (598))
+                                                                    (Prims.of_int (603))
                                                                     (Prims.of_int (24))
-                                                                    (Prims.of_int (598))
+                                                                    (Prims.of_int (603))
                                                                     (Prims.of_int (38)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (597))
+                                                                    (Prims.of_int (602))
                                                                     (Prims.of_int (67))
-                                                                    (Prims.of_int (599))
+                                                                    (Prims.of_int (604))
                                                                     (Prims.of_int (19)))))
                                                                     (Obj.magic
                                                                     (extract
@@ -5761,17 +5774,17 @@ let rec (extract :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (601))
+                                                                    (Prims.of_int (606))
                                                                     (Prims.of_int (18))
-                                                                    (Prims.of_int (601))
+                                                                    (Prims.of_int (606))
                                                                     (Prims.of_int (42)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (602))
+                                                                    (Prims.of_int (607))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (602))
+                                                                    (Prims.of_int (607))
                                                                     (Prims.of_int (38)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Util.map
@@ -5804,17 +5817,17 @@ let rec (extract :
                                                         (Obj.magic
                                                            (FStar_Range.mk_range
                                                               "Pulse.Extract.Main.fst"
-                                                              (Prims.of_int (606))
+                                                              (Prims.of_int (611))
                                                               (Prims.of_int (27))
-                                                              (Prims.of_int (606))
+                                                              (Prims.of_int (611))
                                                               (Prims.of_int (46)))))
                                                      (FStar_Sealed.seal
                                                         (Obj.magic
                                                            (FStar_Range.mk_range
                                                               "Pulse.Extract.Main.fst"
-                                                              (Prims.of_int (605))
+                                                              (Prims.of_int (610))
                                                               (Prims.of_int (39))
-                                                              (Prims.of_int (611))
+                                                              (Prims.of_int (616))
                                                               (Prims.of_int (23)))))
                                                      (Obj.magic
                                                         (extract g condition))
@@ -5830,18 +5843,18 @@ let rec (extract :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (607))
+                                                                    (Prims.of_int (612))
                                                                     (Prims.of_int (22))
-                                                                    (Prims.of_int (607))
+                                                                    (Prims.of_int (612))
                                                                     (Prims.of_int (36)))))
                                                                     (
                                                                     FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (606))
-                                                                    (Prims.of_int (49))
                                                                     (Prims.of_int (611))
+                                                                    (Prims.of_int (49))
+                                                                    (Prims.of_int (616))
                                                                     (Prims.of_int (23)))))
                                                                     (
                                                                     Obj.magic
@@ -5899,17 +5912,17 @@ let rec (extract :
                                                         (Obj.magic
                                                            (FStar_Range.mk_range
                                                               "Pulse.Extract.Main.fst"
-                                                              (Prims.of_int (614))
+                                                              (Prims.of_int (619))
                                                               (Prims.of_int (23))
-                                                              (Prims.of_int (614))
+                                                              (Prims.of_int (619))
                                                               (Prims.of_int (38)))))
                                                      (FStar_Sealed.seal
                                                         (Obj.magic
                                                            (FStar_Range.mk_range
                                                               "Pulse.Extract.Main.fst"
-                                                              (Prims.of_int (613))
+                                                              (Prims.of_int (618))
                                                               (Prims.of_int (34))
-                                                              (Prims.of_int (619))
+                                                              (Prims.of_int (624))
                                                               (Prims.of_int (23)))))
                                                      (Obj.magic
                                                         (extract g body1))
@@ -5925,18 +5938,18 @@ let rec (extract :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (615))
+                                                                    (Prims.of_int (620))
                                                                     (Prims.of_int (23))
-                                                                    (Prims.of_int (615))
+                                                                    (Prims.of_int (620))
                                                                     (Prims.of_int (38)))))
                                                                     (
                                                                     FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (614))
-                                                                    (Prims.of_int (41))
                                                                     (Prims.of_int (619))
+                                                                    (Prims.of_int (41))
+                                                                    (Prims.of_int (624))
                                                                     (Prims.of_int (23)))))
                                                                     (
                                                                     Obj.magic
@@ -5989,17 +6002,17 @@ let rec (extract :
                                                         (Obj.magic
                                                            (FStar_Range.mk_range
                                                               "Pulse.Extract.Main.fst"
-                                                              (Prims.of_int (622))
+                                                              (Prims.of_int (627))
                                                               (Prims.of_int (26))
-                                                              (Prims.of_int (622))
+                                                              (Prims.of_int (627))
                                                               (Prims.of_int (54)))))
                                                      (FStar_Sealed.seal
                                                         (Obj.magic
                                                            (FStar_Range.mk_range
                                                               "Pulse.Extract.Main.fst"
-                                                              (Prims.of_int (622))
+                                                              (Prims.of_int (627))
                                                               (Prims.of_int (57))
-                                                              (Prims.of_int (629))
+                                                              (Prims.of_int (634))
                                                               (Prims.of_int (47)))))
                                                      (Obj.magic
                                                         (term_as_mlexpr g
@@ -6012,17 +6025,17 @@ let rec (extract :
                                                                    (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (623))
+                                                                    (Prims.of_int (628))
                                                                     (Prims.of_int (37))
-                                                                    (Prims.of_int (623))
+                                                                    (Prims.of_int (628))
                                                                     (Prims.of_int (94)))))
                                                                 (FStar_Sealed.seal
                                                                    (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (622))
+                                                                    (Prims.of_int (627))
                                                                     (Prims.of_int (57))
-                                                                    (Prims.of_int (629))
+                                                                    (Prims.of_int (634))
                                                                     (Prims.of_int (47)))))
                                                                 (Obj.magic
                                                                    (extend_env
@@ -6052,17 +6065,17 @@ let rec (extract :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (624))
+                                                                    (Prims.of_int (629))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (624))
+                                                                    (Prims.of_int (629))
                                                                     (Prims.of_int (47)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (624))
-                                                                    (Prims.of_int (50))
                                                                     (Prims.of_int (629))
+                                                                    (Prims.of_int (50))
+                                                                    (Prims.of_int (634))
                                                                     (Prims.of_int (47)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -6080,17 +6093,17 @@ let rec (extract :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (625))
+                                                                    (Prims.of_int (630))
                                                                     (Prims.of_int (22))
-                                                                    (Prims.of_int (625))
+                                                                    (Prims.of_int (630))
                                                                     (Prims.of_int (36)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (624))
-                                                                    (Prims.of_int (50))
                                                                     (Prims.of_int (629))
+                                                                    (Prims.of_int (50))
+                                                                    (Prims.of_int (634))
                                                                     (Prims.of_int (47)))))
                                                                     (Obj.magic
                                                                     (extract
@@ -6143,17 +6156,17 @@ let rec (extract :
                                                         (Obj.magic
                                                            (FStar_Range.mk_range
                                                               "Pulse.Extract.Main.fst"
-                                                              (Prims.of_int (632))
+                                                              (Prims.of_int (637))
                                                               (Prims.of_int (26))
-                                                              (Prims.of_int (632))
+                                                              (Prims.of_int (637))
                                                               (Prims.of_int (54)))))
                                                      (FStar_Sealed.seal
                                                         (Obj.magic
                                                            (FStar_Range.mk_range
                                                               "Pulse.Extract.Main.fst"
-                                                              (Prims.of_int (632))
+                                                              (Prims.of_int (637))
                                                               (Prims.of_int (57))
-                                                              (Prims.of_int (645))
+                                                              (Prims.of_int (650))
                                                               (Prims.of_int (47)))))
                                                      (Obj.magic
                                                         (term_as_mlexpr g
@@ -6166,17 +6179,17 @@ let rec (extract :
                                                                    (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (633))
+                                                                    (Prims.of_int (638))
                                                                     (Prims.of_int (21))
-                                                                    (Prims.of_int (633))
+                                                                    (Prims.of_int (638))
                                                                     (Prims.of_int (44)))))
                                                                 (FStar_Sealed.seal
                                                                    (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (633))
+                                                                    (Prims.of_int (638))
                                                                     (Prims.of_int (47))
-                                                                    (Prims.of_int (645))
+                                                                    (Prims.of_int (650))
                                                                     (Prims.of_int (47)))))
                                                                 (Obj.magic
                                                                    (term_as_mlexpr
@@ -6192,17 +6205,17 @@ let rec (extract :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (634))
+                                                                    (Prims.of_int (639))
                                                                     (Prims.of_int (37))
-                                                                    (Prims.of_int (634))
+                                                                    (Prims.of_int (639))
                                                                     (Prims.of_int (94)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (633))
+                                                                    (Prims.of_int (638))
                                                                     (Prims.of_int (47))
-                                                                    (Prims.of_int (645))
+                                                                    (Prims.of_int (650))
                                                                     (Prims.of_int (47)))))
                                                                     (Obj.magic
                                                                     (extend_env
@@ -6232,17 +6245,17 @@ let rec (extract :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (635))
+                                                                    (Prims.of_int (640))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (635))
+                                                                    (Prims.of_int (640))
                                                                     (Prims.of_int (47)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (635))
+                                                                    (Prims.of_int (640))
                                                                     (Prims.of_int (50))
-                                                                    (Prims.of_int (645))
+                                                                    (Prims.of_int (650))
                                                                     (Prims.of_int (47)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -6260,17 +6273,17 @@ let rec (extract :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (636))
+                                                                    (Prims.of_int (641))
                                                                     (Prims.of_int (22))
-                                                                    (Prims.of_int (636))
+                                                                    (Prims.of_int (641))
                                                                     (Prims.of_int (36)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (635))
+                                                                    (Prims.of_int (640))
                                                                     (Prims.of_int (50))
-                                                                    (Prims.of_int (645))
+                                                                    (Prims.of_int (650))
                                                                     (Prims.of_int (47)))))
                                                                     (Obj.magic
                                                                     (extract
@@ -6318,6 +6331,19 @@ let rec (extract :
                                                   Pulse_Syntax_Base.returns_inv
                                                     = uu___4;_}
                                                 -> Obj.repr (extract g body)
+                                            | Pulse_Syntax_Base.Tm_Unreachable
+                                                ->
+                                                Obj.repr
+                                                  (FStar_Tactics_Effect.lift_div_tac
+                                                     (fun uu___3 ->
+                                                        ((Pulse_Extract_CompilerLib.mle_app
+                                                            (Pulse_Extract_CompilerLib.mle_name
+                                                               (["Pulse";
+                                                                "Lib";
+                                                                "Core"],
+                                                                 "unreachable"))
+                                                            [Pulse_Extract_CompilerLib.mle_unit]),
+                                                          Pulse_Extract_CompilerLib.e_tag_impure)))
                                             | Pulse_Syntax_Base.Tm_ProofHintWithBinders
                                                 {
                                                   Pulse_Syntax_Base.hint_type
@@ -6337,17 +6363,17 @@ let rec (extract :
                                                         (Obj.magic
                                                            (FStar_Range.mk_range
                                                               "Pulse.Extract.Main.fst"
-                                                              (Prims.of_int (651))
+                                                              (Prims.of_int (659))
                                                               (Prims.of_int (30))
-                                                              (Prims.of_int (651))
+                                                              (Prims.of_int (659))
                                                               (Prims.of_int (149)))))
                                                      (FStar_Sealed.seal
                                                         (Obj.magic
                                                            (FStar_Range.mk_range
                                                               "Pulse.Extract.Main.fst"
-                                                              (Prims.of_int (651))
+                                                              (Prims.of_int (659))
                                                               (Prims.of_int (22))
-                                                              (Prims.of_int (651))
+                                                              (Prims.of_int (659))
                                                               (Prims.of_int (149)))))
                                                      (Obj.magic
                                                         (FStar_Tactics_Effect.tac_bind
@@ -6355,17 +6381,17 @@ let rec (extract :
                                                               (Obj.magic
                                                                  (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (651))
+                                                                    (Prims.of_int (659))
                                                                     (Prims.of_int (50))
-                                                                    (Prims.of_int (651))
+                                                                    (Prims.of_int (659))
                                                                     (Prims.of_int (148)))))
                                                            (FStar_Sealed.seal
                                                               (Obj.magic
                                                                  (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (651))
+                                                                    (Prims.of_int (659))
                                                                     (Prims.of_int (30))
-                                                                    (Prims.of_int (651))
+                                                                    (Prims.of_int (659))
                                                                     (Prims.of_int (149)))))
                                                            (Obj.magic
                                                               (FStar_Tactics_Effect.tac_bind
@@ -6374,9 +6400,9 @@ let rec (extract :
                                                                     Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (651))
+                                                                    (Prims.of_int (659))
                                                                     (Prims.of_int (105))
-                                                                    (Prims.of_int (651))
+                                                                    (Prims.of_int (659))
                                                                     (Prims.of_int (147)))))
                                                                  (FStar_Sealed.seal
                                                                     (
@@ -6427,13 +6453,13 @@ let rec (generalize :
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Extract.Main.fst"
-                   (Prims.of_int (660)) (Prims.of_int (2))
-                   (Prims.of_int (660)) (Prims.of_int (84)))))
+                   (Prims.of_int (669)) (Prims.of_int (2))
+                   (Prims.of_int (669)) (Prims.of_int (84)))))
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Extract.Main.fst"
-                   (Prims.of_int (660)) (Prims.of_int (85))
-                   (Prims.of_int (697)) (Prims.of_int (20)))))
+                   (Prims.of_int (669)) (Prims.of_int (85))
+                   (Prims.of_int (706)) (Prims.of_int (20)))))
           (Obj.magic
              (debug g
                 (fun uu___ ->
@@ -6441,8 +6467,8 @@ let rec (generalize :
                      (FStar_Sealed.seal
                         (Obj.magic
                            (FStar_Range.mk_range "Pulse.Extract.Main.fst"
-                              (Prims.of_int (660)) (Prims.of_int (63))
-                              (Prims.of_int (660)) (Prims.of_int (83)))))
+                              (Prims.of_int (669)) (Prims.of_int (63))
+                              (Prims.of_int (669)) (Prims.of_int (83)))))
                      (FStar_Sealed.seal
                         (Obj.magic
                            (FStar_Range.mk_range "prims.fst"
@@ -6461,13 +6487,13 @@ let rec (generalize :
                      (FStar_Sealed.seal
                         (Obj.magic
                            (FStar_Range.mk_range "Pulse.Extract.Main.fst"
-                              (Prims.of_int (661)) (Prims.of_int (11))
-                              (Prims.of_int (661)) (Prims.of_int (25)))))
+                              (Prims.of_int (670)) (Prims.of_int (11))
+                              (Prims.of_int (670)) (Prims.of_int (25)))))
                      (FStar_Sealed.seal
                         (Obj.magic
                            (FStar_Range.mk_range "Pulse.Extract.Main.fst"
-                              (Prims.of_int (662)) (Prims.of_int (2))
-                              (Prims.of_int (697)) (Prims.of_int (20)))))
+                              (Prims.of_int (671)) (Prims.of_int (2))
+                              (Prims.of_int (706)) (Prims.of_int (20)))))
                      (FStar_Tactics_Effect.lift_div_tac
                         (fun uu___1 ->
                            FStar_Reflection_V2_Builtins.inspect_ln t))
@@ -6482,17 +6508,17 @@ let rec (generalize :
                                           (Obj.magic
                                              (FStar_Range.mk_range
                                                 "Pulse.Extract.Main.fst"
-                                                (Prims.of_int (664))
+                                                (Prims.of_int (673))
                                                 (Prims.of_int (25))
-                                                (Prims.of_int (664))
+                                                (Prims.of_int (673))
                                                 (Prims.of_int (43)))))
                                        (FStar_Sealed.seal
                                           (Obj.magic
                                              (FStar_Range.mk_range
                                                 "Pulse.Extract.Main.fst"
-                                                (Prims.of_int (663))
+                                                (Prims.of_int (672))
                                                 (Prims.of_int (21))
-                                                (Prims.of_int (695))
+                                                (Prims.of_int (704))
                                                 (Prims.of_int (20)))))
                                        (FStar_Tactics_Effect.lift_div_tac
                                           (fun uu___1 ->
@@ -6529,17 +6555,17 @@ let rec (generalize :
                                                               (Obj.magic
                                                                  (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (667))
+                                                                    (Prims.of_int (676))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (667))
+                                                                    (Prims.of_int (676))
                                                                     (Prims.of_int (37)))))
                                                            (FStar_Sealed.seal
                                                               (Obj.magic
                                                                  (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (667))
+                                                                    (Prims.of_int (676))
                                                                     (Prims.of_int (9))
-                                                                    (Prims.of_int (695))
+                                                                    (Prims.of_int (704))
                                                                     (Prims.of_int (20)))))
                                                            (FStar_Tactics_Effect.lift_div_tac
                                                               (fun uu___5 ->
@@ -6557,17 +6583,17 @@ let rec (generalize :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (668))
+                                                                    (Prims.of_int (677))
                                                                     (Prims.of_int (21))
-                                                                    (Prims.of_int (668))
+                                                                    (Prims.of_int (677))
                                                                     (Prims.of_int (37)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (669))
+                                                                    (Prims.of_int (678))
                                                                     (Prims.of_int (9))
-                                                                    (Prims.of_int (694))
+                                                                    (Prims.of_int (703))
                                                                     (Prims.of_int (73)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -6590,17 +6616,17 @@ let rec (generalize :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (671))
+                                                                    (Prims.of_int (680))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (671))
+                                                                    (Prims.of_int (680))
                                                                     (Prims.of_int (47)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (671))
+                                                                    (Prims.of_int (680))
                                                                     (Prims.of_int (50))
-                                                                    (Prims.of_int (693))
+                                                                    (Prims.of_int (702))
                                                                     (Prims.of_int (56)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -6616,17 +6642,17 @@ let rec (generalize :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (672))
+                                                                    (Prims.of_int (681))
                                                                     (Prims.of_int (23))
-                                                                    (Prims.of_int (672))
+                                                                    (Prims.of_int (681))
                                                                     (Prims.of_int (96)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (672))
+                                                                    (Prims.of_int (681))
                                                                     (Prims.of_int (100))
-                                                                    (Prims.of_int (693))
+                                                                    (Prims.of_int (702))
                                                                     (Prims.of_int (56)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -6653,17 +6679,17 @@ let rec (generalize :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (673))
+                                                                    (Prims.of_int (682))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (673))
+                                                                    (Prims.of_int (682))
                                                                     (Prims.of_int (45)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (673))
+                                                                    (Prims.of_int (682))
                                                                     (Prims.of_int (48))
-                                                                    (Prims.of_int (693))
+                                                                    (Prims.of_int (702))
                                                                     (Prims.of_int (56)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -6683,17 +6709,17 @@ let rec (generalize :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (675))
+                                                                    (Prims.of_int (684))
                                                                     (Prims.of_int (13))
-                                                                    (Prims.of_int (678))
+                                                                    (Prims.of_int (687))
                                                                     (Prims.of_int (21)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (678))
+                                                                    (Prims.of_int (687))
                                                                     (Prims.of_int (24))
-                                                                    (Prims.of_int (693))
+                                                                    (Prims.of_int (702))
                                                                     (Prims.of_int (56)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -6742,17 +6768,17 @@ let rec (generalize :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (679))
+                                                                    (Prims.of_int (688))
                                                                     (Prims.of_int (24))
-                                                                    (Prims.of_int (683))
+                                                                    (Prims.of_int (692))
                                                                     (Prims.of_int (12)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (683))
+                                                                    (Prims.of_int (692))
                                                                     (Prims.of_int (15))
-                                                                    (Prims.of_int (693))
+                                                                    (Prims.of_int (702))
                                                                     (Prims.of_int (56)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -6778,17 +6804,17 @@ let rec (generalize :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (684))
+                                                                    (Prims.of_int (693))
                                                                     (Prims.of_int (22))
-                                                                    (Prims.of_int (684))
+                                                                    (Prims.of_int (693))
                                                                     (Prims.of_int (51)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (684))
-                                                                    (Prims.of_int (54))
                                                                     (Prims.of_int (693))
+                                                                    (Prims.of_int (54))
+                                                                    (Prims.of_int (702))
                                                                     (Prims.of_int (56)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -6806,17 +6832,17 @@ let rec (generalize :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (686))
+                                                                    (Prims.of_int (695))
                                                                     (Prims.of_int (13))
-                                                                    (Prims.of_int (690))
+                                                                    (Prims.of_int (699))
                                                                     (Prims.of_int (50)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (690))
+                                                                    (Prims.of_int (699))
                                                                     (Prims.of_int (53))
-                                                                    (Prims.of_int (693))
+                                                                    (Prims.of_int (702))
                                                                     (Prims.of_int (56)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -6841,17 +6867,17 @@ let rec (generalize :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (691))
+                                                                    (Prims.of_int (700))
                                                                     (Prims.of_int (21))
-                                                                    (Prims.of_int (691))
+                                                                    (Prims.of_int (700))
                                                                     (Prims.of_int (54)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (691))
+                                                                    (Prims.of_int (700))
                                                                     (Prims.of_int (59))
-                                                                    (Prims.of_int (693))
+                                                                    (Prims.of_int (702))
                                                                     (Prims.of_int (56)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -6871,17 +6897,17 @@ let rec (generalize :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (692))
+                                                                    (Prims.of_int (701))
                                                                     (Prims.of_int (30))
-                                                                    (Prims.of_int (692))
+                                                                    (Prims.of_int (701))
                                                                     (Prims.of_int (46)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (691))
+                                                                    (Prims.of_int (700))
                                                                     (Prims.of_int (59))
-                                                                    (Prims.of_int (693))
+                                                                    (Prims.of_int (702))
                                                                     (Prims.of_int (56)))))
                                                                     (Obj.magic
                                                                     (generalize
@@ -6966,13 +6992,13 @@ let (is_recursive :
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Extract.Main.fst"
-                   (Prims.of_int (708)) (Prims.of_int (16))
-                   (Prims.of_int (708)) (Prims.of_int (38)))))
+                   (Prims.of_int (717)) (Prims.of_int (16))
+                   (Prims.of_int (717)) (Prims.of_int (38)))))
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Extract.Main.fst"
-                   (Prims.of_int (708)) (Prims.of_int (41))
-                   (Prims.of_int (730)) (Prims.of_int (39)))))
+                   (Prims.of_int (717)) (Prims.of_int (41))
+                   (Prims.of_int (739)) (Prims.of_int (39)))))
           (Obj.magic (Pulse_RuntimeUtils.get_attributes selt))
           (fun attrs ->
              FStar_Tactics_Effect.lift_div_tac
@@ -7051,17 +7077,17 @@ let rec (extract_recursive :
                                   (Obj.magic
                                      (FStar_Range.mk_range
                                         "Pulse.Extract.Main.fst"
-                                        (Prims.of_int (738))
+                                        (Prims.of_int (747))
                                         (Prims.of_int (37))
-                                        (Prims.of_int (738))
+                                        (Prims.of_int (747))
                                         (Prims.of_int (51)))))
                                (FStar_Sealed.seal
                                   (Obj.magic
                                      (FStar_Range.mk_range
                                         "Pulse.Extract.Main.fst"
-                                        (Prims.of_int (737))
+                                        (Prims.of_int (746))
                                         (Prims.of_int (19))
-                                        (Prims.of_int (742))
+                                        (Prims.of_int (751))
                                         (Prims.of_int (23)))))
                                (Obj.magic (extend_env g b))
                                (fun uu___2 ->
@@ -7074,17 +7100,17 @@ let rec (extract_recursive :
                                                  (Obj.magic
                                                     (FStar_Range.mk_range
                                                        "Pulse.Extract.Main.fst"
-                                                       (Prims.of_int (739))
+                                                       (Prims.of_int (748))
                                                        (Prims.of_int (19))
-                                                       (Prims.of_int (739))
+                                                       (Prims.of_int (748))
                                                        (Prims.of_int (47)))))
                                               (FStar_Sealed.seal
                                                  (Obj.magic
                                                     (FStar_Range.mk_range
                                                        "Pulse.Extract.Main.fst"
-                                                       (Prims.of_int (739))
+                                                       (Prims.of_int (748))
                                                        (Prims.of_int (50))
-                                                       (Prims.of_int (742))
+                                                       (Prims.of_int (751))
                                                        (Prims.of_int (23)))))
                                               (FStar_Tactics_Effect.lift_div_tac
                                                  (fun uu___3 ->
@@ -7098,17 +7124,17 @@ let rec (extract_recursive :
                                                             (Obj.magic
                                                                (FStar_Range.mk_range
                                                                   "Pulse.Extract.Main.fst"
-                                                                  (Prims.of_int (740))
+                                                                  (Prims.of_int (749))
                                                                   (Prims.of_int (22))
-                                                                  (Prims.of_int (740))
+                                                                  (Prims.of_int (749))
                                                                   (Prims.of_int (55)))))
                                                          (FStar_Sealed.seal
                                                             (Obj.magic
                                                                (FStar_Range.mk_range
                                                                   "Pulse.Extract.Main.fst"
-                                                                  (Prims.of_int (739))
+                                                                  (Prims.of_int (748))
                                                                   (Prims.of_int (50))
-                                                                  (Prims.of_int (742))
+                                                                  (Prims.of_int (751))
                                                                   (Prims.of_int (23)))))
                                                          (Obj.magic
                                                             (extract_recursive
@@ -7135,17 +7161,17 @@ let rec (extract_recursive :
                                   (Obj.magic
                                      (FStar_Range.mk_range
                                         "Pulse.Extract.Main.fst"
-                                        (Prims.of_int (744))
+                                        (Prims.of_int (753))
                                         (Prims.of_int (19))
-                                        (Prims.of_int (744))
+                                        (Prims.of_int (753))
                                         (Prims.of_int (106)))))
                                (FStar_Sealed.seal
                                   (Obj.magic
                                      (FStar_Range.mk_range
                                         "Pulse.Extract.Main.fst"
-                                        (Prims.of_int (744))
+                                        (Prims.of_int (753))
                                         (Prims.of_int (109))
-                                        (Prims.of_int (746))
+                                        (Prims.of_int (755))
                                         (Prims.of_int (17)))))
                                (FStar_Tactics_Effect.lift_div_tac
                                   (fun uu___2 ->
@@ -7165,17 +7191,17 @@ let rec (extract_recursive :
                                              (Obj.magic
                                                 (FStar_Range.mk_range
                                                    "Pulse.Extract.Main.fst"
-                                                   (Prims.of_int (745))
+                                                   (Prims.of_int (754))
                                                    (Prims.of_int (24))
-                                                   (Prims.of_int (745))
+                                                   (Prims.of_int (754))
                                                    (Prims.of_int (38)))))
                                           (FStar_Sealed.seal
                                              (Obj.magic
                                                 (FStar_Range.mk_range
                                                    "Pulse.Extract.Main.fst"
-                                                   (Prims.of_int (744))
+                                                   (Prims.of_int (753))
                                                    (Prims.of_int (109))
-                                                   (Prims.of_int (746))
+                                                   (Prims.of_int (755))
                                                    (Prims.of_int (17)))))
                                           (Obj.magic (extract g body1))
                                           (fun uu___2 ->
@@ -7208,13 +7234,13 @@ let extract_recursive_knot :
             (FStar_Sealed.seal
                (Obj.magic
                   (FStar_Range.mk_range "Pulse.Extract.Main.fst"
-                     (Prims.of_int (753)) (Prims.of_int (33))
-                     (Prims.of_int (753)) (Prims.of_int (63)))))
+                     (Prims.of_int (762)) (Prims.of_int (33))
+                     (Prims.of_int (762)) (Prims.of_int (63)))))
             (FStar_Sealed.seal
                (Obj.magic
                   (FStar_Range.mk_range "Pulse.Extract.Main.fst"
-                     (Prims.of_int (752)) (Prims.of_int (63))
-                     (Prims.of_int (766)) (Prims.of_int (29)))))
+                     (Prims.of_int (761)) (Prims.of_int (63))
+                     (Prims.of_int (775)) (Prims.of_int (29)))))
             (Obj.magic
                (generalize g knot_typ (FStar_Pervasives_Native.Some p)))
             (fun uu___ ->
@@ -7227,14 +7253,14 @@ let extract_recursive_knot :
                               (Obj.magic
                                  (FStar_Range.mk_range
                                     "Pulse.Extract.Main.fst"
-                                    (Prims.of_int (754)) (Prims.of_int (15))
-                                    (Prims.of_int (754)) (Prims.of_int (51)))))
+                                    (Prims.of_int (763)) (Prims.of_int (15))
+                                    (Prims.of_int (763)) (Prims.of_int (51)))))
                            (FStar_Sealed.seal
                               (Obj.magic
                                  (FStar_Range.mk_range
                                     "Pulse.Extract.Main.fst"
-                                    (Prims.of_int (754)) (Prims.of_int (54))
-                                    (Prims.of_int (766)) (Prims.of_int (29)))))
+                                    (Prims.of_int (763)) (Prims.of_int (54))
+                                    (Prims.of_int (775)) (Prims.of_int (29)))))
                            (FStar_Tactics_Effect.lift_div_tac
                               (fun uu___1 ->
                                  Pulse_Extract_CompilerLib.term_as_mlty
@@ -7247,17 +7273,17 @@ let extract_recursive_knot :
                                          (Obj.magic
                                             (FStar_Range.mk_range
                                                "Pulse.Extract.Main.fst"
-                                               (Prims.of_int (755))
+                                               (Prims.of_int (764))
                                                (Prims.of_int (34))
-                                               (Prims.of_int (755))
+                                               (Prims.of_int (764))
                                                (Prims.of_int (78)))))
                                       (FStar_Sealed.seal
                                          (Obj.magic
                                             (FStar_Range.mk_range
                                                "Pulse.Extract.Main.fst"
-                                               (Prims.of_int (754))
+                                               (Prims.of_int (763))
                                                (Prims.of_int (54))
-                                               (Prims.of_int (766))
+                                               (Prims.of_int (775))
                                                (Prims.of_int (29)))))
                                       (FStar_Tactics_Effect.lift_div_tac
                                          (fun uu___1 ->
@@ -7274,17 +7300,17 @@ let extract_recursive_knot :
                                                         (Obj.magic
                                                            (FStar_Range.mk_range
                                                               "Pulse.Extract.Main.fst"
-                                                              (Prims.of_int (756))
+                                                              (Prims.of_int (765))
                                                               (Prims.of_int (14))
-                                                              (Prims.of_int (756))
+                                                              (Prims.of_int (765))
                                                               (Prims.of_int (38)))))
                                                      (FStar_Sealed.seal
                                                         (Obj.magic
                                                            (FStar_Range.mk_range
                                                               "Pulse.Extract.Main.fst"
-                                                              (Prims.of_int (756))
+                                                              (Prims.of_int (765))
                                                               (Prims.of_int (43))
-                                                              (Prims.of_int (766))
+                                                              (Prims.of_int (775))
                                                               (Prims.of_int (29)))))
                                                      (FStar_Tactics_Effect.lift_div_tac
                                                         (fun uu___2 ->
@@ -7302,17 +7328,17 @@ let extract_recursive_knot :
                                                                    (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (757))
+                                                                    (Prims.of_int (766))
                                                                     (Prims.of_int (18))
-                                                                    (Prims.of_int (757))
+                                                                    (Prims.of_int (766))
                                                                     (Prims.of_int (49)))))
                                                                 (FStar_Sealed.seal
                                                                    (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (756))
+                                                                    (Prims.of_int (765))
                                                                     (Prims.of_int (43))
-                                                                    (Prims.of_int (766))
+                                                                    (Prims.of_int (775))
                                                                     (Prims.of_int (29)))))
                                                                 (Obj.magic
                                                                    (extract_recursive
@@ -7333,17 +7359,17 @@ let extract_recursive_knot :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (758))
+                                                                    (Prims.of_int (767))
                                                                     (Prims.of_int (17))
-                                                                    (Prims.of_int (762))
+                                                                    (Prims.of_int (771))
                                                                     (Prims.of_int (30)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (764))
+                                                                    (Prims.of_int (773))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (766))
+                                                                    (Prims.of_int (775))
                                                                     (Prims.of_int (29)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -7351,17 +7377,17 @@ let extract_recursive_knot :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (759))
+                                                                    (Prims.of_int (768))
                                                                     (Prims.of_int (17))
-                                                                    (Prims.of_int (759))
+                                                                    (Prims.of_int (768))
                                                                     (Prims.of_int (39)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (760))
+                                                                    (Prims.of_int (769))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (762))
+                                                                    (Prims.of_int (771))
                                                                     (Prims.of_int (30)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -7378,17 +7404,17 @@ let extract_recursive_knot :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (760))
+                                                                    (Prims.of_int (769))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (761))
+                                                                    (Prims.of_int (770))
                                                                     (Prims.of_int (63)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (762))
+                                                                    (Prims.of_int (771))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (762))
+                                                                    (Prims.of_int (771))
                                                                     (Prims.of_int (30)))))
                                                                     (if
                                                                     Prims.uu___is_Nil
@@ -7421,17 +7447,17 @@ let extract_recursive_knot :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (764))
+                                                                    (Prims.of_int (773))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (764))
+                                                                    (Prims.of_int (773))
                                                                     (Prims.of_int (96)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (766))
+                                                                    (Prims.of_int (775))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (766))
+                                                                    (Prims.of_int (775))
                                                                     (Prims.of_int (29)))))
                                                                     (Obj.magic
                                                                     (debug_
@@ -7487,13 +7513,13 @@ let (extract_pulse :
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Extract.Main.fst"
-                   (Prims.of_int (772)) (Prims.of_int (12))
-                   (Prims.of_int (772)) (Prims.of_int (52)))))
+                   (Prims.of_int (781)) (Prims.of_int (12))
+                   (Prims.of_int (781)) (Prims.of_int (52)))))
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Extract.Main.fst"
-                   (Prims.of_int (773)) (Prims.of_int (2))
-                   (Prims.of_int (807)) (Prims.of_int (75)))))
+                   (Prims.of_int (782)) (Prims.of_int (2))
+                   (Prims.of_int (816)) (Prims.of_int (75)))))
           (FStar_Tactics_Effect.lift_div_tac
              (fun uu___ ->
                 {
@@ -7507,36 +7533,36 @@ let (extract_pulse :
                      (FStar_Sealed.seal
                         (Obj.magic
                            (FStar_Range.mk_range "Pulse.Extract.Main.fst"
-                              (Prims.of_int (773)) (Prims.of_int (2))
-                              (Prims.of_int (773)) (Prims.of_int (74)))))
+                              (Prims.of_int (782)) (Prims.of_int (2))
+                              (Prims.of_int (782)) (Prims.of_int (74)))))
                      (FStar_Sealed.seal
                         (Obj.magic
                            (FStar_Range.mk_range "Pulse.Extract.Main.fst"
-                              (Prims.of_int (774)) (Prims.of_int (2))
-                              (Prims.of_int (807)) (Prims.of_int (75)))))
+                              (Prims.of_int (783)) (Prims.of_int (2))
+                              (Prims.of_int (816)) (Prims.of_int (75)))))
                      (Obj.magic
                         (FStar_Tactics_Effect.tac_bind
                            (FStar_Sealed.seal
                               (Obj.magic
                                  (FStar_Range.mk_range
                                     "Pulse.Extract.Main.fst"
-                                    (Prims.of_int (773)) (Prims.of_int (10))
-                                    (Prims.of_int (773)) (Prims.of_int (74)))))
+                                    (Prims.of_int (782)) (Prims.of_int (10))
+                                    (Prims.of_int (782)) (Prims.of_int (74)))))
                            (FStar_Sealed.seal
                               (Obj.magic
                                  (FStar_Range.mk_range
                                     "Pulse.Extract.Main.fst"
-                                    (Prims.of_int (773)) (Prims.of_int (2))
-                                    (Prims.of_int (773)) (Prims.of_int (74)))))
+                                    (Prims.of_int (782)) (Prims.of_int (2))
+                                    (Prims.of_int (782)) (Prims.of_int (74)))))
                            (Obj.magic
                               (FStar_Tactics_Effect.tac_bind
                                  (FStar_Sealed.seal
                                     (Obj.magic
                                        (FStar_Range.mk_range
                                           "Pulse.Extract.Main.fst"
-                                          (Prims.of_int (773))
+                                          (Prims.of_int (782))
                                           (Prims.of_int (52))
-                                          (Prims.of_int (773))
+                                          (Prims.of_int (782))
                                           (Prims.of_int (73)))))
                                  (FStar_Sealed.seal
                                     (Obj.magic
@@ -7565,17 +7591,17 @@ let (extract_pulse :
                                    (Obj.magic
                                       (FStar_Range.mk_range
                                          "Pulse.Extract.Main.fst"
-                                         (Prims.of_int (774))
+                                         (Prims.of_int (783))
                                          (Prims.of_int (2))
-                                         (Prims.of_int (774))
+                                         (Prims.of_int (783))
                                          (Prims.of_int (83)))))
                                 (FStar_Sealed.seal
                                    (Obj.magic
                                       (FStar_Range.mk_range
                                          "Pulse.Extract.Main.fst"
-                                         (Prims.of_int (776))
+                                         (Prims.of_int (785))
                                          (Prims.of_int (2))
-                                         (Prims.of_int (807))
+                                         (Prims.of_int (816))
                                          (Prims.of_int (75)))))
                                 (Obj.magic
                                    (debug g1
@@ -7585,9 +7611,9 @@ let (extract_pulse :
                                               (Obj.magic
                                                  (FStar_Range.mk_range
                                                     "Pulse.Extract.Main.fst"
-                                                    (Prims.of_int (774))
+                                                    (Prims.of_int (783))
                                                     (Prims.of_int (61))
-                                                    (Prims.of_int (774))
+                                                    (Prims.of_int (783))
                                                     (Prims.of_int (82)))))
                                            (FStar_Sealed.seal
                                               (Obj.magic
@@ -7619,17 +7645,17 @@ let (extract_pulse :
                                                        (Obj.magic
                                                           (FStar_Range.mk_range
                                                              "Pulse.Extract.Main.fst"
-                                                             (Prims.of_int (777))
+                                                             (Prims.of_int (786))
                                                              (Prims.of_int (22))
-                                                             (Prims.of_int (777))
+                                                             (Prims.of_int (786))
                                                              (Prims.of_int (43)))))
                                                     (FStar_Sealed.seal
                                                        (Obj.magic
                                                           (FStar_Range.mk_range
                                                              "Pulse.Extract.Main.fst"
-                                                             (Prims.of_int (778))
+                                                             (Prims.of_int (787))
                                                              (Prims.of_int (4))
-                                                             (Prims.of_int (802))
+                                                             (Prims.of_int (811))
                                                              (Prims.of_int (59)))))
                                                     (FStar_Tactics_Effect.lift_div_tac
                                                        (fun uu___3 ->
@@ -7661,17 +7687,17 @@ let (extract_pulse :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (783))
+                                                                    (Prims.of_int (792))
                                                                     (Prims.of_int (30))
-                                                                    (Prims.of_int (783))
+                                                                    (Prims.of_int (792))
                                                                     (Prims.of_int (60)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (782))
+                                                                    (Prims.of_int (791))
                                                                     (Prims.of_int (11))
-                                                                    (Prims.of_int (800))
+                                                                    (Prims.of_int (809))
                                                                     (Prims.of_int (7)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -7702,17 +7728,17 @@ let (extract_pulse :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (784))
+                                                                    (Prims.of_int (793))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (784))
+                                                                    (Prims.of_int (793))
                                                                     (Prims.of_int (39)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (784))
+                                                                    (Prims.of_int (793))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (799))
+                                                                    (Prims.of_int (808))
                                                                     (Prims.of_int (36)))))
                                                                     (Obj.magic
                                                                     (is_recursive
@@ -7740,17 +7766,17 @@ let (extract_pulse :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (788))
+                                                                    (Prims.of_int (797))
                                                                     (Prims.of_int (39))
-                                                                    (Prims.of_int (788))
+                                                                    (Prims.of_int (797))
                                                                     (Prims.of_int (67)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (787))
+                                                                    (Prims.of_int (796))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (799))
+                                                                    (Prims.of_int (808))
                                                                     (Prims.of_int (36)))))
                                                                     (Obj.magic
                                                                     (generalize
@@ -7774,17 +7800,17 @@ let (extract_pulse :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (789))
+                                                                    (Prims.of_int (798))
                                                                     (Prims.of_int (21))
-                                                                    (Prims.of_int (789))
+                                                                    (Prims.of_int (798))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (789))
+                                                                    (Prims.of_int (798))
                                                                     (Prims.of_int (60))
-                                                                    (Prims.of_int (799))
+                                                                    (Prims.of_int (808))
                                                                     (Prims.of_int (36)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -7804,17 +7830,17 @@ let (extract_pulse :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (790))
+                                                                    (Prims.of_int (799))
                                                                     (Prims.of_int (24))
-                                                                    (Prims.of_int (790))
+                                                                    (Prims.of_int (799))
                                                                     (Prims.of_int (42)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (791))
+                                                                    (Prims.of_int (800))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (799))
+                                                                    (Prims.of_int (808))
                                                                     (Prims.of_int (36)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -7834,17 +7860,17 @@ let (extract_pulse :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (791))
+                                                                    (Prims.of_int (800))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (792))
+                                                                    (Prims.of_int (801))
                                                                     (Prims.of_int (67)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (792))
+                                                                    (Prims.of_int (801))
                                                                     (Prims.of_int (68))
-                                                                    (Prims.of_int (799))
+                                                                    (Prims.of_int (808))
                                                                     (Prims.of_int (36)))))
                                                                     (if
                                                                     Prims.uu___is_Nil
@@ -7870,17 +7896,17 @@ let (extract_pulse :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (793))
+                                                                    (Prims.of_int (802))
                                                                     (Prims.of_int (18))
-                                                                    (Prims.of_int (793))
+                                                                    (Prims.of_int (802))
                                                                     (Prims.of_int (42)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (793))
+                                                                    (Prims.of_int (802))
                                                                     (Prims.of_int (45))
-                                                                    (Prims.of_int (799))
+                                                                    (Prims.of_int (808))
                                                                     (Prims.of_int (36)))))
                                                                     (Obj.magic
                                                                     (erase_ghost_subterms
@@ -7896,17 +7922,17 @@ let (extract_pulse :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (794))
+                                                                    (Prims.of_int (803))
                                                                     (Prims.of_int (18))
-                                                                    (Prims.of_int (794))
+                                                                    (Prims.of_int (803))
                                                                     (Prims.of_int (38)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (794))
+                                                                    (Prims.of_int (803))
                                                                     (Prims.of_int (41))
-                                                                    (Prims.of_int (799))
+                                                                    (Prims.of_int (808))
                                                                     (Prims.of_int (36)))))
                                                                     (Obj.magic
                                                                     (simplify_st_term
@@ -7922,17 +7948,17 @@ let (extract_pulse :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (795))
+                                                                    (Prims.of_int (804))
                                                                     (Prims.of_int (24))
-                                                                    (Prims.of_int (795))
+                                                                    (Prims.of_int (804))
                                                                     (Prims.of_int (35)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (794))
+                                                                    (Prims.of_int (803))
                                                                     (Prims.of_int (41))
-                                                                    (Prims.of_int (799))
+                                                                    (Prims.of_int (808))
                                                                     (Prims.of_int (36)))))
                                                                     (Obj.magic
                                                                     (extract
@@ -7954,17 +7980,17 @@ let (extract_pulse :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (796))
+                                                                    (Prims.of_int (805))
                                                                     (Prims.of_int (24))
-                                                                    (Prims.of_int (796))
+                                                                    (Prims.of_int (805))
                                                                     (Prims.of_int (51)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (797))
+                                                                    (Prims.of_int (806))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (799))
+                                                                    (Prims.of_int (808))
                                                                     (Prims.of_int (36)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -7984,17 +8010,17 @@ let (extract_pulse :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (797))
+                                                                    (Prims.of_int (806))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (797))
+                                                                    (Prims.of_int (806))
                                                                     (Prims.of_int (102)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (799))
+                                                                    (Prims.of_int (808))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (799))
+                                                                    (Prims.of_int (808))
                                                                     (Prims.of_int (36)))))
                                                                     (Obj.magic
                                                                     (debug_
@@ -8091,13 +8117,13 @@ let (extract_pulse_sig :
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Extract.Main.fst"
-                            (Prims.of_int (814)) (Prims.of_int (22))
-                            (Prims.of_int (814)) (Prims.of_int (43)))))
+                            (Prims.of_int (823)) (Prims.of_int (22))
+                            (Prims.of_int (823)) (Prims.of_int (43)))))
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Extract.Main.fst"
-                            (Prims.of_int (815)) (Prims.of_int (4))
-                            (Prims.of_int (828)) (Prims.of_int (59)))))
+                            (Prims.of_int (824)) (Prims.of_int (4))
+                            (Prims.of_int (837)) (Prims.of_int (59)))))
                    (FStar_Tactics_Effect.lift_div_tac
                       (fun uu___1 ->
                          FStar_Reflection_V2_Builtins.inspect_sigelt selt))
@@ -8123,17 +8149,17 @@ let (extract_pulse_sig :
                                              (Obj.magic
                                                 (FStar_Range.mk_range
                                                    "Pulse.Extract.Main.fst"
-                                                   (Prims.of_int (820))
+                                                   (Prims.of_int (829))
                                                    (Prims.of_int (30))
-                                                   (Prims.of_int (820))
+                                                   (Prims.of_int (829))
                                                    (Prims.of_int (60)))))
                                           (FStar_Sealed.seal
                                              (Obj.magic
                                                 (FStar_Range.mk_range
                                                    "Pulse.Extract.Main.fst"
-                                                   (Prims.of_int (819))
+                                                   (Prims.of_int (828))
                                                    (Prims.of_int (10))
-                                                   (Prims.of_int (827))
+                                                   (Prims.of_int (836))
                                                    (Prims.of_int (49)))))
                                           (FStar_Tactics_Effect.lift_div_tac
                                              (fun uu___2 ->
@@ -8158,17 +8184,17 @@ let (extract_pulse_sig :
                                                             (Obj.magic
                                                                (FStar_Range.mk_range
                                                                   "Pulse.Extract.Main.fst"
-                                                                  (Prims.of_int (821))
+                                                                  (Prims.of_int (830))
                                                                   (Prims.of_int (17))
-                                                                  (Prims.of_int (821))
+                                                                  (Prims.of_int (830))
                                                                   (Prims.of_int (18)))))
                                                          (FStar_Sealed.seal
                                                             (Obj.magic
                                                                (FStar_Range.mk_range
                                                                   "Pulse.Extract.Main.fst"
-                                                                  (Prims.of_int (821))
+                                                                  (Prims.of_int (830))
                                                                   (Prims.of_int (21))
-                                                                  (Prims.of_int (827))
+                                                                  (Prims.of_int (836))
                                                                   (Prims.of_int (49)))))
                                                          (FStar_Tactics_Effect.lift_div_tac
                                                             (fun uu___5 -> g))
@@ -8181,18 +8207,18 @@ let (extract_pulse_sig :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (822))
+                                                                    (Prims.of_int (831))
                                                                     (Prims.of_int (18))
-                                                                    (Prims.of_int (822))
+                                                                    (Prims.of_int (831))
                                                                     (Prims.of_int (58)))))
                                                                     (
                                                                     FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (822))
+                                                                    (Prims.of_int (831))
                                                                     (Prims.of_int (63))
-                                                                    (Prims.of_int (827))
+                                                                    (Prims.of_int (836))
                                                                     (Prims.of_int (49)))))
                                                                     (
                                                                     FStar_Tactics_Effect.lift_div_tac
@@ -8216,17 +8242,17 @@ let (extract_pulse_sig :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (823))
+                                                                    (Prims.of_int (832))
                                                                     (Prims.of_int (32))
-                                                                    (Prims.of_int (823))
+                                                                    (Prims.of_int (832))
                                                                     (Prims.of_int (56)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (822))
+                                                                    (Prims.of_int (831))
                                                                     (Prims.of_int (63))
-                                                                    (Prims.of_int (827))
+                                                                    (Prims.of_int (836))
                                                                     (Prims.of_int (49)))))
                                                                     (Obj.magic
                                                                     (generalize
@@ -8249,17 +8275,17 @@ let (extract_pulse_sig :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (824))
+                                                                    (Prims.of_int (833))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (824))
+                                                                    (Prims.of_int (833))
                                                                     (Prims.of_int (94)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (825))
+                                                                    (Prims.of_int (834))
                                                                     (Prims.of_int (58))
-                                                                    (Prims.of_int (827))
+                                                                    (Prims.of_int (836))
                                                                     (Prims.of_int (49)))))
                                                                     (Obj.magic
                                                                     (debug_
@@ -8271,9 +8297,9 @@ let (extract_pulse_sig :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Extract.Main.fst"
-                                                                    (Prims.of_int (824))
+                                                                    (Prims.of_int (833))
                                                                     (Prims.of_int (68))
-                                                                    (Prims.of_int (824))
+                                                                    (Prims.of_int (833))
                                                                     (Prims.of_int (93)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic

--- a/src/ocaml/plugin/generated/Pulse_Syntax_Base.ml
+++ b/src/ocaml/plugin/generated/Pulse_Syntax_Base.ml
@@ -430,6 +430,7 @@ and st_term' =
   | Tm_WithLocalArray of st_term'__Tm_WithLocalArray__payload 
   | Tm_Rewrite of st_term'__Tm_Rewrite__payload 
   | Tm_Admit of st_term'__Tm_Admit__payload 
+  | Tm_Unreachable 
   | Tm_ProofHintWithBinders of st_term'__Tm_ProofHintWithBinders__payload 
   | Tm_WithInv of st_term'__Tm_WithInv__payload 
 and st_term = {
@@ -464,6 +465,8 @@ let uu___is_Tm_Rewrite uu___ =
   match uu___ with | Tm_Rewrite _ -> true | _ -> false
 let uu___is_Tm_Admit uu___ =
   match uu___ with | Tm_Admit _ -> true | _ -> false
+let uu___is_Tm_Unreachable uu___ =
+  match uu___ with | Tm_Unreachable _ -> true | _ -> false
 let uu___is_Tm_ProofHintWithBinders uu___ =
   match uu___ with | Tm_ProofHintWithBinders _ -> true | _ -> false
 let uu___is_Tm_WithInv uu___ =
@@ -756,6 +759,7 @@ let rec (eq_st_term : st_term -> st_term -> Prims.bool) =
          { ctag1 = c2; u1 = u2; typ = t21; post3 = post2;_}) ->
           (((c1 = c2) && (eq_univ u1 u2)) && (eq_tm t11 t21)) &&
             (eq_tm_opt post1 post2)
+      | (Tm_Unreachable, Tm_Unreachable) -> true
       | (Tm_ProofHintWithBinders
          { hint_type = ht1; binders = bs1; t3 = t11;_},
          Tm_ProofHintWithBinders

--- a/src/ocaml/plugin/generated/Pulse_Syntax_Builder.ml
+++ b/src/ocaml/plugin/generated/Pulse_Syntax_Builder.ml
@@ -254,6 +254,8 @@ let (tm_admit :
               Pulse_Syntax_Base.typ = typ;
               Pulse_Syntax_Base.post3 = post
             }
+let (tm_unreachable : Pulse_Syntax_Base.st_term') =
+  Pulse_Syntax_Base.Tm_Unreachable
 let (with_range :
   Pulse_Syntax_Base.st_term' ->
     Pulse_Syntax_Base.range -> Pulse_Syntax_Base.st_term)

--- a/src/ocaml/plugin/generated/Pulse_Syntax_Naming.ml
+++ b/src/ocaml/plugin/generated/Pulse_Syntax_Naming.ml
@@ -190,6 +190,7 @@ let rec (freevars_st :
         { Pulse_Syntax_Base.ctag1 = uu___; Pulse_Syntax_Base.u1 = uu___1;
           Pulse_Syntax_Base.typ = typ; Pulse_Syntax_Base.post3 = post;_}
         -> FStar_Set.union (freevars typ) (freevars_term_opt post)
+    | Pulse_Syntax_Base.Tm_Unreachable -> FStar_Set.empty ()
     | Pulse_Syntax_Base.Tm_ProofHintWithBinders
         { Pulse_Syntax_Base.hint_type = hint_type;
           Pulse_Syntax_Base.binders = binders; Pulse_Syntax_Base.t3 = t1;_}
@@ -425,6 +426,7 @@ let rec (ln_st' : Pulse_Syntax_Base.st_term -> Prims.int -> Prims.bool) =
           { Pulse_Syntax_Base.ctag1 = uu___; Pulse_Syntax_Base.u1 = uu___1;
             Pulse_Syntax_Base.typ = typ; Pulse_Syntax_Base.post3 = post;_}
           -> (ln' typ i) && (ln_opt' ln' post (i + Prims.int_one))
+      | Pulse_Syntax_Base.Tm_Unreachable -> true
       | Pulse_Syntax_Base.Tm_ProofHintWithBinders
           { Pulse_Syntax_Base.hint_type = hint_type;
             Pulse_Syntax_Base.binders = binders; Pulse_Syntax_Base.t3 = t1;_}
@@ -974,6 +976,8 @@ let rec (subst_st_term :
                 Pulse_Syntax_Base.post3 =
                   (subst_term_opt post (shift_subst ss))
               }
+        | Pulse_Syntax_Base.Tm_Unreachable ->
+            Pulse_Syntax_Base.Tm_Unreachable
         | Pulse_Syntax_Base.Tm_ProofHintWithBinders
             { Pulse_Syntax_Base.hint_type = hint_type;
               Pulse_Syntax_Base.binders = binders;

--- a/src/ocaml/plugin/generated/Pulse_Syntax_Printer.ml
+++ b/src/ocaml/plugin/generated/Pulse_Syntax_Printer.ml
@@ -1861,206 +1861,221 @@ let rec (st_term_to_string' :
     Pulse_Syntax_Base.st_term ->
       (Prims.string, unit) FStar_Tactics_Effect.tac_repr)
   =
-  fun level ->
-    fun t ->
-      match t.Pulse_Syntax_Base.term1 with
-      | Pulse_Syntax_Base.Tm_Return
-          { Pulse_Syntax_Base.ctag = ctag;
-            Pulse_Syntax_Base.insert_eq = insert_eq;
-            Pulse_Syntax_Base.term = term;_}
-          ->
-          FStar_Tactics_Effect.tac_bind
-            (FStar_Sealed.seal
-               (Obj.magic
-                  (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                     (Prims.of_int (186)) (Prims.of_int (8))
-                     (Prims.of_int (186)) (Prims.of_int (29)))))
-            (FStar_Sealed.seal
-               (Obj.magic
-                  (FStar_Range.mk_range "prims.fst" (Prims.of_int (590))
-                     (Prims.of_int (19)) (Prims.of_int (590))
-                     (Prims.of_int (31))))) (Obj.magic (term_to_string term))
-            (fun uu___ ->
-               FStar_Tactics_Effect.lift_div_tac
-                 (fun uu___1 ->
-                    Prims.strcat
-                      (Prims.strcat
-                         (Prims.strcat "return_"
-                            (Prims.strcat
-                               (match ctag with
-                                | Pulse_Syntax_Base.STT -> "stt"
-                                | Pulse_Syntax_Base.STT_Atomic ->
-                                    "stt_atomic"
-                                | Pulse_Syntax_Base.STT_Ghost -> "stt_ghost")
-                               ""))
-                         (Prims.strcat (if insert_eq then "" else "_noeq")
-                            " ")) (Prims.strcat uu___ "")))
-      | Pulse_Syntax_Base.Tm_STApp
-          { Pulse_Syntax_Base.head = head;
-            Pulse_Syntax_Base.arg_qual = arg_qual;
-            Pulse_Syntax_Base.arg = arg;_}
-          ->
-          FStar_Tactics_Effect.tac_bind
-            (FStar_Sealed.seal
-               (Obj.magic
-                  (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                     (Prims.of_int (193)) (Prims.of_int (8))
-                     (Prims.of_int (193)) (Prims.of_int (28)))))
-            (FStar_Sealed.seal
-               (Obj.magic
-                  (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                     (Prims.of_int (189)) (Prims.of_int (6))
-                     (Prims.of_int (193)) (Prims.of_int (28)))))
-            (Obj.magic (term_to_string arg))
-            (fun uu___ ->
-               (fun uu___ ->
-                  Obj.magic
+  fun uu___1 ->
+    fun uu___ ->
+      (fun level ->
+         fun t ->
+           match t.Pulse_Syntax_Base.term1 with
+           | Pulse_Syntax_Base.Tm_Return
+               { Pulse_Syntax_Base.ctag = ctag;
+                 Pulse_Syntax_Base.insert_eq = insert_eq;
+                 Pulse_Syntax_Base.term = term;_}
+               ->
+               Obj.magic
+                 (Obj.repr
                     (FStar_Tactics_Effect.tac_bind
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (189)) (Prims.of_int (6))
-                                (Prims.of_int (193)) (Prims.of_int (28)))))
+                                (Prims.of_int (186)) (Prims.of_int (8))
+                                (Prims.of_int (186)) (Prims.of_int (29)))))
                        (FStar_Sealed.seal
                           (Obj.magic
-                             (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (189)) (Prims.of_int (6))
-                                (Prims.of_int (193)) (Prims.of_int (28)))))
-                       (Obj.magic
-                          (FStar_Tactics_Effect.tac_bind
-                             (FStar_Sealed.seal
-                                (Obj.magic
-                                   (FStar_Range.mk_range
-                                      "Pulse.Syntax.Printer.fst"
-                                      (Prims.of_int (189)) (Prims.of_int (6))
-                                      (Prims.of_int (193))
-                                      (Prims.of_int (28)))))
-                             (FStar_Sealed.seal
-                                (Obj.magic
-                                   (FStar_Range.mk_range
-                                      "Pulse.Syntax.Printer.fst"
-                                      (Prims.of_int (189)) (Prims.of_int (6))
-                                      (Prims.of_int (193))
-                                      (Prims.of_int (28)))))
-                             (Obj.magic
-                                (FStar_Tactics_Effect.tac_bind
-                                   (FStar_Sealed.seal
-                                      (Obj.magic
-                                         (FStar_Range.mk_range
-                                            "Pulse.Syntax.Printer.fst"
-                                            (Prims.of_int (191))
-                                            (Prims.of_int (8))
-                                            (Prims.of_int (191))
-                                            (Prims.of_int (29)))))
-                                   (FStar_Sealed.seal
-                                      (Obj.magic
-                                         (FStar_Range.mk_range
-                                            "FStar.Printf.fst"
-                                            (Prims.of_int (122))
-                                            (Prims.of_int (8))
-                                            (Prims.of_int (124))
-                                            (Prims.of_int (44)))))
-                                   (Obj.magic (term_to_string head))
-                                   (fun uu___1 ->
-                                      FStar_Tactics_Effect.lift_div_tac
-                                        (fun uu___2 ->
-                                           fun x ->
-                                             fun x1 ->
-                                               Prims.strcat
-                                                 (Prims.strcat
-                                                    (Prims.strcat
-                                                       (Prims.strcat "("
-                                                          (Prims.strcat
-                                                             (if dbg_printing
-                                                              then "<stapp>"
-                                                              else "") ""))
-                                                       (Prims.strcat uu___1
-                                                          " "))
-                                                    (Prims.strcat x ""))
-                                                 (Prims.strcat x1 ")")))))
-                             (fun uu___1 ->
-                                FStar_Tactics_Effect.lift_div_tac
-                                  (fun uu___2 ->
-                                     uu___1 (qual_to_string arg_qual)))))
-                       (fun uu___1 ->
+                             (FStar_Range.mk_range "prims.fst"
+                                (Prims.of_int (590)) (Prims.of_int (19))
+                                (Prims.of_int (590)) (Prims.of_int (31)))))
+                       (Obj.magic (term_to_string term))
+                       (fun uu___ ->
                           FStar_Tactics_Effect.lift_div_tac
-                            (fun uu___2 -> uu___1 uu___)))) uu___)
-      | Pulse_Syntax_Base.Tm_Bind
-          { Pulse_Syntax_Base.binder = binder;
-            Pulse_Syntax_Base.head1 = head; Pulse_Syntax_Base.body1 = body;_}
-          ->
-          FStar_Tactics_Effect.tac_bind
-            (FStar_Sealed.seal
-               (Obj.magic
-                  (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                     (Prims.of_int (206)) (Prims.of_int (10))
-                     (Prims.of_int (206)) (Prims.of_int (41)))))
-            (FStar_Sealed.seal
-               (Obj.magic
-                  (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                     (Prims.of_int (202)) (Prims.of_int (8))
-                     (Prims.of_int (206)) (Prims.of_int (41)))))
-            (Obj.magic (st_term_to_string' level body))
-            (fun uu___ ->
-               (fun uu___ ->
-                  Obj.magic
+                            (fun uu___1 ->
+                               Prims.strcat
+                                 (Prims.strcat
+                                    (Prims.strcat "return_"
+                                       (Prims.strcat
+                                          (match ctag with
+                                           | Pulse_Syntax_Base.STT -> "stt"
+                                           | Pulse_Syntax_Base.STT_Atomic ->
+                                               "stt_atomic"
+                                           | Pulse_Syntax_Base.STT_Ghost ->
+                                               "stt_ghost") ""))
+                                    (Prims.strcat
+                                       (if insert_eq then "" else "_noeq")
+                                       " ")) (Prims.strcat uu___ "")))))
+           | Pulse_Syntax_Base.Tm_STApp
+               { Pulse_Syntax_Base.head = head;
+                 Pulse_Syntax_Base.arg_qual = arg_qual;
+                 Pulse_Syntax_Base.arg = arg;_}
+               ->
+               Obj.magic
+                 (Obj.repr
                     (FStar_Tactics_Effect.tac_bind
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (202)) (Prims.of_int (8))
-                                (Prims.of_int (206)) (Prims.of_int (41)))))
+                                (Prims.of_int (193)) (Prims.of_int (8))
+                                (Prims.of_int (193)) (Prims.of_int (28)))))
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (202)) (Prims.of_int (8))
-                                (Prims.of_int (206)) (Prims.of_int (41)))))
-                       (Obj.magic
-                          (FStar_Tactics_Effect.tac_bind
-                             (FStar_Sealed.seal
-                                (Obj.magic
-                                   (FStar_Range.mk_range
-                                      "Pulse.Syntax.Printer.fst"
-                                      (Prims.of_int (202)) (Prims.of_int (8))
-                                      (Prims.of_int (206))
-                                      (Prims.of_int (41)))))
-                             (FStar_Sealed.seal
-                                (Obj.magic
-                                   (FStar_Range.mk_range
-                                      "Pulse.Syntax.Printer.fst"
-                                      (Prims.of_int (202)) (Prims.of_int (8))
-                                      (Prims.of_int (206))
-                                      (Prims.of_int (41)))))
-                             (Obj.magic
-                                (FStar_Tactics_Effect.tac_bind
-                                   (FStar_Sealed.seal
-                                      (Obj.magic
-                                         (FStar_Range.mk_range
-                                            "Pulse.Syntax.Printer.fst"
-                                            (Prims.of_int (204))
-                                            (Prims.of_int (10))
-                                            (Prims.of_int (204))
-                                            (Prims.of_int (41)))))
-                                   (FStar_Sealed.seal
-                                      (Obj.magic
-                                         (FStar_Range.mk_range
-                                            "Pulse.Syntax.Printer.fst"
-                                            (Prims.of_int (202))
-                                            (Prims.of_int (8))
-                                            (Prims.of_int (206))
-                                            (Prims.of_int (41)))))
-                                   (Obj.magic (st_term_to_string' level head))
-                                   (fun uu___1 ->
-                                      (fun uu___1 ->
-                                         Obj.magic
+                                (Prims.of_int (189)) (Prims.of_int (6))
+                                (Prims.of_int (193)) (Prims.of_int (28)))))
+                       (Obj.magic (term_to_string arg))
+                       (fun uu___ ->
+                          (fun uu___ ->
+                             Obj.magic
+                               (FStar_Tactics_Effect.tac_bind
+                                  (FStar_Sealed.seal
+                                     (Obj.magic
+                                        (FStar_Range.mk_range
+                                           "Pulse.Syntax.Printer.fst"
+                                           (Prims.of_int (189))
+                                           (Prims.of_int (6))
+                                           (Prims.of_int (193))
+                                           (Prims.of_int (28)))))
+                                  (FStar_Sealed.seal
+                                     (Obj.magic
+                                        (FStar_Range.mk_range
+                                           "Pulse.Syntax.Printer.fst"
+                                           (Prims.of_int (189))
+                                           (Prims.of_int (6))
+                                           (Prims.of_int (193))
+                                           (Prims.of_int (28)))))
+                                  (Obj.magic
+                                     (FStar_Tactics_Effect.tac_bind
+                                        (FStar_Sealed.seal
+                                           (Obj.magic
+                                              (FStar_Range.mk_range
+                                                 "Pulse.Syntax.Printer.fst"
+                                                 (Prims.of_int (189))
+                                                 (Prims.of_int (6))
+                                                 (Prims.of_int (193))
+                                                 (Prims.of_int (28)))))
+                                        (FStar_Sealed.seal
+                                           (Obj.magic
+                                              (FStar_Range.mk_range
+                                                 "Pulse.Syntax.Printer.fst"
+                                                 (Prims.of_int (189))
+                                                 (Prims.of_int (6))
+                                                 (Prims.of_int (193))
+                                                 (Prims.of_int (28)))))
+                                        (Obj.magic
                                            (FStar_Tactics_Effect.tac_bind
                                               (FStar_Sealed.seal
                                                  (Obj.magic
                                                     (FStar_Range.mk_range
                                                        "Pulse.Syntax.Printer.fst"
-                                                       (Prims.of_int (202))
+                                                       (Prims.of_int (191))
                                                        (Prims.of_int (8))
-                                                       (Prims.of_int (206))
+                                                       (Prims.of_int (191))
+                                                       (Prims.of_int (29)))))
+                                              (FStar_Sealed.seal
+                                                 (Obj.magic
+                                                    (FStar_Range.mk_range
+                                                       "FStar.Printf.fst"
+                                                       (Prims.of_int (122))
+                                                       (Prims.of_int (8))
+                                                       (Prims.of_int (124))
+                                                       (Prims.of_int (44)))))
+                                              (Obj.magic
+                                                 (term_to_string head))
+                                              (fun uu___1 ->
+                                                 FStar_Tactics_Effect.lift_div_tac
+                                                   (fun uu___2 ->
+                                                      fun x ->
+                                                        fun x1 ->
+                                                          Prims.strcat
+                                                            (Prims.strcat
+                                                               (Prims.strcat
+                                                                  (Prims.strcat
+                                                                    "("
+                                                                    (Prims.strcat
+                                                                    (if
+                                                                    dbg_printing
+                                                                    then
+                                                                    "<stapp>"
+                                                                    else "")
+                                                                    ""))
+                                                                  (Prims.strcat
+                                                                    uu___1
+                                                                    " "))
+                                                               (Prims.strcat
+                                                                  x ""))
+                                                            (Prims.strcat x1
+                                                               ")")))))
+                                        (fun uu___1 ->
+                                           FStar_Tactics_Effect.lift_div_tac
+                                             (fun uu___2 ->
+                                                uu___1
+                                                  (qual_to_string arg_qual)))))
+                                  (fun uu___1 ->
+                                     FStar_Tactics_Effect.lift_div_tac
+                                       (fun uu___2 -> uu___1 uu___)))) uu___)))
+           | Pulse_Syntax_Base.Tm_Bind
+               { Pulse_Syntax_Base.binder = binder;
+                 Pulse_Syntax_Base.head1 = head;
+                 Pulse_Syntax_Base.body1 = body;_}
+               ->
+               Obj.magic
+                 (Obj.repr
+                    (FStar_Tactics_Effect.tac_bind
+                       (FStar_Sealed.seal
+                          (Obj.magic
+                             (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
+                                (Prims.of_int (206)) (Prims.of_int (10))
+                                (Prims.of_int (206)) (Prims.of_int (41)))))
+                       (FStar_Sealed.seal
+                          (Obj.magic
+                             (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
+                                (Prims.of_int (202)) (Prims.of_int (8))
+                                (Prims.of_int (206)) (Prims.of_int (41)))))
+                       (Obj.magic (st_term_to_string' level body))
+                       (fun uu___ ->
+                          (fun uu___ ->
+                             Obj.magic
+                               (FStar_Tactics_Effect.tac_bind
+                                  (FStar_Sealed.seal
+                                     (Obj.magic
+                                        (FStar_Range.mk_range
+                                           "Pulse.Syntax.Printer.fst"
+                                           (Prims.of_int (202))
+                                           (Prims.of_int (8))
+                                           (Prims.of_int (206))
+                                           (Prims.of_int (41)))))
+                                  (FStar_Sealed.seal
+                                     (Obj.magic
+                                        (FStar_Range.mk_range
+                                           "Pulse.Syntax.Printer.fst"
+                                           (Prims.of_int (202))
+                                           (Prims.of_int (8))
+                                           (Prims.of_int (206))
+                                           (Prims.of_int (41)))))
+                                  (Obj.magic
+                                     (FStar_Tactics_Effect.tac_bind
+                                        (FStar_Sealed.seal
+                                           (Obj.magic
+                                              (FStar_Range.mk_range
+                                                 "Pulse.Syntax.Printer.fst"
+                                                 (Prims.of_int (202))
+                                                 (Prims.of_int (8))
+                                                 (Prims.of_int (206))
+                                                 (Prims.of_int (41)))))
+                                        (FStar_Sealed.seal
+                                           (Obj.magic
+                                              (FStar_Range.mk_range
+                                                 "Pulse.Syntax.Printer.fst"
+                                                 (Prims.of_int (202))
+                                                 (Prims.of_int (8))
+                                                 (Prims.of_int (206))
+                                                 (Prims.of_int (41)))))
+                                        (Obj.magic
+                                           (FStar_Tactics_Effect.tac_bind
+                                              (FStar_Sealed.seal
+                                                 (Obj.magic
+                                                    (FStar_Range.mk_range
+                                                       "Pulse.Syntax.Printer.fst"
+                                                       (Prims.of_int (204))
+                                                       (Prims.of_int (10))
+                                                       (Prims.of_int (204))
                                                        (Prims.of_int (41)))))
                                               (FStar_Sealed.seal
                                                  (Obj.magic
@@ -2071,35 +2086,59 @@ let rec (st_term_to_string' :
                                                        (Prims.of_int (206))
                                                        (Prims.of_int (41)))))
                                               (Obj.magic
-                                                 (FStar_Tactics_Effect.tac_bind
-                                                    (FStar_Sealed.seal
-                                                       (Obj.magic
-                                                          (FStar_Range.mk_range
-                                                             "Pulse.Syntax.Printer.fst"
-                                                             (Prims.of_int (203))
-                                                             (Prims.of_int (10))
-                                                             (Prims.of_int (203))
-                                                             (Prims.of_int (35)))))
-                                                    (FStar_Sealed.seal
-                                                       (Obj.magic
-                                                          (FStar_Range.mk_range
-                                                             "FStar.Printf.fst"
-                                                             (Prims.of_int (122))
-                                                             (Prims.of_int (8))
-                                                             (Prims.of_int (124))
-                                                             (Prims.of_int (44)))))
-                                                    (Obj.magic
-                                                       (binder_to_string
-                                                          binder))
-                                                    (fun uu___2 ->
-                                                       FStar_Tactics_Effect.lift_div_tac
-                                                         (fun uu___3 ->
-                                                            fun x ->
-                                                              fun x1 ->
-                                                                fun x2 ->
-                                                                  Prims.strcat
+                                                 (st_term_to_string' level
+                                                    head))
+                                              (fun uu___1 ->
+                                                 (fun uu___1 ->
+                                                    Obj.magic
+                                                      (FStar_Tactics_Effect.tac_bind
+                                                         (FStar_Sealed.seal
+                                                            (Obj.magic
+                                                               (FStar_Range.mk_range
+                                                                  "Pulse.Syntax.Printer.fst"
+                                                                  (Prims.of_int (202))
+                                                                  (Prims.of_int (8))
+                                                                  (Prims.of_int (206))
+                                                                  (Prims.of_int (41)))))
+                                                         (FStar_Sealed.seal
+                                                            (Obj.magic
+                                                               (FStar_Range.mk_range
+                                                                  "Pulse.Syntax.Printer.fst"
+                                                                  (Prims.of_int (202))
+                                                                  (Prims.of_int (8))
+                                                                  (Prims.of_int (206))
+                                                                  (Prims.of_int (41)))))
+                                                         (Obj.magic
+                                                            (FStar_Tactics_Effect.tac_bind
+                                                               (FStar_Sealed.seal
+                                                                  (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Syntax.Printer.fst"
+                                                                    (Prims.of_int (203))
+                                                                    (Prims.of_int (10))
+                                                                    (Prims.of_int (203))
+                                                                    (Prims.of_int (35)))))
+                                                               (FStar_Sealed.seal
+                                                                  (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "FStar.Printf.fst"
+                                                                    (Prims.of_int (122))
+                                                                    (Prims.of_int (8))
+                                                                    (Prims.of_int (124))
+                                                                    (Prims.of_int (44)))))
+                                                               (Obj.magic
+                                                                  (binder_to_string
+                                                                    binder))
+                                                               (fun uu___2 ->
+                                                                  FStar_Tactics_Effect.lift_div_tac
                                                                     (
+                                                                    fun
+                                                                    uu___3 ->
+                                                                    fun x ->
+                                                                    fun x1 ->
+                                                                    fun x2 ->
                                                                     Prims.strcat
+                                                                    (Prims.strcat
                                                                     (Prims.strcat
                                                                     (Prims.strcat
                                                                     "let "
@@ -2110,97 +2149,87 @@ let rec (st_term_to_string' :
                                                                     x ";\n"))
                                                                     (Prims.strcat
                                                                     x1 ""))
-                                                                    (
-                                                                    Prims.strcat
+                                                                    (Prims.strcat
                                                                     x2 "")))))
-                                              (fun uu___2 ->
-                                                 FStar_Tactics_Effect.lift_div_tac
-                                                   (fun uu___3 ->
-                                                      uu___2 uu___1))))
-                                        uu___1)))
-                             (fun uu___1 ->
-                                FStar_Tactics_Effect.lift_div_tac
-                                  (fun uu___2 -> uu___1 level))))
-                       (fun uu___1 ->
-                          FStar_Tactics_Effect.lift_div_tac
-                            (fun uu___2 -> uu___1 uu___)))) uu___)
-      | Pulse_Syntax_Base.Tm_TotBind
-          { Pulse_Syntax_Base.binder1 = binder;
-            Pulse_Syntax_Base.head2 = head; Pulse_Syntax_Base.body2 = body;_}
-          ->
-          FStar_Tactics_Effect.tac_bind
-            (FStar_Sealed.seal
-               (Obj.magic
-                  (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                     (Prims.of_int (214)) (Prims.of_int (8))
-                     (Prims.of_int (214)) (Prims.of_int (39)))))
-            (FStar_Sealed.seal
-               (Obj.magic
-                  (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                     (Prims.of_int (210)) (Prims.of_int (6))
-                     (Prims.of_int (214)) (Prims.of_int (39)))))
-            (Obj.magic (st_term_to_string' level body))
-            (fun uu___ ->
-               (fun uu___ ->
-                  Obj.magic
+                                                         (fun uu___2 ->
+                                                            FStar_Tactics_Effect.lift_div_tac
+                                                              (fun uu___3 ->
+                                                                 uu___2
+                                                                   uu___1))))
+                                                   uu___1)))
+                                        (fun uu___1 ->
+                                           FStar_Tactics_Effect.lift_div_tac
+                                             (fun uu___2 -> uu___1 level))))
+                                  (fun uu___1 ->
+                                     FStar_Tactics_Effect.lift_div_tac
+                                       (fun uu___2 -> uu___1 uu___)))) uu___)))
+           | Pulse_Syntax_Base.Tm_TotBind
+               { Pulse_Syntax_Base.binder1 = binder;
+                 Pulse_Syntax_Base.head2 = head;
+                 Pulse_Syntax_Base.body2 = body;_}
+               ->
+               Obj.magic
+                 (Obj.repr
                     (FStar_Tactics_Effect.tac_bind
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (210)) (Prims.of_int (6))
+                                (Prims.of_int (214)) (Prims.of_int (8))
                                 (Prims.of_int (214)) (Prims.of_int (39)))))
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
                                 (Prims.of_int (210)) (Prims.of_int (6))
                                 (Prims.of_int (214)) (Prims.of_int (39)))))
-                       (Obj.magic
-                          (FStar_Tactics_Effect.tac_bind
-                             (FStar_Sealed.seal
-                                (Obj.magic
-                                   (FStar_Range.mk_range
-                                      "Pulse.Syntax.Printer.fst"
-                                      (Prims.of_int (210)) (Prims.of_int (6))
-                                      (Prims.of_int (214))
-                                      (Prims.of_int (39)))))
-                             (FStar_Sealed.seal
-                                (Obj.magic
-                                   (FStar_Range.mk_range
-                                      "Pulse.Syntax.Printer.fst"
-                                      (Prims.of_int (210)) (Prims.of_int (6))
-                                      (Prims.of_int (214))
-                                      (Prims.of_int (39)))))
-                             (Obj.magic
-                                (FStar_Tactics_Effect.tac_bind
-                                   (FStar_Sealed.seal
-                                      (Obj.magic
-                                         (FStar_Range.mk_range
-                                            "Pulse.Syntax.Printer.fst"
-                                            (Prims.of_int (212))
-                                            (Prims.of_int (8))
-                                            (Prims.of_int (212))
-                                            (Prims.of_int (29)))))
-                                   (FStar_Sealed.seal
-                                      (Obj.magic
-                                         (FStar_Range.mk_range
-                                            "Pulse.Syntax.Printer.fst"
-                                            (Prims.of_int (210))
-                                            (Prims.of_int (6))
-                                            (Prims.of_int (214))
-                                            (Prims.of_int (39)))))
-                                   (Obj.magic (term_to_string head))
-                                   (fun uu___1 ->
-                                      (fun uu___1 ->
-                                         Obj.magic
+                       (Obj.magic (st_term_to_string' level body))
+                       (fun uu___ ->
+                          (fun uu___ ->
+                             Obj.magic
+                               (FStar_Tactics_Effect.tac_bind
+                                  (FStar_Sealed.seal
+                                     (Obj.magic
+                                        (FStar_Range.mk_range
+                                           "Pulse.Syntax.Printer.fst"
+                                           (Prims.of_int (210))
+                                           (Prims.of_int (6))
+                                           (Prims.of_int (214))
+                                           (Prims.of_int (39)))))
+                                  (FStar_Sealed.seal
+                                     (Obj.magic
+                                        (FStar_Range.mk_range
+                                           "Pulse.Syntax.Printer.fst"
+                                           (Prims.of_int (210))
+                                           (Prims.of_int (6))
+                                           (Prims.of_int (214))
+                                           (Prims.of_int (39)))))
+                                  (Obj.magic
+                                     (FStar_Tactics_Effect.tac_bind
+                                        (FStar_Sealed.seal
+                                           (Obj.magic
+                                              (FStar_Range.mk_range
+                                                 "Pulse.Syntax.Printer.fst"
+                                                 (Prims.of_int (210))
+                                                 (Prims.of_int (6))
+                                                 (Prims.of_int (214))
+                                                 (Prims.of_int (39)))))
+                                        (FStar_Sealed.seal
+                                           (Obj.magic
+                                              (FStar_Range.mk_range
+                                                 "Pulse.Syntax.Printer.fst"
+                                                 (Prims.of_int (210))
+                                                 (Prims.of_int (6))
+                                                 (Prims.of_int (214))
+                                                 (Prims.of_int (39)))))
+                                        (Obj.magic
                                            (FStar_Tactics_Effect.tac_bind
                                               (FStar_Sealed.seal
                                                  (Obj.magic
                                                     (FStar_Range.mk_range
                                                        "Pulse.Syntax.Printer.fst"
-                                                       (Prims.of_int (210))
-                                                       (Prims.of_int (6))
-                                                       (Prims.of_int (214))
-                                                       (Prims.of_int (39)))))
+                                                       (Prims.of_int (212))
+                                                       (Prims.of_int (8))
+                                                       (Prims.of_int (212))
+                                                       (Prims.of_int (29)))))
                                               (FStar_Sealed.seal
                                                  (Obj.magic
                                                     (FStar_Range.mk_range
@@ -2210,35 +2239,58 @@ let rec (st_term_to_string' :
                                                        (Prims.of_int (214))
                                                        (Prims.of_int (39)))))
                                               (Obj.magic
-                                                 (FStar_Tactics_Effect.tac_bind
-                                                    (FStar_Sealed.seal
-                                                       (Obj.magic
-                                                          (FStar_Range.mk_range
-                                                             "Pulse.Syntax.Printer.fst"
-                                                             (Prims.of_int (211))
-                                                             (Prims.of_int (8))
-                                                             (Prims.of_int (211))
-                                                             (Prims.of_int (33)))))
-                                                    (FStar_Sealed.seal
-                                                       (Obj.magic
-                                                          (FStar_Range.mk_range
-                                                             "FStar.Printf.fst"
-                                                             (Prims.of_int (122))
-                                                             (Prims.of_int (8))
-                                                             (Prims.of_int (124))
-                                                             (Prims.of_int (44)))))
-                                                    (Obj.magic
-                                                       (binder_to_string
-                                                          binder))
-                                                    (fun uu___2 ->
-                                                       FStar_Tactics_Effect.lift_div_tac
-                                                         (fun uu___3 ->
-                                                            fun x ->
-                                                              fun x1 ->
-                                                                fun x2 ->
-                                                                  Prims.strcat
+                                                 (term_to_string head))
+                                              (fun uu___1 ->
+                                                 (fun uu___1 ->
+                                                    Obj.magic
+                                                      (FStar_Tactics_Effect.tac_bind
+                                                         (FStar_Sealed.seal
+                                                            (Obj.magic
+                                                               (FStar_Range.mk_range
+                                                                  "Pulse.Syntax.Printer.fst"
+                                                                  (Prims.of_int (210))
+                                                                  (Prims.of_int (6))
+                                                                  (Prims.of_int (214))
+                                                                  (Prims.of_int (39)))))
+                                                         (FStar_Sealed.seal
+                                                            (Obj.magic
+                                                               (FStar_Range.mk_range
+                                                                  "Pulse.Syntax.Printer.fst"
+                                                                  (Prims.of_int (210))
+                                                                  (Prims.of_int (6))
+                                                                  (Prims.of_int (214))
+                                                                  (Prims.of_int (39)))))
+                                                         (Obj.magic
+                                                            (FStar_Tactics_Effect.tac_bind
+                                                               (FStar_Sealed.seal
+                                                                  (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Syntax.Printer.fst"
+                                                                    (Prims.of_int (211))
+                                                                    (Prims.of_int (8))
+                                                                    (Prims.of_int (211))
+                                                                    (Prims.of_int (33)))))
+                                                               (FStar_Sealed.seal
+                                                                  (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "FStar.Printf.fst"
+                                                                    (Prims.of_int (122))
+                                                                    (Prims.of_int (8))
+                                                                    (Prims.of_int (124))
+                                                                    (Prims.of_int (44)))))
+                                                               (Obj.magic
+                                                                  (binder_to_string
+                                                                    binder))
+                                                               (fun uu___2 ->
+                                                                  FStar_Tactics_Effect.lift_div_tac
                                                                     (
+                                                                    fun
+                                                                    uu___3 ->
+                                                                    fun x ->
+                                                                    fun x1 ->
+                                                                    fun x2 ->
                                                                     Prims.strcat
+                                                                    (Prims.strcat
                                                                     (Prims.strcat
                                                                     (Prims.strcat
                                                                     "let tot "
@@ -2249,105 +2301,98 @@ let rec (st_term_to_string' :
                                                                     x ";\n"))
                                                                     (Prims.strcat
                                                                     x1 ""))
-                                                                    (
-                                                                    Prims.strcat
+                                                                    (Prims.strcat
                                                                     x2 "")))))
-                                              (fun uu___2 ->
-                                                 FStar_Tactics_Effect.lift_div_tac
-                                                   (fun uu___3 ->
-                                                      uu___2 uu___1))))
-                                        uu___1)))
-                             (fun uu___1 ->
-                                FStar_Tactics_Effect.lift_div_tac
-                                  (fun uu___2 -> uu___1 level))))
-                       (fun uu___1 ->
-                          FStar_Tactics_Effect.lift_div_tac
-                            (fun uu___2 -> uu___1 uu___)))) uu___)
-      | Pulse_Syntax_Base.Tm_Abs
-          { Pulse_Syntax_Base.b = b; Pulse_Syntax_Base.q = q;
-            Pulse_Syntax_Base.ascription = c;
-            Pulse_Syntax_Base.body = body;_}
-          ->
-          FStar_Tactics_Effect.tac_bind
-            (FStar_Sealed.seal
-               (Obj.magic
-                  (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                     (Prims.of_int (223)) (Prims.of_int (14))
-                     (Prims.of_int (223)) (Prims.of_int (90)))))
-            (FStar_Sealed.seal
-               (Obj.magic
-                  (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                     (Prims.of_int (217)) (Prims.of_int (6))
-                     (Prims.of_int (223)) (Prims.of_int (90)))))
-            (match c.Pulse_Syntax_Base.elaborated with
-             | FStar_Pervasives_Native.None ->
-                 Obj.magic
-                   (Obj.repr
-                      (FStar_Tactics_Effect.lift_div_tac (fun uu___ -> "")))
-             | FStar_Pervasives_Native.Some c1 ->
-                 Obj.magic
-                   (Obj.repr
-                      (FStar_Tactics_Effect.tac_bind
-                         (FStar_Sealed.seal
-                            (Obj.magic
-                               (FStar_Range.mk_range
-                                  "Pulse.Syntax.Printer.fst"
-                                  (Prims.of_int (223)) (Prims.of_int (73))
-                                  (Prims.of_int (223)) (Prims.of_int (89)))))
-                         (FStar_Sealed.seal
-                            (Obj.magic
-                               (FStar_Range.mk_range "prims.fst"
-                                  (Prims.of_int (590)) (Prims.of_int (19))
-                                  (Prims.of_int (590)) (Prims.of_int (31)))))
-                         (Obj.magic (comp_to_string c1))
-                         (fun uu___ ->
-                            FStar_Tactics_Effect.lift_div_tac
-                              (fun uu___1 -> Prims.strcat " <: " uu___)))))
-            (fun uu___ ->
-               (fun uu___ ->
-                  Obj.magic
+                                                         (fun uu___2 ->
+                                                            FStar_Tactics_Effect.lift_div_tac
+                                                              (fun uu___3 ->
+                                                                 uu___2
+                                                                   uu___1))))
+                                                   uu___1)))
+                                        (fun uu___1 ->
+                                           FStar_Tactics_Effect.lift_div_tac
+                                             (fun uu___2 -> uu___1 level))))
+                                  (fun uu___1 ->
+                                     FStar_Tactics_Effect.lift_div_tac
+                                       (fun uu___2 -> uu___1 uu___)))) uu___)))
+           | Pulse_Syntax_Base.Tm_Abs
+               { Pulse_Syntax_Base.b = b; Pulse_Syntax_Base.q = q;
+                 Pulse_Syntax_Base.ascription = c;
+                 Pulse_Syntax_Base.body = body;_}
+               ->
+               Obj.magic
+                 (Obj.repr
                     (FStar_Tactics_Effect.tac_bind
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (217)) (Prims.of_int (6))
+                                (Prims.of_int (223)) (Prims.of_int (14))
                                 (Prims.of_int (223)) (Prims.of_int (90)))))
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
                                 (Prims.of_int (217)) (Prims.of_int (6))
                                 (Prims.of_int (223)) (Prims.of_int (90)))))
-                       (Obj.magic
-                          (FStar_Tactics_Effect.tac_bind
-                             (FStar_Sealed.seal
-                                (Obj.magic
-                                   (FStar_Range.mk_range
-                                      "Pulse.Syntax.Printer.fst"
-                                      (Prims.of_int (222))
-                                      (Prims.of_int (14))
-                                      (Prims.of_int (222))
-                                      (Prims.of_int (54)))))
-                             (FStar_Sealed.seal
-                                (Obj.magic
-                                   (FStar_Range.mk_range
-                                      "Pulse.Syntax.Printer.fst"
-                                      (Prims.of_int (217)) (Prims.of_int (6))
-                                      (Prims.of_int (223))
-                                      (Prims.of_int (90)))))
-                             (Obj.magic
-                                (st_term_to_string' (indent level) body))
-                             (fun uu___1 ->
-                                (fun uu___1 ->
-                                   Obj.magic
+                       (match c.Pulse_Syntax_Base.elaborated with
+                        | FStar_Pervasives_Native.None ->
+                            Obj.magic
+                              (Obj.repr
+                                 (FStar_Tactics_Effect.lift_div_tac
+                                    (fun uu___ -> "")))
+                        | FStar_Pervasives_Native.Some c1 ->
+                            Obj.magic
+                              (Obj.repr
+                                 (FStar_Tactics_Effect.tac_bind
+                                    (FStar_Sealed.seal
+                                       (Obj.magic
+                                          (FStar_Range.mk_range
+                                             "Pulse.Syntax.Printer.fst"
+                                             (Prims.of_int (223))
+                                             (Prims.of_int (73))
+                                             (Prims.of_int (223))
+                                             (Prims.of_int (89)))))
+                                    (FStar_Sealed.seal
+                                       (Obj.magic
+                                          (FStar_Range.mk_range "prims.fst"
+                                             (Prims.of_int (590))
+                                             (Prims.of_int (19))
+                                             (Prims.of_int (590))
+                                             (Prims.of_int (31)))))
+                                    (Obj.magic (comp_to_string c1))
+                                    (fun uu___ ->
+                                       FStar_Tactics_Effect.lift_div_tac
+                                         (fun uu___1 ->
+                                            Prims.strcat " <: " uu___)))))
+                       (fun uu___ ->
+                          (fun uu___ ->
+                             Obj.magic
+                               (FStar_Tactics_Effect.tac_bind
+                                  (FStar_Sealed.seal
+                                     (Obj.magic
+                                        (FStar_Range.mk_range
+                                           "Pulse.Syntax.Printer.fst"
+                                           (Prims.of_int (217))
+                                           (Prims.of_int (6))
+                                           (Prims.of_int (223))
+                                           (Prims.of_int (90)))))
+                                  (FStar_Sealed.seal
+                                     (Obj.magic
+                                        (FStar_Range.mk_range
+                                           "Pulse.Syntax.Printer.fst"
+                                           (Prims.of_int (217))
+                                           (Prims.of_int (6))
+                                           (Prims.of_int (223))
+                                           (Prims.of_int (90)))))
+                                  (Obj.magic
                                      (FStar_Tactics_Effect.tac_bind
                                         (FStar_Sealed.seal
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.Syntax.Printer.fst"
-                                                 (Prims.of_int (217))
-                                                 (Prims.of_int (6))
-                                                 (Prims.of_int (223))
-                                                 (Prims.of_int (90)))))
+                                                 (Prims.of_int (222))
+                                                 (Prims.of_int (14))
+                                                 (Prims.of_int (222))
+                                                 (Prims.of_int (54)))))
                                         (FStar_Sealed.seal
                                            (Obj.magic
                                               (FStar_Range.mk_range
@@ -2357,68 +2402,56 @@ let rec (st_term_to_string' :
                                                  (Prims.of_int (223))
                                                  (Prims.of_int (90)))))
                                         (Obj.magic
-                                           (FStar_Tactics_Effect.tac_bind
-                                              (FStar_Sealed.seal
-                                                 (Obj.magic
-                                                    (FStar_Range.mk_range
-                                                       "Pulse.Syntax.Printer.fst"
-                                                       (Prims.of_int (217))
-                                                       (Prims.of_int (6))
-                                                       (Prims.of_int (223))
-                                                       (Prims.of_int (90)))))
-                                              (FStar_Sealed.seal
-                                                 (Obj.magic
-                                                    (FStar_Range.mk_range
-                                                       "Pulse.Syntax.Printer.fst"
-                                                       (Prims.of_int (217))
-                                                       (Prims.of_int (6))
-                                                       (Prims.of_int (223))
-                                                       (Prims.of_int (90)))))
-                                              (Obj.magic
-                                                 (FStar_Tactics_Effect.tac_bind
-                                                    (FStar_Sealed.seal
-                                                       (Obj.magic
-                                                          (FStar_Range.mk_range
-                                                             "Pulse.Syntax.Printer.fst"
-                                                             (Prims.of_int (220))
-                                                             (Prims.of_int (14))
-                                                             (Prims.of_int (220))
-                                                             (Prims.of_int (80)))))
-                                                    (FStar_Sealed.seal
-                                                       (Obj.magic
-                                                          (FStar_Range.mk_range
-                                                             "Pulse.Syntax.Printer.fst"
-                                                             (Prims.of_int (217))
-                                                             (Prims.of_int (6))
-                                                             (Prims.of_int (223))
-                                                             (Prims.of_int (90)))))
-                                                    (match c.Pulse_Syntax_Base.annotated
-                                                     with
-                                                     | FStar_Pervasives_Native.None
-                                                         ->
-                                                         Obj.magic
-                                                           (Obj.repr
-                                                              (FStar_Tactics_Effect.lift_div_tac
-                                                                 (fun uu___2
-                                                                    -> "")))
-                                                     | FStar_Pervasives_Native.Some
-                                                         c1 ->
-                                                         Obj.magic
-                                                           (Obj.repr
-                                                              (comp_to_string
-                                                                 c1)))
-                                                    (fun uu___2 ->
-                                                       (fun uu___2 ->
-                                                          Obj.magic
+                                           (st_term_to_string' (indent level)
+                                              body))
+                                        (fun uu___1 ->
+                                           (fun uu___1 ->
+                                              Obj.magic
+                                                (FStar_Tactics_Effect.tac_bind
+                                                   (FStar_Sealed.seal
+                                                      (Obj.magic
+                                                         (FStar_Range.mk_range
+                                                            "Pulse.Syntax.Printer.fst"
+                                                            (Prims.of_int (217))
+                                                            (Prims.of_int (6))
+                                                            (Prims.of_int (223))
+                                                            (Prims.of_int (90)))))
+                                                   (FStar_Sealed.seal
+                                                      (Obj.magic
+                                                         (FStar_Range.mk_range
+                                                            "Pulse.Syntax.Printer.fst"
+                                                            (Prims.of_int (217))
+                                                            (Prims.of_int (6))
+                                                            (Prims.of_int (223))
+                                                            (Prims.of_int (90)))))
+                                                   (Obj.magic
+                                                      (FStar_Tactics_Effect.tac_bind
+                                                         (FStar_Sealed.seal
+                                                            (Obj.magic
+                                                               (FStar_Range.mk_range
+                                                                  "Pulse.Syntax.Printer.fst"
+                                                                  (Prims.of_int (217))
+                                                                  (Prims.of_int (6))
+                                                                  (Prims.of_int (223))
+                                                                  (Prims.of_int (90)))))
+                                                         (FStar_Sealed.seal
+                                                            (Obj.magic
+                                                               (FStar_Range.mk_range
+                                                                  "Pulse.Syntax.Printer.fst"
+                                                                  (Prims.of_int (217))
+                                                                  (Prims.of_int (6))
+                                                                  (Prims.of_int (223))
+                                                                  (Prims.of_int (90)))))
+                                                         (Obj.magic
                                                             (FStar_Tactics_Effect.tac_bind
                                                                (FStar_Sealed.seal
                                                                   (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (217))
-                                                                    (Prims.of_int (6))
-                                                                    (Prims.of_int (223))
-                                                                    (Prims.of_int (90)))))
+                                                                    (Prims.of_int (220))
+                                                                    (Prims.of_int (14))
+                                                                    (Prims.of_int (220))
+                                                                    (Prims.of_int (80)))))
                                                                (FStar_Sealed.seal
                                                                   (Obj.magic
                                                                     (FStar_Range.mk_range
@@ -2427,8 +2460,46 @@ let rec (st_term_to_string' :
                                                                     (Prims.of_int (6))
                                                                     (Prims.of_int (223))
                                                                     (Prims.of_int (90)))))
-                                                               (Obj.magic
-                                                                  (FStar_Tactics_Effect.tac_bind
+                                                               (match 
+                                                                  c.Pulse_Syntax_Base.annotated
+                                                                with
+                                                                | FStar_Pervasives_Native.None
+                                                                    ->
+                                                                    Obj.magic
+                                                                    (Obj.repr
+                                                                    (FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___2 ->
+                                                                    "")))
+                                                                | FStar_Pervasives_Native.Some
+                                                                    c1 ->
+                                                                    Obj.magic
+                                                                    (Obj.repr
+                                                                    (comp_to_string
+                                                                    c1)))
+                                                               (fun uu___2 ->
+                                                                  (fun uu___2
+                                                                    ->
+                                                                    Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Syntax.Printer.fst"
+                                                                    (Prims.of_int (217))
+                                                                    (Prims.of_int (6))
+                                                                    (Prims.of_int (223))
+                                                                    (Prims.of_int (90)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Syntax.Printer.fst"
+                                                                    (Prims.of_int (217))
+                                                                    (Prims.of_int (6))
+                                                                    (Prims.of_int (223))
+                                                                    (Prims.of_int (90)))))
+                                                                    (Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
@@ -2479,65 +2550,55 @@ let rec (st_term_to_string' :
                                                                     x2 "\n}"))
                                                                     (Prims.strcat
                                                                     x3 ")")))))
-                                                               (fun uu___3 ->
-                                                                  FStar_Tactics_Effect.lift_div_tac
-                                                                    (
-                                                                    fun
+                                                                    (fun
+                                                                    uu___3 ->
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
                                                                     uu___4 ->
                                                                     uu___3
                                                                     uu___2))))
-                                                         uu___2)))
-                                              (fun uu___2 ->
-                                                 FStar_Tactics_Effect.lift_div_tac
-                                                   (fun uu___3 ->
-                                                      uu___2 (indent level)))))
-                                        (fun uu___2 ->
-                                           FStar_Tactics_Effect.lift_div_tac
-                                             (fun uu___3 -> uu___2 uu___1))))
-                                  uu___1)))
-                       (fun uu___1 ->
-                          FStar_Tactics_Effect.lift_div_tac
-                            (fun uu___2 -> uu___1 uu___)))) uu___)
-      | Pulse_Syntax_Base.Tm_If
-          { Pulse_Syntax_Base.b1 = b; Pulse_Syntax_Base.then_ = then_;
-            Pulse_Syntax_Base.else_ = else_;
-            Pulse_Syntax_Base.post1 = uu___;_}
-          ->
-          FStar_Tactics_Effect.tac_bind
-            (FStar_Sealed.seal
-               (Obj.magic
-                  (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                     (Prims.of_int (226)) (Prims.of_int (6))
-                     (Prims.of_int (236)) (Prims.of_int (13)))))
-            (FStar_Sealed.seal
-               (Obj.magic
-                  (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                     (Prims.of_int (226)) (Prims.of_int (6))
-                     (Prims.of_int (236)) (Prims.of_int (13)))))
-            (Obj.magic
-               (FStar_Tactics_Effect.tac_bind
-                  (FStar_Sealed.seal
-                     (Obj.magic
-                        (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                           (Prims.of_int (235)) (Prims.of_int (8))
-                           (Prims.of_int (235)) (Prims.of_int (49)))))
-                  (FStar_Sealed.seal
-                     (Obj.magic
-                        (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                           (Prims.of_int (226)) (Prims.of_int (6))
-                           (Prims.of_int (236)) (Prims.of_int (13)))))
-                  (Obj.magic (st_term_to_string' (indent level) else_))
-                  (fun uu___1 ->
-                     (fun uu___1 ->
-                        Obj.magic
+                                                                    uu___2)))
+                                                         (fun uu___2 ->
+                                                            FStar_Tactics_Effect.lift_div_tac
+                                                              (fun uu___3 ->
+                                                                 uu___2
+                                                                   (indent
+                                                                    level)))))
+                                                   (fun uu___2 ->
+                                                      FStar_Tactics_Effect.lift_div_tac
+                                                        (fun uu___3 ->
+                                                           uu___2 uu___1))))
+                                             uu___1)))
+                                  (fun uu___1 ->
+                                     FStar_Tactics_Effect.lift_div_tac
+                                       (fun uu___2 -> uu___1 uu___)))) uu___)))
+           | Pulse_Syntax_Base.Tm_If
+               { Pulse_Syntax_Base.b1 = b; Pulse_Syntax_Base.then_ = then_;
+                 Pulse_Syntax_Base.else_ = else_;
+                 Pulse_Syntax_Base.post1 = uu___;_}
+               ->
+               Obj.magic
+                 (Obj.repr
+                    (FStar_Tactics_Effect.tac_bind
+                       (FStar_Sealed.seal
+                          (Obj.magic
+                             (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
+                                (Prims.of_int (226)) (Prims.of_int (6))
+                                (Prims.of_int (236)) (Prims.of_int (13)))))
+                       (FStar_Sealed.seal
+                          (Obj.magic
+                             (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
+                                (Prims.of_int (226)) (Prims.of_int (6))
+                                (Prims.of_int (236)) (Prims.of_int (13)))))
+                       (Obj.magic
                           (FStar_Tactics_Effect.tac_bind
                              (FStar_Sealed.seal
                                 (Obj.magic
                                    (FStar_Range.mk_range
                                       "Pulse.Syntax.Printer.fst"
-                                      (Prims.of_int (226)) (Prims.of_int (6))
-                                      (Prims.of_int (236))
-                                      (Prims.of_int (13)))))
+                                      (Prims.of_int (235)) (Prims.of_int (8))
+                                      (Prims.of_int (235))
+                                      (Prims.of_int (49)))))
                              (FStar_Sealed.seal
                                 (Obj.magic
                                    (FStar_Range.mk_range
@@ -2546,104 +2607,128 @@ let rec (st_term_to_string' :
                                       (Prims.of_int (236))
                                       (Prims.of_int (13)))))
                              (Obj.magic
-                                (FStar_Tactics_Effect.tac_bind
-                                   (FStar_Sealed.seal
-                                      (Obj.magic
-                                         (FStar_Range.mk_range
-                                            "Pulse.Syntax.Printer.fst"
-                                            (Prims.of_int (226))
-                                            (Prims.of_int (6))
-                                            (Prims.of_int (236))
-                                            (Prims.of_int (13)))))
-                                   (FStar_Sealed.seal
-                                      (Obj.magic
-                                         (FStar_Range.mk_range
-                                            "Pulse.Syntax.Printer.fst"
-                                            (Prims.of_int (226))
-                                            (Prims.of_int (6))
-                                            (Prims.of_int (236))
-                                            (Prims.of_int (13)))))
-                                   (Obj.magic
-                                      (FStar_Tactics_Effect.tac_bind
-                                         (FStar_Sealed.seal
-                                            (Obj.magic
-                                               (FStar_Range.mk_range
-                                                  "Pulse.Syntax.Printer.fst"
-                                                  (Prims.of_int (226))
-                                                  (Prims.of_int (6))
-                                                  (Prims.of_int (236))
-                                                  (Prims.of_int (13)))))
-                                         (FStar_Sealed.seal
-                                            (Obj.magic
-                                               (FStar_Range.mk_range
-                                                  "Pulse.Syntax.Printer.fst"
-                                                  (Prims.of_int (226))
-                                                  (Prims.of_int (6))
-                                                  (Prims.of_int (236))
-                                                  (Prims.of_int (13)))))
-                                         (Obj.magic
-                                            (FStar_Tactics_Effect.tac_bind
-                                               (FStar_Sealed.seal
-                                                  (Obj.magic
-                                                     (FStar_Range.mk_range
-                                                        "Pulse.Syntax.Printer.fst"
-                                                        (Prims.of_int (226))
-                                                        (Prims.of_int (6))
-                                                        (Prims.of_int (236))
-                                                        (Prims.of_int (13)))))
-                                               (FStar_Sealed.seal
-                                                  (Obj.magic
-                                                     (FStar_Range.mk_range
-                                                        "Pulse.Syntax.Printer.fst"
-                                                        (Prims.of_int (226))
-                                                        (Prims.of_int (6))
-                                                        (Prims.of_int (236))
-                                                        (Prims.of_int (13)))))
-                                               (Obj.magic
-                                                  (FStar_Tactics_Effect.tac_bind
-                                                     (FStar_Sealed.seal
-                                                        (Obj.magic
-                                                           (FStar_Range.mk_range
-                                                              "Pulse.Syntax.Printer.fst"
-                                                              (Prims.of_int (226))
-                                                              (Prims.of_int (6))
-                                                              (Prims.of_int (236))
-                                                              (Prims.of_int (13)))))
-                                                     (FStar_Sealed.seal
-                                                        (Obj.magic
-                                                           (FStar_Range.mk_range
-                                                              "Pulse.Syntax.Printer.fst"
-                                                              (Prims.of_int (226))
-                                                              (Prims.of_int (6))
-                                                              (Prims.of_int (236))
-                                                              (Prims.of_int (13)))))
-                                                     (Obj.magic
-                                                        (FStar_Tactics_Effect.tac_bind
-                                                           (FStar_Sealed.seal
-                                                              (Obj.magic
-                                                                 (FStar_Range.mk_range
-                                                                    "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (230))
-                                                                    (Prims.of_int (8))
-                                                                    (Prims.of_int (230))
-                                                                    (Prims.of_int (49)))))
-                                                           (FStar_Sealed.seal
-                                                              (Obj.magic
-                                                                 (FStar_Range.mk_range
+                                (st_term_to_string' (indent level) else_))
+                             (fun uu___1 ->
+                                (fun uu___1 ->
+                                   Obj.magic
+                                     (FStar_Tactics_Effect.tac_bind
+                                        (FStar_Sealed.seal
+                                           (Obj.magic
+                                              (FStar_Range.mk_range
+                                                 "Pulse.Syntax.Printer.fst"
+                                                 (Prims.of_int (226))
+                                                 (Prims.of_int (6))
+                                                 (Prims.of_int (236))
+                                                 (Prims.of_int (13)))))
+                                        (FStar_Sealed.seal
+                                           (Obj.magic
+                                              (FStar_Range.mk_range
+                                                 "Pulse.Syntax.Printer.fst"
+                                                 (Prims.of_int (226))
+                                                 (Prims.of_int (6))
+                                                 (Prims.of_int (236))
+                                                 (Prims.of_int (13)))))
+                                        (Obj.magic
+                                           (FStar_Tactics_Effect.tac_bind
+                                              (FStar_Sealed.seal
+                                                 (Obj.magic
+                                                    (FStar_Range.mk_range
+                                                       "Pulse.Syntax.Printer.fst"
+                                                       (Prims.of_int (226))
+                                                       (Prims.of_int (6))
+                                                       (Prims.of_int (236))
+                                                       (Prims.of_int (13)))))
+                                              (FStar_Sealed.seal
+                                                 (Obj.magic
+                                                    (FStar_Range.mk_range
+                                                       "Pulse.Syntax.Printer.fst"
+                                                       (Prims.of_int (226))
+                                                       (Prims.of_int (6))
+                                                       (Prims.of_int (236))
+                                                       (Prims.of_int (13)))))
+                                              (Obj.magic
+                                                 (FStar_Tactics_Effect.tac_bind
+                                                    (FStar_Sealed.seal
+                                                       (Obj.magic
+                                                          (FStar_Range.mk_range
+                                                             "Pulse.Syntax.Printer.fst"
+                                                             (Prims.of_int (226))
+                                                             (Prims.of_int (6))
+                                                             (Prims.of_int (236))
+                                                             (Prims.of_int (13)))))
+                                                    (FStar_Sealed.seal
+                                                       (Obj.magic
+                                                          (FStar_Range.mk_range
+                                                             "Pulse.Syntax.Printer.fst"
+                                                             (Prims.of_int (226))
+                                                             (Prims.of_int (6))
+                                                             (Prims.of_int (236))
+                                                             (Prims.of_int (13)))))
+                                                    (Obj.magic
+                                                       (FStar_Tactics_Effect.tac_bind
+                                                          (FStar_Sealed.seal
+                                                             (Obj.magic
+                                                                (FStar_Range.mk_range
+                                                                   "Pulse.Syntax.Printer.fst"
+                                                                   (Prims.of_int (226))
+                                                                   (Prims.of_int (6))
+                                                                   (Prims.of_int (236))
+                                                                   (Prims.of_int (13)))))
+                                                          (FStar_Sealed.seal
+                                                             (Obj.magic
+                                                                (FStar_Range.mk_range
+                                                                   "Pulse.Syntax.Printer.fst"
+                                                                   (Prims.of_int (226))
+                                                                   (Prims.of_int (6))
+                                                                   (Prims.of_int (236))
+                                                                   (Prims.of_int (13)))))
+                                                          (Obj.magic
+                                                             (FStar_Tactics_Effect.tac_bind
+                                                                (FStar_Sealed.seal
+                                                                   (Obj.magic
+                                                                    (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
                                                                     (Prims.of_int (226))
                                                                     (Prims.of_int (6))
                                                                     (Prims.of_int (236))
                                                                     (Prims.of_int (13)))))
-                                                           (Obj.magic
-                                                              (st_term_to_string'
-                                                                 (indent
-                                                                    level)
-                                                                 then_))
-                                                           (fun uu___2 ->
-                                                              (fun uu___2 ->
-                                                                 Obj.magic
+                                                                (FStar_Sealed.seal
+                                                                   (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Syntax.Printer.fst"
+                                                                    (Prims.of_int (226))
+                                                                    (Prims.of_int (6))
+                                                                    (Prims.of_int (236))
+                                                                    (Prims.of_int (13)))))
+                                                                (Obj.magic
                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Syntax.Printer.fst"
+                                                                    (Prims.of_int (230))
+                                                                    (Prims.of_int (8))
+                                                                    (Prims.of_int (230))
+                                                                    (Prims.of_int (49)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Syntax.Printer.fst"
+                                                                    (Prims.of_int (226))
+                                                                    (Prims.of_int (6))
+                                                                    (Prims.of_int (236))
+                                                                    (Prims.of_int (13)))))
+                                                                    (Obj.magic
+                                                                    (st_term_to_string'
+                                                                    (indent
+                                                                    level)
+                                                                    then_))
+                                                                    (fun
+                                                                    uu___2 ->
+                                                                    (fun
+                                                                    uu___2 ->
+                                                                    Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
@@ -2786,249 +2871,278 @@ let rec (st_term_to_string' :
                                                                     uu___4 ->
                                                                     uu___3
                                                                     uu___2))))
-                                                                uu___2)))
-                                                     (fun uu___2 ->
-                                                        FStar_Tactics_Effect.lift_div_tac
-                                                          (fun uu___3 ->
-                                                             uu___2 level))))
-                                               (fun uu___2 ->
-                                                  FStar_Tactics_Effect.lift_div_tac
-                                                    (fun uu___3 ->
-                                                       uu___2 level))))
-                                         (fun uu___2 ->
-                                            FStar_Tactics_Effect.lift_div_tac
-                                              (fun uu___3 -> uu___2 level))))
-                                   (fun uu___2 ->
-                                      FStar_Tactics_Effect.lift_div_tac
-                                        (fun uu___3 -> uu___2 (indent level)))))
-                             (fun uu___2 ->
-                                FStar_Tactics_Effect.lift_div_tac
-                                  (fun uu___3 -> uu___2 uu___1)))) uu___1)))
-            (fun uu___1 ->
-               FStar_Tactics_Effect.lift_div_tac (fun uu___2 -> uu___1 level))
-      | Pulse_Syntax_Base.Tm_Match
-          { Pulse_Syntax_Base.sc = sc; Pulse_Syntax_Base.returns_ = uu___;
-            Pulse_Syntax_Base.brs = brs;_}
-          ->
-          FStar_Tactics_Effect.tac_bind
-            (FStar_Sealed.seal
-               (Obj.magic
-                  (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                     (Prims.of_int (241)) (Prims.of_int (8))
-                     (Prims.of_int (241)) (Prims.of_int (32)))))
-            (FStar_Sealed.seal
-               (Obj.magic
-                  (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                     (Prims.of_int (239)) (Prims.of_int (6))
-                     (Prims.of_int (241)) (Prims.of_int (32)))))
-            (Obj.magic (branches_to_string brs))
-            (fun uu___1 ->
-               (fun uu___1 ->
-                  Obj.magic
-                    (FStar_Tactics_Effect.tac_bind
-                       (FStar_Sealed.seal
-                          (Obj.magic
-                             (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (239)) (Prims.of_int (6))
-                                (Prims.of_int (241)) (Prims.of_int (32)))))
-                       (FStar_Sealed.seal
-                          (Obj.magic
-                             (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (239)) (Prims.of_int (6))
-                                (Prims.of_int (241)) (Prims.of_int (32)))))
-                       (Obj.magic
-                          (FStar_Tactics_Effect.tac_bind
-                             (FStar_Sealed.seal
-                                (Obj.magic
-                                   (FStar_Range.mk_range
-                                      "Pulse.Syntax.Printer.fst"
-                                      (Prims.of_int (240)) (Prims.of_int (8))
-                                      (Prims.of_int (240))
-                                      (Prims.of_int (27)))))
-                             (FStar_Sealed.seal
-                                (Obj.magic
-                                   (FStar_Range.mk_range "FStar.Printf.fst"
-                                      (Prims.of_int (122)) (Prims.of_int (8))
-                                      (Prims.of_int (124))
-                                      (Prims.of_int (44)))))
-                             (Obj.magic (term_to_string sc))
-                             (fun uu___2 ->
-                                FStar_Tactics_Effect.lift_div_tac
-                                  (fun uu___3 ->
-                                     fun x ->
-                                       Prims.strcat
-                                         (Prims.strcat "match ("
-                                            (Prims.strcat uu___2 ") with "))
-                                         (Prims.strcat x "")))))
-                       (fun uu___2 ->
-                          FStar_Tactics_Effect.lift_div_tac
-                            (fun uu___3 -> uu___2 uu___1)))) uu___1)
-      | Pulse_Syntax_Base.Tm_IntroPure { Pulse_Syntax_Base.p3 = p;_} ->
-          FStar_Tactics_Effect.tac_bind
-            (FStar_Sealed.seal
-               (Obj.magic
-                  (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                     (Prims.of_int (246)) (Prims.of_int (8))
-                     (Prims.of_int (246)) (Prims.of_int (42)))))
-            (FStar_Sealed.seal
-               (Obj.magic
-                  (FStar_Range.mk_range "prims.fst" (Prims.of_int (590))
-                     (Prims.of_int (19)) (Prims.of_int (590))
-                     (Prims.of_int (31)))))
-            (Obj.magic (term_to_string' (indent level) p))
-            (fun uu___ ->
-               FStar_Tactics_Effect.lift_div_tac
-                 (fun uu___1 ->
-                    Prims.strcat
-                      (Prims.strcat "introduce pure (\n"
-                         (Prims.strcat (indent level) ""))
-                      (Prims.strcat uu___ ")")))
-      | Pulse_Syntax_Base.Tm_ElimExists { Pulse_Syntax_Base.p4 = p;_} ->
-          FStar_Tactics_Effect.tac_bind
-            (FStar_Sealed.seal
-               (Obj.magic
-                  (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                     (Prims.of_int (250)) (Prims.of_int (8))
-                     (Prims.of_int (250)) (Prims.of_int (26)))))
-            (FStar_Sealed.seal
-               (Obj.magic
-                  (FStar_Range.mk_range "prims.fst" (Prims.of_int (590))
-                     (Prims.of_int (19)) (Prims.of_int (590))
-                     (Prims.of_int (31))))) (Obj.magic (term_to_string p))
-            (fun uu___ ->
-               FStar_Tactics_Effect.lift_div_tac
-                 (fun uu___1 ->
-                    Prims.strcat "elim_exists " (Prims.strcat uu___ "")))
-      | Pulse_Syntax_Base.Tm_IntroExists
-          { Pulse_Syntax_Base.p5 = p;
-            Pulse_Syntax_Base.witnesses = witnesses;_}
-          ->
-          FStar_Tactics_Effect.tac_bind
-            (FStar_Sealed.seal
-               (Obj.magic
-                  (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                     (Prims.of_int (257)) (Prims.of_int (8))
-                     (Prims.of_int (257)) (Prims.of_int (43)))))
-            (FStar_Sealed.seal
-               (Obj.magic
-                  (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                     (Prims.of_int (253)) (Prims.of_int (6))
-                     (Prims.of_int (257)) (Prims.of_int (43)))))
-            (Obj.magic (term_list_to_string " " witnesses))
-            (fun uu___ ->
-               (fun uu___ ->
-                  Obj.magic
-                    (FStar_Tactics_Effect.tac_bind
-                       (FStar_Sealed.seal
-                          (Obj.magic
-                             (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (253)) (Prims.of_int (6))
-                                (Prims.of_int (257)) (Prims.of_int (43)))))
-                       (FStar_Sealed.seal
-                          (Obj.magic
-                             (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (253)) (Prims.of_int (6))
-                                (Prims.of_int (257)) (Prims.of_int (43)))))
-                       (Obj.magic
-                          (FStar_Tactics_Effect.tac_bind
-                             (FStar_Sealed.seal
-                                (Obj.magic
-                                   (FStar_Range.mk_range
-                                      "Pulse.Syntax.Printer.fst"
-                                      (Prims.of_int (253)) (Prims.of_int (6))
-                                      (Prims.of_int (257))
-                                      (Prims.of_int (43)))))
-                             (FStar_Sealed.seal
-                                (Obj.magic
-                                   (FStar_Range.mk_range
-                                      "Pulse.Syntax.Printer.fst"
-                                      (Prims.of_int (253)) (Prims.of_int (6))
-                                      (Prims.of_int (257))
-                                      (Prims.of_int (43)))))
-                             (Obj.magic
-                                (FStar_Tactics_Effect.tac_bind
-                                   (FStar_Sealed.seal
-                                      (Obj.magic
-                                         (FStar_Range.mk_range
-                                            "Pulse.Syntax.Printer.fst"
-                                            (Prims.of_int (255))
-                                            (Prims.of_int (8))
-                                            (Prims.of_int (255))
-                                            (Prims.of_int (42)))))
-                                   (FStar_Sealed.seal
-                                      (Obj.magic
-                                         (FStar_Range.mk_range
-                                            "FStar.Printf.fst"
-                                            (Prims.of_int (122))
-                                            (Prims.of_int (8))
-                                            (Prims.of_int (124))
-                                            (Prims.of_int (44)))))
-                                   (Obj.magic
-                                      (term_to_string' (indent level) p))
-                                   (fun uu___1 ->
-                                      FStar_Tactics_Effect.lift_div_tac
+                                                                    uu___2)))
+                                                                (fun uu___2
+                                                                   ->
+                                                                   FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___3 ->
+                                                                    uu___2
+                                                                    level))))
+                                                          (fun uu___2 ->
+                                                             FStar_Tactics_Effect.lift_div_tac
+                                                               (fun uu___3 ->
+                                                                  uu___2
+                                                                    level))))
+                                                    (fun uu___2 ->
+                                                       FStar_Tactics_Effect.lift_div_tac
+                                                         (fun uu___3 ->
+                                                            uu___2 level))))
+                                              (fun uu___2 ->
+                                                 FStar_Tactics_Effect.lift_div_tac
+                                                   (fun uu___3 ->
+                                                      uu___2 (indent level)))))
                                         (fun uu___2 ->
-                                           fun x ->
-                                             fun x1 ->
-                                               Prims.strcat
-                                                 (Prims.strcat
-                                                    (Prims.strcat
-                                                       (Prims.strcat
-                                                          "introduce\n"
-                                                          (Prims.strcat
-                                                             (indent level)
-                                                             ""))
-                                                       (Prims.strcat uu___1
-                                                          "\n"))
-                                                    (Prims.strcat x "with "))
-                                                 (Prims.strcat x1 "")))))
-                             (fun uu___1 ->
-                                FStar_Tactics_Effect.lift_div_tac
-                                  (fun uu___2 -> uu___1 level))))
+                                           FStar_Tactics_Effect.lift_div_tac
+                                             (fun uu___3 -> uu___2 uu___1))))
+                                  uu___1)))
                        (fun uu___1 ->
                           FStar_Tactics_Effect.lift_div_tac
-                            (fun uu___2 -> uu___1 uu___)))) uu___)
-      | Pulse_Syntax_Base.Tm_While
-          { Pulse_Syntax_Base.invariant = invariant;
-            Pulse_Syntax_Base.condition = condition;
-            Pulse_Syntax_Base.condition_var = uu___;
-            Pulse_Syntax_Base.body3 = body;_}
-          ->
-          FStar_Tactics_Effect.tac_bind
-            (FStar_Sealed.seal
-               (Obj.magic
-                  (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                     (Prims.of_int (260)) (Prims.of_int (6))
-                     (Prims.of_int (267)) (Prims.of_int (13)))))
-            (FStar_Sealed.seal
-               (Obj.magic
-                  (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                     (Prims.of_int (260)) (Prims.of_int (6))
-                     (Prims.of_int (267)) (Prims.of_int (13)))))
-            (Obj.magic
-               (FStar_Tactics_Effect.tac_bind
-                  (FStar_Sealed.seal
-                     (Obj.magic
-                        (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                           (Prims.of_int (266)) (Prims.of_int (8))
-                           (Prims.of_int (266)) (Prims.of_int (48)))))
-                  (FStar_Sealed.seal
-                     (Obj.magic
-                        (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                           (Prims.of_int (260)) (Prims.of_int (6))
-                           (Prims.of_int (267)) (Prims.of_int (13)))))
-                  (Obj.magic (st_term_to_string' (indent level) body))
-                  (fun uu___1 ->
-                     (fun uu___1 ->
-                        Obj.magic
+                            (fun uu___2 -> uu___1 level))))
+           | Pulse_Syntax_Base.Tm_Match
+               { Pulse_Syntax_Base.sc = sc;
+                 Pulse_Syntax_Base.returns_ = uu___;
+                 Pulse_Syntax_Base.brs = brs;_}
+               ->
+               Obj.magic
+                 (Obj.repr
+                    (FStar_Tactics_Effect.tac_bind
+                       (FStar_Sealed.seal
+                          (Obj.magic
+                             (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
+                                (Prims.of_int (241)) (Prims.of_int (8))
+                                (Prims.of_int (241)) (Prims.of_int (32)))))
+                       (FStar_Sealed.seal
+                          (Obj.magic
+                             (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
+                                (Prims.of_int (239)) (Prims.of_int (6))
+                                (Prims.of_int (241)) (Prims.of_int (32)))))
+                       (Obj.magic (branches_to_string brs))
+                       (fun uu___1 ->
+                          (fun uu___1 ->
+                             Obj.magic
+                               (FStar_Tactics_Effect.tac_bind
+                                  (FStar_Sealed.seal
+                                     (Obj.magic
+                                        (FStar_Range.mk_range
+                                           "Pulse.Syntax.Printer.fst"
+                                           (Prims.of_int (239))
+                                           (Prims.of_int (6))
+                                           (Prims.of_int (241))
+                                           (Prims.of_int (32)))))
+                                  (FStar_Sealed.seal
+                                     (Obj.magic
+                                        (FStar_Range.mk_range
+                                           "Pulse.Syntax.Printer.fst"
+                                           (Prims.of_int (239))
+                                           (Prims.of_int (6))
+                                           (Prims.of_int (241))
+                                           (Prims.of_int (32)))))
+                                  (Obj.magic
+                                     (FStar_Tactics_Effect.tac_bind
+                                        (FStar_Sealed.seal
+                                           (Obj.magic
+                                              (FStar_Range.mk_range
+                                                 "Pulse.Syntax.Printer.fst"
+                                                 (Prims.of_int (240))
+                                                 (Prims.of_int (8))
+                                                 (Prims.of_int (240))
+                                                 (Prims.of_int (27)))))
+                                        (FStar_Sealed.seal
+                                           (Obj.magic
+                                              (FStar_Range.mk_range
+                                                 "FStar.Printf.fst"
+                                                 (Prims.of_int (122))
+                                                 (Prims.of_int (8))
+                                                 (Prims.of_int (124))
+                                                 (Prims.of_int (44)))))
+                                        (Obj.magic (term_to_string sc))
+                                        (fun uu___2 ->
+                                           FStar_Tactics_Effect.lift_div_tac
+                                             (fun uu___3 ->
+                                                fun x ->
+                                                  Prims.strcat
+                                                    (Prims.strcat "match ("
+                                                       (Prims.strcat uu___2
+                                                          ") with "))
+                                                    (Prims.strcat x "")))))
+                                  (fun uu___2 ->
+                                     FStar_Tactics_Effect.lift_div_tac
+                                       (fun uu___3 -> uu___2 uu___1))))
+                            uu___1)))
+           | Pulse_Syntax_Base.Tm_IntroPure { Pulse_Syntax_Base.p3 = p;_} ->
+               Obj.magic
+                 (Obj.repr
+                    (FStar_Tactics_Effect.tac_bind
+                       (FStar_Sealed.seal
+                          (Obj.magic
+                             (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
+                                (Prims.of_int (246)) (Prims.of_int (8))
+                                (Prims.of_int (246)) (Prims.of_int (42)))))
+                       (FStar_Sealed.seal
+                          (Obj.magic
+                             (FStar_Range.mk_range "prims.fst"
+                                (Prims.of_int (590)) (Prims.of_int (19))
+                                (Prims.of_int (590)) (Prims.of_int (31)))))
+                       (Obj.magic (term_to_string' (indent level) p))
+                       (fun uu___ ->
+                          FStar_Tactics_Effect.lift_div_tac
+                            (fun uu___1 ->
+                               Prims.strcat
+                                 (Prims.strcat "introduce pure (\n"
+                                    (Prims.strcat (indent level) ""))
+                                 (Prims.strcat uu___ ")")))))
+           | Pulse_Syntax_Base.Tm_ElimExists { Pulse_Syntax_Base.p4 = p;_} ->
+               Obj.magic
+                 (Obj.repr
+                    (FStar_Tactics_Effect.tac_bind
+                       (FStar_Sealed.seal
+                          (Obj.magic
+                             (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
+                                (Prims.of_int (250)) (Prims.of_int (8))
+                                (Prims.of_int (250)) (Prims.of_int (26)))))
+                       (FStar_Sealed.seal
+                          (Obj.magic
+                             (FStar_Range.mk_range "prims.fst"
+                                (Prims.of_int (590)) (Prims.of_int (19))
+                                (Prims.of_int (590)) (Prims.of_int (31)))))
+                       (Obj.magic (term_to_string p))
+                       (fun uu___ ->
+                          FStar_Tactics_Effect.lift_div_tac
+                            (fun uu___1 ->
+                               Prims.strcat "elim_exists "
+                                 (Prims.strcat uu___ "")))))
+           | Pulse_Syntax_Base.Tm_IntroExists
+               { Pulse_Syntax_Base.p5 = p;
+                 Pulse_Syntax_Base.witnesses = witnesses;_}
+               ->
+               Obj.magic
+                 (Obj.repr
+                    (FStar_Tactics_Effect.tac_bind
+                       (FStar_Sealed.seal
+                          (Obj.magic
+                             (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
+                                (Prims.of_int (257)) (Prims.of_int (8))
+                                (Prims.of_int (257)) (Prims.of_int (43)))))
+                       (FStar_Sealed.seal
+                          (Obj.magic
+                             (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
+                                (Prims.of_int (253)) (Prims.of_int (6))
+                                (Prims.of_int (257)) (Prims.of_int (43)))))
+                       (Obj.magic (term_list_to_string " " witnesses))
+                       (fun uu___ ->
+                          (fun uu___ ->
+                             Obj.magic
+                               (FStar_Tactics_Effect.tac_bind
+                                  (FStar_Sealed.seal
+                                     (Obj.magic
+                                        (FStar_Range.mk_range
+                                           "Pulse.Syntax.Printer.fst"
+                                           (Prims.of_int (253))
+                                           (Prims.of_int (6))
+                                           (Prims.of_int (257))
+                                           (Prims.of_int (43)))))
+                                  (FStar_Sealed.seal
+                                     (Obj.magic
+                                        (FStar_Range.mk_range
+                                           "Pulse.Syntax.Printer.fst"
+                                           (Prims.of_int (253))
+                                           (Prims.of_int (6))
+                                           (Prims.of_int (257))
+                                           (Prims.of_int (43)))))
+                                  (Obj.magic
+                                     (FStar_Tactics_Effect.tac_bind
+                                        (FStar_Sealed.seal
+                                           (Obj.magic
+                                              (FStar_Range.mk_range
+                                                 "Pulse.Syntax.Printer.fst"
+                                                 (Prims.of_int (253))
+                                                 (Prims.of_int (6))
+                                                 (Prims.of_int (257))
+                                                 (Prims.of_int (43)))))
+                                        (FStar_Sealed.seal
+                                           (Obj.magic
+                                              (FStar_Range.mk_range
+                                                 "Pulse.Syntax.Printer.fst"
+                                                 (Prims.of_int (253))
+                                                 (Prims.of_int (6))
+                                                 (Prims.of_int (257))
+                                                 (Prims.of_int (43)))))
+                                        (Obj.magic
+                                           (FStar_Tactics_Effect.tac_bind
+                                              (FStar_Sealed.seal
+                                                 (Obj.magic
+                                                    (FStar_Range.mk_range
+                                                       "Pulse.Syntax.Printer.fst"
+                                                       (Prims.of_int (255))
+                                                       (Prims.of_int (8))
+                                                       (Prims.of_int (255))
+                                                       (Prims.of_int (42)))))
+                                              (FStar_Sealed.seal
+                                                 (Obj.magic
+                                                    (FStar_Range.mk_range
+                                                       "FStar.Printf.fst"
+                                                       (Prims.of_int (122))
+                                                       (Prims.of_int (8))
+                                                       (Prims.of_int (124))
+                                                       (Prims.of_int (44)))))
+                                              (Obj.magic
+                                                 (term_to_string'
+                                                    (indent level) p))
+                                              (fun uu___1 ->
+                                                 FStar_Tactics_Effect.lift_div_tac
+                                                   (fun uu___2 ->
+                                                      fun x ->
+                                                        fun x1 ->
+                                                          Prims.strcat
+                                                            (Prims.strcat
+                                                               (Prims.strcat
+                                                                  (Prims.strcat
+                                                                    "introduce\n"
+                                                                    (Prims.strcat
+                                                                    (indent
+                                                                    level) ""))
+                                                                  (Prims.strcat
+                                                                    uu___1
+                                                                    "\n"))
+                                                               (Prims.strcat
+                                                                  x "with "))
+                                                            (Prims.strcat x1
+                                                               "")))))
+                                        (fun uu___1 ->
+                                           FStar_Tactics_Effect.lift_div_tac
+                                             (fun uu___2 -> uu___1 level))))
+                                  (fun uu___1 ->
+                                     FStar_Tactics_Effect.lift_div_tac
+                                       (fun uu___2 -> uu___1 uu___)))) uu___)))
+           | Pulse_Syntax_Base.Tm_While
+               { Pulse_Syntax_Base.invariant = invariant;
+                 Pulse_Syntax_Base.condition = condition;
+                 Pulse_Syntax_Base.condition_var = uu___;
+                 Pulse_Syntax_Base.body3 = body;_}
+               ->
+               Obj.magic
+                 (Obj.repr
+                    (FStar_Tactics_Effect.tac_bind
+                       (FStar_Sealed.seal
+                          (Obj.magic
+                             (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
+                                (Prims.of_int (260)) (Prims.of_int (6))
+                                (Prims.of_int (267)) (Prims.of_int (13)))))
+                       (FStar_Sealed.seal
+                          (Obj.magic
+                             (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
+                                (Prims.of_int (260)) (Prims.of_int (6))
+                                (Prims.of_int (267)) (Prims.of_int (13)))))
+                       (Obj.magic
                           (FStar_Tactics_Effect.tac_bind
                              (FStar_Sealed.seal
                                 (Obj.magic
                                    (FStar_Range.mk_range
                                       "Pulse.Syntax.Printer.fst"
-                                      (Prims.of_int (260)) (Prims.of_int (6))
-                                      (Prims.of_int (267))
-                                      (Prims.of_int (13)))))
+                                      (Prims.of_int (266)) (Prims.of_int (8))
+                                      (Prims.of_int (266))
+                                      (Prims.of_int (48)))))
                              (FStar_Sealed.seal
                                 (Obj.magic
                                    (FStar_Range.mk_range
@@ -3037,73 +3151,73 @@ let rec (st_term_to_string' :
                                       (Prims.of_int (267))
                                       (Prims.of_int (13)))))
                              (Obj.magic
-                                (FStar_Tactics_Effect.tac_bind
-                                   (FStar_Sealed.seal
-                                      (Obj.magic
-                                         (FStar_Range.mk_range
-                                            "Pulse.Syntax.Printer.fst"
-                                            (Prims.of_int (260))
-                                            (Prims.of_int (6))
-                                            (Prims.of_int (267))
-                                            (Prims.of_int (13)))))
-                                   (FStar_Sealed.seal
-                                      (Obj.magic
-                                         (FStar_Range.mk_range
-                                            "Pulse.Syntax.Printer.fst"
-                                            (Prims.of_int (260))
-                                            (Prims.of_int (6))
-                                            (Prims.of_int (267))
-                                            (Prims.of_int (13)))))
-                                   (Obj.magic
-                                      (FStar_Tactics_Effect.tac_bind
-                                         (FStar_Sealed.seal
-                                            (Obj.magic
-                                               (FStar_Range.mk_range
-                                                  "Pulse.Syntax.Printer.fst"
-                                                  (Prims.of_int (260))
-                                                  (Prims.of_int (6))
-                                                  (Prims.of_int (267))
-                                                  (Prims.of_int (13)))))
-                                         (FStar_Sealed.seal
-                                            (Obj.magic
-                                               (FStar_Range.mk_range
-                                                  "Pulse.Syntax.Printer.fst"
-                                                  (Prims.of_int (260))
-                                                  (Prims.of_int (6))
-                                                  (Prims.of_int (267))
-                                                  (Prims.of_int (13)))))
-                                         (Obj.magic
-                                            (FStar_Tactics_Effect.tac_bind
-                                               (FStar_Sealed.seal
-                                                  (Obj.magic
-                                                     (FStar_Range.mk_range
-                                                        "Pulse.Syntax.Printer.fst"
-                                                        (Prims.of_int (263))
-                                                        (Prims.of_int (8))
-                                                        (Prims.of_int (263))
-                                                        (Prims.of_int (34)))))
-                                               (FStar_Sealed.seal
-                                                  (Obj.magic
-                                                     (FStar_Range.mk_range
-                                                        "Pulse.Syntax.Printer.fst"
-                                                        (Prims.of_int (260))
-                                                        (Prims.of_int (6))
-                                                        (Prims.of_int (267))
-                                                        (Prims.of_int (13)))))
-                                               (Obj.magic
-                                                  (term_to_string invariant))
-                                               (fun uu___2 ->
-                                                  (fun uu___2 ->
-                                                     Obj.magic
+                                (st_term_to_string' (indent level) body))
+                             (fun uu___1 ->
+                                (fun uu___1 ->
+                                   Obj.magic
+                                     (FStar_Tactics_Effect.tac_bind
+                                        (FStar_Sealed.seal
+                                           (Obj.magic
+                                              (FStar_Range.mk_range
+                                                 "Pulse.Syntax.Printer.fst"
+                                                 (Prims.of_int (260))
+                                                 (Prims.of_int (6))
+                                                 (Prims.of_int (267))
+                                                 (Prims.of_int (13)))))
+                                        (FStar_Sealed.seal
+                                           (Obj.magic
+                                              (FStar_Range.mk_range
+                                                 "Pulse.Syntax.Printer.fst"
+                                                 (Prims.of_int (260))
+                                                 (Prims.of_int (6))
+                                                 (Prims.of_int (267))
+                                                 (Prims.of_int (13)))))
+                                        (Obj.magic
+                                           (FStar_Tactics_Effect.tac_bind
+                                              (FStar_Sealed.seal
+                                                 (Obj.magic
+                                                    (FStar_Range.mk_range
+                                                       "Pulse.Syntax.Printer.fst"
+                                                       (Prims.of_int (260))
+                                                       (Prims.of_int (6))
+                                                       (Prims.of_int (267))
+                                                       (Prims.of_int (13)))))
+                                              (FStar_Sealed.seal
+                                                 (Obj.magic
+                                                    (FStar_Range.mk_range
+                                                       "Pulse.Syntax.Printer.fst"
+                                                       (Prims.of_int (260))
+                                                       (Prims.of_int (6))
+                                                       (Prims.of_int (267))
+                                                       (Prims.of_int (13)))))
+                                              (Obj.magic
+                                                 (FStar_Tactics_Effect.tac_bind
+                                                    (FStar_Sealed.seal
+                                                       (Obj.magic
+                                                          (FStar_Range.mk_range
+                                                             "Pulse.Syntax.Printer.fst"
+                                                             (Prims.of_int (260))
+                                                             (Prims.of_int (6))
+                                                             (Prims.of_int (267))
+                                                             (Prims.of_int (13)))))
+                                                    (FStar_Sealed.seal
+                                                       (Obj.magic
+                                                          (FStar_Range.mk_range
+                                                             "Pulse.Syntax.Printer.fst"
+                                                             (Prims.of_int (260))
+                                                             (Prims.of_int (6))
+                                                             (Prims.of_int (267))
+                                                             (Prims.of_int (13)))))
+                                                    (Obj.magic
                                                        (FStar_Tactics_Effect.tac_bind
                                                           (FStar_Sealed.seal
                                                              (Obj.magic
                                                                 (FStar_Range.mk_range
                                                                    "Pulse.Syntax.Printer.fst"
-                                                                   (Prims.of_int (260))
-                                                                   (Prims.of_int (6))
-                                                                   (Prims.of_int (267))
-                                                                   (Prims.of_int (13)))))
+                                                                   (Prims.of_int (263))
+                                                                   (Prims.of_int (8))
+                                                                   (Prims.of_int (263))
+                                                                   (Prims.of_int (34)))))
                                                           (FStar_Sealed.seal
                                                              (Obj.magic
                                                                 (FStar_Range.mk_range
@@ -3113,25 +3227,48 @@ let rec (st_term_to_string' :
                                                                    (Prims.of_int (267))
                                                                    (Prims.of_int (13)))))
                                                           (Obj.magic
-                                                             (FStar_Tactics_Effect.tac_bind
-                                                                (FStar_Sealed.seal
-                                                                   (Obj.magic
+                                                             (term_to_string
+                                                                invariant))
+                                                          (fun uu___2 ->
+                                                             (fun uu___2 ->
+                                                                Obj.magic
+                                                                  (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
                                                                     (Prims.of_int (260))
                                                                     (Prims.of_int (6))
                                                                     (Prims.of_int (267))
                                                                     (Prims.of_int (13)))))
-                                                                (FStar_Sealed.seal
-                                                                   (Obj.magic
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
                                                                     (Prims.of_int (260))
                                                                     (Prims.of_int (6))
                                                                     (Prims.of_int (267))
                                                                     (Prims.of_int (13)))))
-                                                                (Obj.magic
-                                                                   (FStar_Tactics_Effect.tac_bind
+                                                                    (Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Syntax.Printer.fst"
+                                                                    (Prims.of_int (260))
+                                                                    (Prims.of_int (6))
+                                                                    (Prims.of_int (267))
+                                                                    (Prims.of_int (13)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Syntax.Printer.fst"
+                                                                    (Prims.of_int (260))
+                                                                    (Prims.of_int (6))
+                                                                    (Prims.of_int (267))
+                                                                    (Prims.of_int (13)))))
+                                                                    (Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
@@ -3187,91 +3324,88 @@ let rec (st_term_to_string' :
                                                                     x4 "\n"))
                                                                     (Prims.strcat
                                                                     x5 "}")))))
-                                                                (fun uu___3
-                                                                   ->
-                                                                   FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___3 ->
+                                                                    FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
                                                                     uu___4 ->
                                                                     uu___3
                                                                     level))))
-                                                          (fun uu___3 ->
-                                                             FStar_Tactics_Effect.lift_div_tac
-                                                               (fun uu___4 ->
-                                                                  uu___3
+                                                                    (fun
+                                                                    uu___3 ->
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___4 ->
+                                                                    uu___3
                                                                     uu___2))))
-                                                    uu___2)))
-                                         (fun uu___2 ->
-                                            FStar_Tactics_Effect.lift_div_tac
-                                              (fun uu___3 -> uu___2 level))))
-                                   (fun uu___2 ->
-                                      FStar_Tactics_Effect.lift_div_tac
-                                        (fun uu___3 -> uu___2 (indent level)))))
-                             (fun uu___2 ->
-                                FStar_Tactics_Effect.lift_div_tac
-                                  (fun uu___3 -> uu___2 uu___1)))) uu___1)))
-            (fun uu___1 ->
-               FStar_Tactics_Effect.lift_div_tac (fun uu___2 -> uu___1 level))
-      | Pulse_Syntax_Base.Tm_Par
-          { Pulse_Syntax_Base.pre1 = pre1; Pulse_Syntax_Base.body11 = body1;
-            Pulse_Syntax_Base.post11 = post1; Pulse_Syntax_Base.pre2 = pre2;
-            Pulse_Syntax_Base.body21 = body2;
-            Pulse_Syntax_Base.post2 = post2;_}
-          ->
-          FStar_Tactics_Effect.tac_bind
-            (FStar_Sealed.seal
-               (Obj.magic
-                  (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                     (Prims.of_int (276)) (Prims.of_int (8))
-                     (Prims.of_int (276)) (Prims.of_int (30)))))
-            (FStar_Sealed.seal
-               (Obj.magic
-                  (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                     (Prims.of_int (270)) (Prims.of_int (6))
-                     (Prims.of_int (276)) (Prims.of_int (30)))))
-            (Obj.magic (term_to_string post2))
-            (fun uu___ ->
-               (fun uu___ ->
-                  Obj.magic
+                                                               uu___2)))
+                                                    (fun uu___2 ->
+                                                       FStar_Tactics_Effect.lift_div_tac
+                                                         (fun uu___3 ->
+                                                            uu___2 level))))
+                                              (fun uu___2 ->
+                                                 FStar_Tactics_Effect.lift_div_tac
+                                                   (fun uu___3 ->
+                                                      uu___2 (indent level)))))
+                                        (fun uu___2 ->
+                                           FStar_Tactics_Effect.lift_div_tac
+                                             (fun uu___3 -> uu___2 uu___1))))
+                                  uu___1)))
+                       (fun uu___1 ->
+                          FStar_Tactics_Effect.lift_div_tac
+                            (fun uu___2 -> uu___1 level))))
+           | Pulse_Syntax_Base.Tm_Par
+               { Pulse_Syntax_Base.pre1 = pre1;
+                 Pulse_Syntax_Base.body11 = body1;
+                 Pulse_Syntax_Base.post11 = post1;
+                 Pulse_Syntax_Base.pre2 = pre2;
+                 Pulse_Syntax_Base.body21 = body2;
+                 Pulse_Syntax_Base.post2 = post2;_}
+               ->
+               Obj.magic
+                 (Obj.repr
                     (FStar_Tactics_Effect.tac_bind
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (270)) (Prims.of_int (6))
+                                (Prims.of_int (276)) (Prims.of_int (8))
                                 (Prims.of_int (276)) (Prims.of_int (30)))))
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
                                 (Prims.of_int (270)) (Prims.of_int (6))
                                 (Prims.of_int (276)) (Prims.of_int (30)))))
-                       (Obj.magic
-                          (FStar_Tactics_Effect.tac_bind
-                             (FStar_Sealed.seal
-                                (Obj.magic
-                                   (FStar_Range.mk_range
-                                      "Pulse.Syntax.Printer.fst"
-                                      (Prims.of_int (275)) (Prims.of_int (8))
-                                      (Prims.of_int (275))
-                                      (Prims.of_int (40)))))
-                             (FStar_Sealed.seal
-                                (Obj.magic
-                                   (FStar_Range.mk_range
-                                      "Pulse.Syntax.Printer.fst"
-                                      (Prims.of_int (270)) (Prims.of_int (6))
-                                      (Prims.of_int (276))
-                                      (Prims.of_int (30)))))
-                             (Obj.magic (st_term_to_string' level body2))
-                             (fun uu___1 ->
-                                (fun uu___1 ->
-                                   Obj.magic
+                       (Obj.magic (term_to_string post2))
+                       (fun uu___ ->
+                          (fun uu___ ->
+                             Obj.magic
+                               (FStar_Tactics_Effect.tac_bind
+                                  (FStar_Sealed.seal
+                                     (Obj.magic
+                                        (FStar_Range.mk_range
+                                           "Pulse.Syntax.Printer.fst"
+                                           (Prims.of_int (270))
+                                           (Prims.of_int (6))
+                                           (Prims.of_int (276))
+                                           (Prims.of_int (30)))))
+                                  (FStar_Sealed.seal
+                                     (Obj.magic
+                                        (FStar_Range.mk_range
+                                           "Pulse.Syntax.Printer.fst"
+                                           (Prims.of_int (270))
+                                           (Prims.of_int (6))
+                                           (Prims.of_int (276))
+                                           (Prims.of_int (30)))))
+                                  (Obj.magic
                                      (FStar_Tactics_Effect.tac_bind
                                         (FStar_Sealed.seal
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.Syntax.Printer.fst"
-                                                 (Prims.of_int (270))
-                                                 (Prims.of_int (6))
-                                                 (Prims.of_int (276))
-                                                 (Prims.of_int (30)))))
+                                                 (Prims.of_int (275))
+                                                 (Prims.of_int (8))
+                                                 (Prims.of_int (275))
+                                                 (Prims.of_int (40)))))
                                         (FStar_Sealed.seal
                                            (Obj.magic
                                               (FStar_Range.mk_range
@@ -3281,37 +3415,37 @@ let rec (st_term_to_string' :
                                                  (Prims.of_int (276))
                                                  (Prims.of_int (30)))))
                                         (Obj.magic
-                                           (FStar_Tactics_Effect.tac_bind
-                                              (FStar_Sealed.seal
-                                                 (Obj.magic
-                                                    (FStar_Range.mk_range
-                                                       "Pulse.Syntax.Printer.fst"
-                                                       (Prims.of_int (274))
-                                                       (Prims.of_int (8))
-                                                       (Prims.of_int (274))
-                                                       (Prims.of_int (29)))))
-                                              (FStar_Sealed.seal
-                                                 (Obj.magic
-                                                    (FStar_Range.mk_range
-                                                       "Pulse.Syntax.Printer.fst"
-                                                       (Prims.of_int (270))
-                                                       (Prims.of_int (6))
-                                                       (Prims.of_int (276))
-                                                       (Prims.of_int (30)))))
-                                              (Obj.magic
-                                                 (term_to_string pre2))
-                                              (fun uu___2 ->
-                                                 (fun uu___2 ->
-                                                    Obj.magic
+                                           (st_term_to_string' level body2))
+                                        (fun uu___1 ->
+                                           (fun uu___1 ->
+                                              Obj.magic
+                                                (FStar_Tactics_Effect.tac_bind
+                                                   (FStar_Sealed.seal
+                                                      (Obj.magic
+                                                         (FStar_Range.mk_range
+                                                            "Pulse.Syntax.Printer.fst"
+                                                            (Prims.of_int (270))
+                                                            (Prims.of_int (6))
+                                                            (Prims.of_int (276))
+                                                            (Prims.of_int (30)))))
+                                                   (FStar_Sealed.seal
+                                                      (Obj.magic
+                                                         (FStar_Range.mk_range
+                                                            "Pulse.Syntax.Printer.fst"
+                                                            (Prims.of_int (270))
+                                                            (Prims.of_int (6))
+                                                            (Prims.of_int (276))
+                                                            (Prims.of_int (30)))))
+                                                   (Obj.magic
                                                       (FStar_Tactics_Effect.tac_bind
                                                          (FStar_Sealed.seal
                                                             (Obj.magic
                                                                (FStar_Range.mk_range
                                                                   "Pulse.Syntax.Printer.fst"
-                                                                  (Prims.of_int (270))
-                                                                  (Prims.of_int (6))
-                                                                  (Prims.of_int (276))
-                                                                  (Prims.of_int (30)))))
+                                                                  (Prims.of_int (274))
+                                                                  (Prims.of_int (8))
+                                                                  (Prims.of_int (274))
+                                                                  (Prims.of_int (29)))))
                                                          (FStar_Sealed.seal
                                                             (Obj.magic
                                                                (FStar_Range.mk_range
@@ -3321,29 +3455,56 @@ let rec (st_term_to_string' :
                                                                   (Prims.of_int (276))
                                                                   (Prims.of_int (30)))))
                                                          (Obj.magic
-                                                            (FStar_Tactics_Effect.tac_bind
-                                                               (FStar_Sealed.seal
-                                                                  (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (273))
-                                                                    (Prims.of_int (8))
-                                                                    (Prims.of_int (273))
-                                                                    (Prims.of_int (30)))))
-                                                               (FStar_Sealed.seal
-                                                                  (Obj.magic
+                                                            (term_to_string
+                                                               pre2))
+                                                         (fun uu___2 ->
+                                                            (fun uu___2 ->
+                                                               Obj.magic
+                                                                 (FStar_Tactics_Effect.tac_bind
+                                                                    (
+                                                                    FStar_Sealed.seal
+                                                                    (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
                                                                     (Prims.of_int (270))
                                                                     (Prims.of_int (6))
                                                                     (Prims.of_int (276))
                                                                     (Prims.of_int (30)))))
-                                                               (Obj.magic
-                                                                  (term_to_string
+                                                                    (
+                                                                    FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Syntax.Printer.fst"
+                                                                    (Prims.of_int (270))
+                                                                    (Prims.of_int (6))
+                                                                    (Prims.of_int (276))
+                                                                    (Prims.of_int (30)))))
+                                                                    (
+                                                                    Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Syntax.Printer.fst"
+                                                                    (Prims.of_int (273))
+                                                                    (Prims.of_int (8))
+                                                                    (Prims.of_int (273))
+                                                                    (Prims.of_int (30)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Syntax.Printer.fst"
+                                                                    (Prims.of_int (270))
+                                                                    (Prims.of_int (6))
+                                                                    (Prims.of_int (276))
+                                                                    (Prims.of_int (30)))))
+                                                                    (Obj.magic
+                                                                    (term_to_string
                                                                     post1))
-                                                               (fun uu___3 ->
-                                                                  (fun uu___3
-                                                                    ->
+                                                                    (fun
+                                                                    uu___3 ->
+                                                                    (fun
+                                                                    uu___3 ->
                                                                     Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
                                                                     (FStar_Sealed.seal
@@ -3473,152 +3634,157 @@ let rec (st_term_to_string' :
                                                                     uu___4
                                                                     uu___3))))
                                                                     uu___3)))
-                                                         (fun uu___3 ->
-                                                            FStar_Tactics_Effect.lift_div_tac
-                                                              (fun uu___4 ->
-                                                                 uu___3
-                                                                   uu___2))))
-                                                   uu___2)))
-                                        (fun uu___2 ->
+                                                                    (
+                                                                    fun
+                                                                    uu___3 ->
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___4 ->
+                                                                    uu___3
+                                                                    uu___2))))
+                                                              uu___2)))
+                                                   (fun uu___2 ->
+                                                      FStar_Tactics_Effect.lift_div_tac
+                                                        (fun uu___3 ->
+                                                           uu___2 uu___1))))
+                                             uu___1)))
+                                  (fun uu___1 ->
+                                     FStar_Tactics_Effect.lift_div_tac
+                                       (fun uu___2 -> uu___1 uu___)))) uu___)))
+           | Pulse_Syntax_Base.Tm_Rewrite
+               { Pulse_Syntax_Base.t11 = t1; Pulse_Syntax_Base.t21 = t2;_} ->
+               Obj.magic
+                 (Obj.repr
+                    (FStar_Tactics_Effect.tac_bind
+                       (FStar_Sealed.seal
+                          (Obj.magic
+                             (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
+                                (Prims.of_int (281)) (Prims.of_int (8))
+                                (Prims.of_int (281)) (Prims.of_int (27)))))
+                       (FStar_Sealed.seal
+                          (Obj.magic
+                             (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
+                                (Prims.of_int (279)) (Prims.of_int (7))
+                                (Prims.of_int (281)) (Prims.of_int (27)))))
+                       (Obj.magic (term_to_string t2))
+                       (fun uu___ ->
+                          (fun uu___ ->
+                             Obj.magic
+                               (FStar_Tactics_Effect.tac_bind
+                                  (FStar_Sealed.seal
+                                     (Obj.magic
+                                        (FStar_Range.mk_range
+                                           "Pulse.Syntax.Printer.fst"
+                                           (Prims.of_int (279))
+                                           (Prims.of_int (7))
+                                           (Prims.of_int (281))
+                                           (Prims.of_int (27)))))
+                                  (FStar_Sealed.seal
+                                     (Obj.magic
+                                        (FStar_Range.mk_range
+                                           "Pulse.Syntax.Printer.fst"
+                                           (Prims.of_int (279))
+                                           (Prims.of_int (7))
+                                           (Prims.of_int (281))
+                                           (Prims.of_int (27)))))
+                                  (Obj.magic
+                                     (FStar_Tactics_Effect.tac_bind
+                                        (FStar_Sealed.seal
+                                           (Obj.magic
+                                              (FStar_Range.mk_range
+                                                 "Pulse.Syntax.Printer.fst"
+                                                 (Prims.of_int (280))
+                                                 (Prims.of_int (8))
+                                                 (Prims.of_int (280))
+                                                 (Prims.of_int (27)))))
+                                        (FStar_Sealed.seal
+                                           (Obj.magic
+                                              (FStar_Range.mk_range
+                                                 "FStar.Printf.fst"
+                                                 (Prims.of_int (122))
+                                                 (Prims.of_int (8))
+                                                 (Prims.of_int (124))
+                                                 (Prims.of_int (44)))))
+                                        (Obj.magic (term_to_string t1))
+                                        (fun uu___1 ->
                                            FStar_Tactics_Effect.lift_div_tac
-                                             (fun uu___3 -> uu___2 uu___1))))
-                                  uu___1)))
-                       (fun uu___1 ->
-                          FStar_Tactics_Effect.lift_div_tac
-                            (fun uu___2 -> uu___1 uu___)))) uu___)
-      | Pulse_Syntax_Base.Tm_Rewrite
-          { Pulse_Syntax_Base.t11 = t1; Pulse_Syntax_Base.t21 = t2;_} ->
-          FStar_Tactics_Effect.tac_bind
-            (FStar_Sealed.seal
-               (Obj.magic
-                  (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                     (Prims.of_int (281)) (Prims.of_int (8))
-                     (Prims.of_int (281)) (Prims.of_int (27)))))
-            (FStar_Sealed.seal
-               (Obj.magic
-                  (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                     (Prims.of_int (279)) (Prims.of_int (7))
-                     (Prims.of_int (281)) (Prims.of_int (27)))))
-            (Obj.magic (term_to_string t2))
-            (fun uu___ ->
-               (fun uu___ ->
-                  Obj.magic
+                                             (fun uu___2 ->
+                                                fun x ->
+                                                  Prims.strcat
+                                                    (Prims.strcat "rewrite "
+                                                       (Prims.strcat uu___1
+                                                          " "))
+                                                    (Prims.strcat x "")))))
+                                  (fun uu___1 ->
+                                     FStar_Tactics_Effect.lift_div_tac
+                                       (fun uu___2 -> uu___1 uu___)))) uu___)))
+           | Pulse_Syntax_Base.Tm_WithLocal
+               { Pulse_Syntax_Base.binder2 = binder;
+                 Pulse_Syntax_Base.initializer1 = initializer1;
+                 Pulse_Syntax_Base.body4 = body;_}
+               ->
+               Obj.magic
+                 (Obj.repr
                     (FStar_Tactics_Effect.tac_bind
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (279)) (Prims.of_int (7))
-                                (Prims.of_int (281)) (Prims.of_int (27)))))
-                       (FStar_Sealed.seal
-                          (Obj.magic
-                             (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (279)) (Prims.of_int (7))
-                                (Prims.of_int (281)) (Prims.of_int (27)))))
-                       (Obj.magic
-                          (FStar_Tactics_Effect.tac_bind
-                             (FStar_Sealed.seal
-                                (Obj.magic
-                                   (FStar_Range.mk_range
-                                      "Pulse.Syntax.Printer.fst"
-                                      (Prims.of_int (280)) (Prims.of_int (8))
-                                      (Prims.of_int (280))
-                                      (Prims.of_int (27)))))
-                             (FStar_Sealed.seal
-                                (Obj.magic
-                                   (FStar_Range.mk_range "FStar.Printf.fst"
-                                      (Prims.of_int (122)) (Prims.of_int (8))
-                                      (Prims.of_int (124))
-                                      (Prims.of_int (44)))))
-                             (Obj.magic (term_to_string t1))
-                             (fun uu___1 ->
-                                FStar_Tactics_Effect.lift_div_tac
-                                  (fun uu___2 ->
-                                     fun x ->
-                                       Prims.strcat
-                                         (Prims.strcat "rewrite "
-                                            (Prims.strcat uu___1 " "))
-                                         (Prims.strcat x "")))))
-                       (fun uu___1 ->
-                          FStar_Tactics_Effect.lift_div_tac
-                            (fun uu___2 -> uu___1 uu___)))) uu___)
-      | Pulse_Syntax_Base.Tm_WithLocal
-          { Pulse_Syntax_Base.binder2 = binder;
-            Pulse_Syntax_Base.initializer1 = initializer1;
-            Pulse_Syntax_Base.body4 = body;_}
-          ->
-          FStar_Tactics_Effect.tac_bind
-            (FStar_Sealed.seal
-               (Obj.magic
-                  (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                     (Prims.of_int (288)) (Prims.of_int (8))
-                     (Prims.of_int (288)) (Prims.of_int (39)))))
-            (FStar_Sealed.seal
-               (Obj.magic
-                  (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                     (Prims.of_int (284)) (Prims.of_int (6))
-                     (Prims.of_int (288)) (Prims.of_int (39)))))
-            (Obj.magic (st_term_to_string' level body))
-            (fun uu___ ->
-               (fun uu___ ->
-                  Obj.magic
-                    (FStar_Tactics_Effect.tac_bind
-                       (FStar_Sealed.seal
-                          (Obj.magic
-                             (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (284)) (Prims.of_int (6))
+                                (Prims.of_int (288)) (Prims.of_int (8))
                                 (Prims.of_int (288)) (Prims.of_int (39)))))
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
                                 (Prims.of_int (284)) (Prims.of_int (6))
                                 (Prims.of_int (288)) (Prims.of_int (39)))))
-                       (Obj.magic
-                          (FStar_Tactics_Effect.tac_bind
-                             (FStar_Sealed.seal
-                                (Obj.magic
-                                   (FStar_Range.mk_range
-                                      "Pulse.Syntax.Printer.fst"
-                                      (Prims.of_int (284)) (Prims.of_int (6))
-                                      (Prims.of_int (288))
-                                      (Prims.of_int (39)))))
-                             (FStar_Sealed.seal
-                                (Obj.magic
-                                   (FStar_Range.mk_range
-                                      "Pulse.Syntax.Printer.fst"
-                                      (Prims.of_int (284)) (Prims.of_int (6))
-                                      (Prims.of_int (288))
-                                      (Prims.of_int (39)))))
-                             (Obj.magic
-                                (FStar_Tactics_Effect.tac_bind
-                                   (FStar_Sealed.seal
-                                      (Obj.magic
-                                         (FStar_Range.mk_range
-                                            "Pulse.Syntax.Printer.fst"
-                                            (Prims.of_int (286))
-                                            (Prims.of_int (8))
-                                            (Prims.of_int (286))
-                                            (Prims.of_int (36)))))
-                                   (FStar_Sealed.seal
-                                      (Obj.magic
-                                         (FStar_Range.mk_range
-                                            "Pulse.Syntax.Printer.fst"
-                                            (Prims.of_int (284))
-                                            (Prims.of_int (6))
-                                            (Prims.of_int (288))
-                                            (Prims.of_int (39)))))
-                                   (Obj.magic (term_to_string initializer1))
-                                   (fun uu___1 ->
-                                      (fun uu___1 ->
-                                         Obj.magic
+                       (Obj.magic (st_term_to_string' level body))
+                       (fun uu___ ->
+                          (fun uu___ ->
+                             Obj.magic
+                               (FStar_Tactics_Effect.tac_bind
+                                  (FStar_Sealed.seal
+                                     (Obj.magic
+                                        (FStar_Range.mk_range
+                                           "Pulse.Syntax.Printer.fst"
+                                           (Prims.of_int (284))
+                                           (Prims.of_int (6))
+                                           (Prims.of_int (288))
+                                           (Prims.of_int (39)))))
+                                  (FStar_Sealed.seal
+                                     (Obj.magic
+                                        (FStar_Range.mk_range
+                                           "Pulse.Syntax.Printer.fst"
+                                           (Prims.of_int (284))
+                                           (Prims.of_int (6))
+                                           (Prims.of_int (288))
+                                           (Prims.of_int (39)))))
+                                  (Obj.magic
+                                     (FStar_Tactics_Effect.tac_bind
+                                        (FStar_Sealed.seal
+                                           (Obj.magic
+                                              (FStar_Range.mk_range
+                                                 "Pulse.Syntax.Printer.fst"
+                                                 (Prims.of_int (284))
+                                                 (Prims.of_int (6))
+                                                 (Prims.of_int (288))
+                                                 (Prims.of_int (39)))))
+                                        (FStar_Sealed.seal
+                                           (Obj.magic
+                                              (FStar_Range.mk_range
+                                                 "Pulse.Syntax.Printer.fst"
+                                                 (Prims.of_int (284))
+                                                 (Prims.of_int (6))
+                                                 (Prims.of_int (288))
+                                                 (Prims.of_int (39)))))
+                                        (Obj.magic
                                            (FStar_Tactics_Effect.tac_bind
                                               (FStar_Sealed.seal
                                                  (Obj.magic
                                                     (FStar_Range.mk_range
                                                        "Pulse.Syntax.Printer.fst"
-                                                       (Prims.of_int (284))
-                                                       (Prims.of_int (6))
-                                                       (Prims.of_int (288))
-                                                       (Prims.of_int (39)))))
+                                                       (Prims.of_int (286))
+                                                       (Prims.of_int (8))
+                                                       (Prims.of_int (286))
+                                                       (Prims.of_int (36)))))
                                               (FStar_Sealed.seal
                                                  (Obj.magic
                                                     (FStar_Range.mk_range
@@ -3628,35 +3794,58 @@ let rec (st_term_to_string' :
                                                        (Prims.of_int (288))
                                                        (Prims.of_int (39)))))
                                               (Obj.magic
-                                                 (FStar_Tactics_Effect.tac_bind
-                                                    (FStar_Sealed.seal
-                                                       (Obj.magic
-                                                          (FStar_Range.mk_range
-                                                             "Pulse.Syntax.Printer.fst"
-                                                             (Prims.of_int (285))
-                                                             (Prims.of_int (8))
-                                                             (Prims.of_int (285))
-                                                             (Prims.of_int (33)))))
-                                                    (FStar_Sealed.seal
-                                                       (Obj.magic
-                                                          (FStar_Range.mk_range
-                                                             "FStar.Printf.fst"
-                                                             (Prims.of_int (122))
-                                                             (Prims.of_int (8))
-                                                             (Prims.of_int (124))
-                                                             (Prims.of_int (44)))))
-                                                    (Obj.magic
-                                                       (binder_to_string
-                                                          binder))
-                                                    (fun uu___2 ->
-                                                       FStar_Tactics_Effect.lift_div_tac
-                                                         (fun uu___3 ->
-                                                            fun x ->
-                                                              fun x1 ->
-                                                                fun x2 ->
-                                                                  Prims.strcat
+                                                 (term_to_string initializer1))
+                                              (fun uu___1 ->
+                                                 (fun uu___1 ->
+                                                    Obj.magic
+                                                      (FStar_Tactics_Effect.tac_bind
+                                                         (FStar_Sealed.seal
+                                                            (Obj.magic
+                                                               (FStar_Range.mk_range
+                                                                  "Pulse.Syntax.Printer.fst"
+                                                                  (Prims.of_int (284))
+                                                                  (Prims.of_int (6))
+                                                                  (Prims.of_int (288))
+                                                                  (Prims.of_int (39)))))
+                                                         (FStar_Sealed.seal
+                                                            (Obj.magic
+                                                               (FStar_Range.mk_range
+                                                                  "Pulse.Syntax.Printer.fst"
+                                                                  (Prims.of_int (284))
+                                                                  (Prims.of_int (6))
+                                                                  (Prims.of_int (288))
+                                                                  (Prims.of_int (39)))))
+                                                         (Obj.magic
+                                                            (FStar_Tactics_Effect.tac_bind
+                                                               (FStar_Sealed.seal
+                                                                  (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Syntax.Printer.fst"
+                                                                    (Prims.of_int (285))
+                                                                    (Prims.of_int (8))
+                                                                    (Prims.of_int (285))
+                                                                    (Prims.of_int (33)))))
+                                                               (FStar_Sealed.seal
+                                                                  (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "FStar.Printf.fst"
+                                                                    (Prims.of_int (122))
+                                                                    (Prims.of_int (8))
+                                                                    (Prims.of_int (124))
+                                                                    (Prims.of_int (44)))))
+                                                               (Obj.magic
+                                                                  (binder_to_string
+                                                                    binder))
+                                                               (fun uu___2 ->
+                                                                  FStar_Tactics_Effect.lift_div_tac
                                                                     (
+                                                                    fun
+                                                                    uu___3 ->
+                                                                    fun x ->
+                                                                    fun x1 ->
+                                                                    fun x2 ->
                                                                     Prims.strcat
+                                                                    (Prims.strcat
                                                                     (Prims.strcat
                                                                     (Prims.strcat
                                                                     "let mut "
@@ -3667,99 +3856,88 @@ let rec (st_term_to_string' :
                                                                     x ";\n"))
                                                                     (Prims.strcat
                                                                     x1 ""))
-                                                                    (
-                                                                    Prims.strcat
+                                                                    (Prims.strcat
                                                                     x2 "")))))
-                                              (fun uu___2 ->
-                                                 FStar_Tactics_Effect.lift_div_tac
-                                                   (fun uu___3 ->
-                                                      uu___2 uu___1))))
-                                        uu___1)))
-                             (fun uu___1 ->
-                                FStar_Tactics_Effect.lift_div_tac
-                                  (fun uu___2 -> uu___1 level))))
-                       (fun uu___1 ->
-                          FStar_Tactics_Effect.lift_div_tac
-                            (fun uu___2 -> uu___1 uu___)))) uu___)
-      | Pulse_Syntax_Base.Tm_WithLocalArray
-          { Pulse_Syntax_Base.binder3 = binder;
-            Pulse_Syntax_Base.initializer2 = initializer1;
-            Pulse_Syntax_Base.length = length;
-            Pulse_Syntax_Base.body5 = body;_}
-          ->
-          FStar_Tactics_Effect.tac_bind
-            (FStar_Sealed.seal
-               (Obj.magic
-                  (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                     (Prims.of_int (296)) (Prims.of_int (8))
-                     (Prims.of_int (296)) (Prims.of_int (39)))))
-            (FStar_Sealed.seal
-               (Obj.magic
-                  (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                     (Prims.of_int (291)) (Prims.of_int (6))
-                     (Prims.of_int (296)) (Prims.of_int (39)))))
-            (Obj.magic (st_term_to_string' level body))
-            (fun uu___ ->
-               (fun uu___ ->
-                  Obj.magic
+                                                         (fun uu___2 ->
+                                                            FStar_Tactics_Effect.lift_div_tac
+                                                              (fun uu___3 ->
+                                                                 uu___2
+                                                                   uu___1))))
+                                                   uu___1)))
+                                        (fun uu___1 ->
+                                           FStar_Tactics_Effect.lift_div_tac
+                                             (fun uu___2 -> uu___1 level))))
+                                  (fun uu___1 ->
+                                     FStar_Tactics_Effect.lift_div_tac
+                                       (fun uu___2 -> uu___1 uu___)))) uu___)))
+           | Pulse_Syntax_Base.Tm_WithLocalArray
+               { Pulse_Syntax_Base.binder3 = binder;
+                 Pulse_Syntax_Base.initializer2 = initializer1;
+                 Pulse_Syntax_Base.length = length;
+                 Pulse_Syntax_Base.body5 = body;_}
+               ->
+               Obj.magic
+                 (Obj.repr
                     (FStar_Tactics_Effect.tac_bind
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (291)) (Prims.of_int (6))
+                                (Prims.of_int (296)) (Prims.of_int (8))
                                 (Prims.of_int (296)) (Prims.of_int (39)))))
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
                                 (Prims.of_int (291)) (Prims.of_int (6))
                                 (Prims.of_int (296)) (Prims.of_int (39)))))
-                       (Obj.magic
-                          (FStar_Tactics_Effect.tac_bind
-                             (FStar_Sealed.seal
-                                (Obj.magic
-                                   (FStar_Range.mk_range
-                                      "Pulse.Syntax.Printer.fst"
-                                      (Prims.of_int (291)) (Prims.of_int (6))
-                                      (Prims.of_int (296))
-                                      (Prims.of_int (39)))))
-                             (FStar_Sealed.seal
-                                (Obj.magic
-                                   (FStar_Range.mk_range
-                                      "Pulse.Syntax.Printer.fst"
-                                      (Prims.of_int (291)) (Prims.of_int (6))
-                                      (Prims.of_int (296))
-                                      (Prims.of_int (39)))))
-                             (Obj.magic
-                                (FStar_Tactics_Effect.tac_bind
-                                   (FStar_Sealed.seal
-                                      (Obj.magic
-                                         (FStar_Range.mk_range
-                                            "Pulse.Syntax.Printer.fst"
-                                            (Prims.of_int (294))
-                                            (Prims.of_int (8))
-                                            (Prims.of_int (294))
-                                            (Prims.of_int (31)))))
-                                   (FStar_Sealed.seal
-                                      (Obj.magic
-                                         (FStar_Range.mk_range
-                                            "Pulse.Syntax.Printer.fst"
-                                            (Prims.of_int (291))
-                                            (Prims.of_int (6))
-                                            (Prims.of_int (296))
-                                            (Prims.of_int (39)))))
-                                   (Obj.magic (term_to_string length))
-                                   (fun uu___1 ->
-                                      (fun uu___1 ->
-                                         Obj.magic
+                       (Obj.magic (st_term_to_string' level body))
+                       (fun uu___ ->
+                          (fun uu___ ->
+                             Obj.magic
+                               (FStar_Tactics_Effect.tac_bind
+                                  (FStar_Sealed.seal
+                                     (Obj.magic
+                                        (FStar_Range.mk_range
+                                           "Pulse.Syntax.Printer.fst"
+                                           (Prims.of_int (291))
+                                           (Prims.of_int (6))
+                                           (Prims.of_int (296))
+                                           (Prims.of_int (39)))))
+                                  (FStar_Sealed.seal
+                                     (Obj.magic
+                                        (FStar_Range.mk_range
+                                           "Pulse.Syntax.Printer.fst"
+                                           (Prims.of_int (291))
+                                           (Prims.of_int (6))
+                                           (Prims.of_int (296))
+                                           (Prims.of_int (39)))))
+                                  (Obj.magic
+                                     (FStar_Tactics_Effect.tac_bind
+                                        (FStar_Sealed.seal
+                                           (Obj.magic
+                                              (FStar_Range.mk_range
+                                                 "Pulse.Syntax.Printer.fst"
+                                                 (Prims.of_int (291))
+                                                 (Prims.of_int (6))
+                                                 (Prims.of_int (296))
+                                                 (Prims.of_int (39)))))
+                                        (FStar_Sealed.seal
+                                           (Obj.magic
+                                              (FStar_Range.mk_range
+                                                 "Pulse.Syntax.Printer.fst"
+                                                 (Prims.of_int (291))
+                                                 (Prims.of_int (6))
+                                                 (Prims.of_int (296))
+                                                 (Prims.of_int (39)))))
+                                        (Obj.magic
                                            (FStar_Tactics_Effect.tac_bind
                                               (FStar_Sealed.seal
                                                  (Obj.magic
                                                     (FStar_Range.mk_range
                                                        "Pulse.Syntax.Printer.fst"
-                                                       (Prims.of_int (291))
-                                                       (Prims.of_int (6))
-                                                       (Prims.of_int (296))
-                                                       (Prims.of_int (39)))))
+                                                       (Prims.of_int (294))
+                                                       (Prims.of_int (8))
+                                                       (Prims.of_int (294))
+                                                       (Prims.of_int (31)))))
                                               (FStar_Sealed.seal
                                                  (Obj.magic
                                                     (FStar_Range.mk_range
@@ -3769,38 +3947,37 @@ let rec (st_term_to_string' :
                                                        (Prims.of_int (296))
                                                        (Prims.of_int (39)))))
                                               (Obj.magic
-                                                 (FStar_Tactics_Effect.tac_bind
-                                                    (FStar_Sealed.seal
-                                                       (Obj.magic
-                                                          (FStar_Range.mk_range
-                                                             "Pulse.Syntax.Printer.fst"
-                                                             (Prims.of_int (293))
-                                                             (Prims.of_int (8))
-                                                             (Prims.of_int (293))
-                                                             (Prims.of_int (36)))))
-                                                    (FStar_Sealed.seal
-                                                       (Obj.magic
-                                                          (FStar_Range.mk_range
-                                                             "Pulse.Syntax.Printer.fst"
-                                                             (Prims.of_int (291))
-                                                             (Prims.of_int (6))
-                                                             (Prims.of_int (296))
-                                                             (Prims.of_int (39)))))
-                                                    (Obj.magic
-                                                       (term_to_string
-                                                          initializer1))
-                                                    (fun uu___2 ->
-                                                       (fun uu___2 ->
-                                                          Obj.magic
+                                                 (term_to_string length))
+                                              (fun uu___1 ->
+                                                 (fun uu___1 ->
+                                                    Obj.magic
+                                                      (FStar_Tactics_Effect.tac_bind
+                                                         (FStar_Sealed.seal
+                                                            (Obj.magic
+                                                               (FStar_Range.mk_range
+                                                                  "Pulse.Syntax.Printer.fst"
+                                                                  (Prims.of_int (291))
+                                                                  (Prims.of_int (6))
+                                                                  (Prims.of_int (296))
+                                                                  (Prims.of_int (39)))))
+                                                         (FStar_Sealed.seal
+                                                            (Obj.magic
+                                                               (FStar_Range.mk_range
+                                                                  "Pulse.Syntax.Printer.fst"
+                                                                  (Prims.of_int (291))
+                                                                  (Prims.of_int (6))
+                                                                  (Prims.of_int (296))
+                                                                  (Prims.of_int (39)))))
+                                                         (Obj.magic
                                                             (FStar_Tactics_Effect.tac_bind
                                                                (FStar_Sealed.seal
                                                                   (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (291))
-                                                                    (Prims.of_int (6))
-                                                                    (Prims.of_int (296))
-                                                                    (Prims.of_int (39)))))
+                                                                    (Prims.of_int (293))
+                                                                    (Prims.of_int (8))
+                                                                    (Prims.of_int (293))
+                                                                    (Prims.of_int (36)))))
                                                                (FStar_Sealed.seal
                                                                   (Obj.magic
                                                                     (FStar_Range.mk_range
@@ -3810,7 +3987,31 @@ let rec (st_term_to_string' :
                                                                     (Prims.of_int (296))
                                                                     (Prims.of_int (39)))))
                                                                (Obj.magic
-                                                                  (FStar_Tactics_Effect.tac_bind
+                                                                  (term_to_string
+                                                                    initializer1))
+                                                               (fun uu___2 ->
+                                                                  (fun uu___2
+                                                                    ->
+                                                                    Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Syntax.Printer.fst"
+                                                                    (Prims.of_int (291))
+                                                                    (Prims.of_int (6))
+                                                                    (Prims.of_int (296))
+                                                                    (Prims.of_int (39)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Syntax.Printer.fst"
+                                                                    (Prims.of_int (291))
+                                                                    (Prims.of_int (6))
+                                                                    (Prims.of_int (296))
+                                                                    (Prims.of_int (39)))))
+                                                                    (Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
@@ -3857,398 +4058,460 @@ let rec (st_term_to_string' :
                                                                     x2 ""))
                                                                     (Prims.strcat
                                                                     x3 "")))))
-                                                               (fun uu___3 ->
-                                                                  FStar_Tactics_Effect.lift_div_tac
-                                                                    (
-                                                                    fun
+                                                                    (fun
+                                                                    uu___3 ->
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
                                                                     uu___4 ->
                                                                     uu___3
                                                                     uu___2))))
-                                                         uu___2)))
-                                              (fun uu___2 ->
-                                                 FStar_Tactics_Effect.lift_div_tac
-                                                   (fun uu___3 ->
-                                                      uu___2 uu___1))))
-                                        uu___1)))
-                             (fun uu___1 ->
-                                FStar_Tactics_Effect.lift_div_tac
-                                  (fun uu___2 -> uu___1 level))))
-                       (fun uu___1 ->
-                          FStar_Tactics_Effect.lift_div_tac
-                            (fun uu___2 -> uu___1 uu___)))) uu___)
-      | Pulse_Syntax_Base.Tm_Admit
-          { Pulse_Syntax_Base.ctag1 = ctag; Pulse_Syntax_Base.u1 = u;
-            Pulse_Syntax_Base.typ = typ; Pulse_Syntax_Base.post3 = post;_}
-          ->
-          FStar_Tactics_Effect.tac_bind
-            (FStar_Sealed.seal
-               (Obj.magic
-                  (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                     (Prims.of_int (306)) (Prims.of_int (8))
-                     (Prims.of_int (308)) (Prims.of_int (60)))))
-            (FStar_Sealed.seal
-               (Obj.magic
-                  (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                     (Prims.of_int (299)) (Prims.of_int (6))
-                     (Prims.of_int (308)) (Prims.of_int (60)))))
-            (match post with
-             | FStar_Pervasives_Native.None ->
-                 Obj.magic
-                   (Obj.repr
-                      (FStar_Tactics_Effect.lift_div_tac (fun uu___ -> "")))
-             | FStar_Pervasives_Native.Some post1 ->
-                 Obj.magic
-                   (Obj.repr
-                      (FStar_Tactics_Effect.tac_bind
-                         (FStar_Sealed.seal
-                            (Obj.magic
-                               (FStar_Range.mk_range
-                                  "Pulse.Syntax.Printer.fst"
-                                  (Prims.of_int (308)) (Prims.of_int (38))
-                                  (Prims.of_int (308)) (Prims.of_int (59)))))
-                         (FStar_Sealed.seal
-                            (Obj.magic
-                               (FStar_Range.mk_range "prims.fst"
-                                  (Prims.of_int (590)) (Prims.of_int (19))
-                                  (Prims.of_int (590)) (Prims.of_int (31)))))
-                         (Obj.magic (term_to_string post1))
-                         (fun uu___ ->
-                            FStar_Tactics_Effect.lift_div_tac
-                              (fun uu___1 ->
-                                 Prims.strcat " " (Prims.strcat uu___ ""))))))
-            (fun uu___ ->
-               (fun uu___ ->
-                  Obj.magic
+                                                                    uu___2)))
+                                                         (fun uu___2 ->
+                                                            FStar_Tactics_Effect.lift_div_tac
+                                                              (fun uu___3 ->
+                                                                 uu___2
+                                                                   uu___1))))
+                                                   uu___1)))
+                                        (fun uu___1 ->
+                                           FStar_Tactics_Effect.lift_div_tac
+                                             (fun uu___2 -> uu___1 level))))
+                                  (fun uu___1 ->
+                                     FStar_Tactics_Effect.lift_div_tac
+                                       (fun uu___2 -> uu___1 uu___)))) uu___)))
+           | Pulse_Syntax_Base.Tm_Admit
+               { Pulse_Syntax_Base.ctag1 = ctag; Pulse_Syntax_Base.u1 = u;
+                 Pulse_Syntax_Base.typ = typ;
+                 Pulse_Syntax_Base.post3 = post;_}
+               ->
+               Obj.magic
+                 (Obj.repr
                     (FStar_Tactics_Effect.tac_bind
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (299)) (Prims.of_int (6))
+                                (Prims.of_int (306)) (Prims.of_int (8))
                                 (Prims.of_int (308)) (Prims.of_int (60)))))
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
                                 (Prims.of_int (299)) (Prims.of_int (6))
                                 (Prims.of_int (308)) (Prims.of_int (60)))))
-                       (Obj.magic
-                          (FStar_Tactics_Effect.tac_bind
-                             (FStar_Sealed.seal
-                                (Obj.magic
-                                   (FStar_Range.mk_range
-                                      "Pulse.Syntax.Printer.fst"
-                                      (Prims.of_int (305)) (Prims.of_int (8))
-                                      (Prims.of_int (305))
-                                      (Prims.of_int (28)))))
-                             (FStar_Sealed.seal
-                                (Obj.magic
-                                   (FStar_Range.mk_range "FStar.Printf.fst"
-                                      (Prims.of_int (122)) (Prims.of_int (8))
-                                      (Prims.of_int (124))
-                                      (Prims.of_int (44)))))
-                             (Obj.magic (term_to_string typ))
-                             (fun uu___1 ->
-                                FStar_Tactics_Effect.lift_div_tac
-                                  (fun uu___2 ->
-                                     fun x ->
-                                       Prims.strcat
-                                         (Prims.strcat
-                                            (Prims.strcat
-                                               (Prims.strcat ""
-                                                  (Prims.strcat
-                                                     (match ctag with
-                                                      | Pulse_Syntax_Base.STT
-                                                          -> "stt_admit"
-                                                      | Pulse_Syntax_Base.STT_Atomic
-                                                          ->
-                                                          "stt_atomic_admit"
-                                                      | Pulse_Syntax_Base.STT_Ghost
-                                                          ->
-                                                          "stt_ghost_admit")
-                                                     "<"))
-                                               (Prims.strcat
-                                                  (universe_to_string
-                                                     Prims.int_zero u) "> "))
-                                            (Prims.strcat uu___1 ""))
-                                         (Prims.strcat x "")))))
-                       (fun uu___1 ->
-                          FStar_Tactics_Effect.lift_div_tac
-                            (fun uu___2 -> uu___1 uu___)))) uu___)
-      | Pulse_Syntax_Base.Tm_ProofHintWithBinders
-          { Pulse_Syntax_Base.hint_type = hint_type;
-            Pulse_Syntax_Base.binders = binders; Pulse_Syntax_Base.t3 = t1;_}
-          ->
-          FStar_Tactics_Effect.tac_bind
-            (FStar_Sealed.seal
-               (Obj.magic
-                  (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                     (Prims.of_int (312)) (Prims.of_int (8))
-                     (Prims.of_int (314)) (Prims.of_int (86)))))
-            (FStar_Sealed.seal
-               (Obj.magic
-                  (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                     (Prims.of_int (315)) (Prims.of_int (8))
-                     (Prims.of_int (338)) (Prims.of_int (36)))))
-            (match binders with
-             | [] ->
-                 Obj.magic
-                   (Obj.repr
-                      (FStar_Tactics_Effect.lift_div_tac (fun uu___ -> "")))
-             | uu___ ->
-                 Obj.magic
-                   (Obj.repr
-                      (FStar_Tactics_Effect.tac_bind
-                         (FStar_Sealed.seal
-                            (Obj.magic
-                               (FStar_Range.mk_range
-                                  "Pulse.Syntax.Printer.fst"
-                                  (Prims.of_int (314)) (Prims.of_int (34))
-                                  (Prims.of_int (314)) (Prims.of_int (86)))))
-                         (FStar_Sealed.seal
-                            (Obj.magic
-                               (FStar_Range.mk_range "prims.fst"
-                                  (Prims.of_int (590)) (Prims.of_int (19))
-                                  (Prims.of_int (590)) (Prims.of_int (31)))))
-                         (Obj.magic
-                            (FStar_Tactics_Effect.tac_bind
-                               (FStar_Sealed.seal
-                                  (Obj.magic
-                                     (FStar_Range.mk_range
-                                        "Pulse.Syntax.Printer.fst"
-                                        (Prims.of_int (314))
-                                        (Prims.of_int (53))
-                                        (Prims.of_int (314))
-                                        (Prims.of_int (85)))))
-                               (FStar_Sealed.seal
-                                  (Obj.magic
-                                     (FStar_Range.mk_range
-                                        "Pulse.Syntax.Printer.fst"
-                                        (Prims.of_int (314))
-                                        (Prims.of_int (34))
-                                        (Prims.of_int (314))
-                                        (Prims.of_int (86)))))
-                               (Obj.magic
-                                  (FStar_Tactics_Util.map binder_to_string
-                                     binders))
-                               (fun uu___1 ->
-                                  FStar_Tactics_Effect.lift_div_tac
-                                    (fun uu___2 ->
-                                       FStar_String.concat " " uu___1))))
-                         (fun uu___1 ->
-                            FStar_Tactics_Effect.lift_div_tac
-                              (fun uu___2 ->
-                                 Prims.strcat "with "
-                                   (Prims.strcat uu___1 "."))))))
-            (fun uu___ ->
-               (fun with_prefix ->
-                  Obj.magic
-                    (FStar_Tactics_Effect.tac_bind
-                       (FStar_Sealed.seal
-                          (Obj.magic
-                             (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (316)) (Prims.of_int (28))
-                                (Prims.of_int (318)) (Prims.of_int (58)))))
-                       (FStar_Sealed.seal
-                          (Obj.magic
-                             (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (319)) (Prims.of_int (8))
-                                (Prims.of_int (338)) (Prims.of_int (36)))))
-                       (FStar_Tactics_Effect.lift_div_tac
-                          (fun uu___ ->
-                             fun uu___1 ->
-                               match uu___1 with
-                               | FStar_Pervasives_Native.None -> ""
-                               | FStar_Pervasives_Native.Some l ->
-                                   Prims.strcat " ["
-                                     (Prims.strcat
-                                        (FStar_String.concat "; " l) "]")))
+                       (match post with
+                        | FStar_Pervasives_Native.None ->
+                            Obj.magic
+                              (Obj.repr
+                                 (FStar_Tactics_Effect.lift_div_tac
+                                    (fun uu___ -> "")))
+                        | FStar_Pervasives_Native.Some post1 ->
+                            Obj.magic
+                              (Obj.repr
+                                 (FStar_Tactics_Effect.tac_bind
+                                    (FStar_Sealed.seal
+                                       (Obj.magic
+                                          (FStar_Range.mk_range
+                                             "Pulse.Syntax.Printer.fst"
+                                             (Prims.of_int (308))
+                                             (Prims.of_int (38))
+                                             (Prims.of_int (308))
+                                             (Prims.of_int (59)))))
+                                    (FStar_Sealed.seal
+                                       (Obj.magic
+                                          (FStar_Range.mk_range "prims.fst"
+                                             (Prims.of_int (590))
+                                             (Prims.of_int (19))
+                                             (Prims.of_int (590))
+                                             (Prims.of_int (31)))))
+                                    (Obj.magic (term_to_string post1))
+                                    (fun uu___ ->
+                                       FStar_Tactics_Effect.lift_div_tac
+                                         (fun uu___1 ->
+                                            Prims.strcat " "
+                                              (Prims.strcat uu___ ""))))))
                        (fun uu___ ->
-                          (fun names_to_string ->
+                          (fun uu___ ->
                              Obj.magic
                                (FStar_Tactics_Effect.tac_bind
                                   (FStar_Sealed.seal
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "Pulse.Syntax.Printer.fst"
-                                           (Prims.of_int (321))
-                                           (Prims.of_int (8))
-                                           (Prims.of_int (335))
-                                           (Prims.of_int (80)))))
+                                           (Prims.of_int (299))
+                                           (Prims.of_int (6))
+                                           (Prims.of_int (308))
+                                           (Prims.of_int (60)))))
                                   (FStar_Sealed.seal
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "Pulse.Syntax.Printer.fst"
-                                           (Prims.of_int (319))
-                                           (Prims.of_int (8))
-                                           (Prims.of_int (338))
-                                           (Prims.of_int (36)))))
-                                  (match hint_type with
-                                   | Pulse_Syntax_Base.ASSERT
-                                       { Pulse_Syntax_Base.p = p;_} ->
-                                       Obj.magic
-                                         (FStar_Tactics_Effect.tac_bind
-                                            (FStar_Sealed.seal
-                                               (Obj.magic
-                                                  (FStar_Range.mk_range
-                                                     "Pulse.Syntax.Printer.fst"
-                                                     (Prims.of_int (322))
-                                                     (Prims.of_int (36))
-                                                     (Prims.of_int (322))
-                                                     (Prims.of_int (52)))))
-                                            (FStar_Sealed.seal
-                                               (Obj.magic
-                                                  (FStar_Range.mk_range
-                                                     "Pulse.Syntax.Printer.fst"
-                                                     (Prims.of_int (322))
-                                                     (Prims.of_int (26))
-                                                     (Prims.of_int (322))
-                                                     (Prims.of_int (52)))))
-                                            (Obj.magic (term_to_string p))
-                                            (fun uu___ ->
-                                               FStar_Tactics_Effect.lift_div_tac
-                                                 (fun uu___1 ->
-                                                    ("assert", uu___))))
-                                   | Pulse_Syntax_Base.UNFOLD
-                                       { Pulse_Syntax_Base.names1 = names;
-                                         Pulse_Syntax_Base.p2 = p;_}
-                                       ->
-                                       Obj.magic
-                                         (FStar_Tactics_Effect.tac_bind
-                                            (FStar_Sealed.seal
-                                               (Obj.magic
-                                                  (FStar_Range.mk_range
-                                                     "Pulse.Syntax.Printer.fst"
-                                                     (Prims.of_int (323))
-                                                     (Prims.of_int (77))
-                                                     (Prims.of_int (323))
-                                                     (Prims.of_int (93)))))
-                                            (FStar_Sealed.seal
-                                               (Obj.magic
-                                                  (FStar_Range.mk_range
-                                                     "Pulse.Syntax.Printer.fst"
-                                                     (Prims.of_int (323))
-                                                     (Prims.of_int (33))
-                                                     (Prims.of_int (323))
-                                                     (Prims.of_int (93)))))
-                                            (Obj.magic (term_to_string p))
-                                            (fun uu___ ->
-                                               FStar_Tactics_Effect.lift_div_tac
-                                                 (fun uu___1 ->
-                                                    ((Prims.strcat "unfold"
-                                                        (Prims.strcat
-                                                           (names_to_string
-                                                              names) "")),
-                                                      uu___))))
-                                   | Pulse_Syntax_Base.FOLD
-                                       { Pulse_Syntax_Base.names = names;
-                                         Pulse_Syntax_Base.p1 = p;_}
-                                       ->
-                                       Obj.magic
-                                         (FStar_Tactics_Effect.tac_bind
-                                            (FStar_Sealed.seal
-                                               (Obj.magic
-                                                  (FStar_Range.mk_range
-                                                     "Pulse.Syntax.Printer.fst"
-                                                     (Prims.of_int (324))
-                                                     (Prims.of_int (73))
-                                                     (Prims.of_int (324))
-                                                     (Prims.of_int (89)))))
-                                            (FStar_Sealed.seal
-                                               (Obj.magic
-                                                  (FStar_Range.mk_range
-                                                     "Pulse.Syntax.Printer.fst"
-                                                     (Prims.of_int (324))
-                                                     (Prims.of_int (31))
-                                                     (Prims.of_int (324))
-                                                     (Prims.of_int (89)))))
-                                            (Obj.magic (term_to_string p))
-                                            (fun uu___ ->
-                                               FStar_Tactics_Effect.lift_div_tac
-                                                 (fun uu___1 ->
-                                                    ((Prims.strcat "fold"
-                                                        (Prims.strcat
-                                                           (names_to_string
-                                                              names) "")),
-                                                      uu___))))
-                                   | Pulse_Syntax_Base.RENAME
-                                       { Pulse_Syntax_Base.pairs = pairs;
-                                         Pulse_Syntax_Base.goal = goal;_}
-                                       ->
-                                       Obj.magic
-                                         (FStar_Tactics_Effect.tac_bind
-                                            (FStar_Sealed.seal
-                                               (Obj.magic
-                                                  (FStar_Range.mk_range
-                                                     "Pulse.Syntax.Printer.fst"
-                                                     (Prims.of_int (326))
-                                                     (Prims.of_int (10))
-                                                     (Prims.of_int (330))
-                                                     (Prims.of_int (21)))))
-                                            (FStar_Sealed.seal
-                                               (Obj.magic
-                                                  (FStar_Range.mk_range
-                                                     "Pulse.Syntax.Printer.fst"
-                                                     (Prims.of_int (326))
-                                                     (Prims.of_int (10))
-                                                     (Prims.of_int (333))
-                                                     (Prims.of_int (60)))))
-                                            (Obj.magic
-                                               (FStar_Tactics_Effect.tac_bind
-                                                  (FStar_Sealed.seal
-                                                     (Obj.magic
-                                                        (FStar_Range.mk_range
-                                                           "Pulse.Syntax.Printer.fst"
-                                                           (Prims.of_int (327))
-                                                           (Prims.of_int (12))
-                                                           (Prims.of_int (330))
-                                                           (Prims.of_int (21)))))
-                                                  (FStar_Sealed.seal
-                                                     (Obj.magic
-                                                        (FStar_Range.mk_range
-                                                           "prims.fst"
-                                                           (Prims.of_int (590))
-                                                           (Prims.of_int (19))
-                                                           (Prims.of_int (590))
-                                                           (Prims.of_int (31)))))
-                                                  (Obj.magic
-                                                     (FStar_Tactics_Effect.tac_bind
-                                                        (FStar_Sealed.seal
-                                                           (Obj.magic
-                                                              (FStar_Range.mk_range
-                                                                 "Pulse.Syntax.Printer.fst"
-                                                                 (Prims.of_int (328))
-                                                                 (Prims.of_int (14))
-                                                                 (Prims.of_int (330))
-                                                                 (Prims.of_int (20)))))
-                                                        (FStar_Sealed.seal
-                                                           (Obj.magic
-                                                              (FStar_Range.mk_range
-                                                                 "Pulse.Syntax.Printer.fst"
-                                                                 (Prims.of_int (327))
-                                                                 (Prims.of_int (12))
-                                                                 (Prims.of_int (330))
-                                                                 (Prims.of_int (21)))))
-                                                        (Obj.magic
-                                                           (FStar_Tactics_Util.map
-                                                              (fun uu___ ->
-                                                                 match uu___
+                                           (Prims.of_int (299))
+                                           (Prims.of_int (6))
+                                           (Prims.of_int (308))
+                                           (Prims.of_int (60)))))
+                                  (Obj.magic
+                                     (FStar_Tactics_Effect.tac_bind
+                                        (FStar_Sealed.seal
+                                           (Obj.magic
+                                              (FStar_Range.mk_range
+                                                 "Pulse.Syntax.Printer.fst"
+                                                 (Prims.of_int (305))
+                                                 (Prims.of_int (8))
+                                                 (Prims.of_int (305))
+                                                 (Prims.of_int (28)))))
+                                        (FStar_Sealed.seal
+                                           (Obj.magic
+                                              (FStar_Range.mk_range
+                                                 "FStar.Printf.fst"
+                                                 (Prims.of_int (122))
+                                                 (Prims.of_int (8))
+                                                 (Prims.of_int (124))
+                                                 (Prims.of_int (44)))))
+                                        (Obj.magic (term_to_string typ))
+                                        (fun uu___1 ->
+                                           FStar_Tactics_Effect.lift_div_tac
+                                             (fun uu___2 ->
+                                                fun x ->
+                                                  Prims.strcat
+                                                    (Prims.strcat
+                                                       (Prims.strcat
+                                                          (Prims.strcat ""
+                                                             (Prims.strcat
+                                                                (match ctag
                                                                  with
-                                                                 | (x, y) ->
+                                                                 | Pulse_Syntax_Base.STT
+                                                                    ->
+                                                                    "stt_admit"
+                                                                 | Pulse_Syntax_Base.STT_Atomic
+                                                                    ->
+                                                                    "stt_atomic_admit"
+                                                                 | Pulse_Syntax_Base.STT_Ghost
+                                                                    ->
+                                                                    "stt_ghost_admit")
+                                                                "<"))
+                                                          (Prims.strcat
+                                                             (universe_to_string
+                                                                Prims.int_zero
+                                                                u) "> "))
+                                                       (Prims.strcat uu___1
+                                                          ""))
+                                                    (Prims.strcat x "")))))
+                                  (fun uu___1 ->
+                                     FStar_Tactics_Effect.lift_div_tac
+                                       (fun uu___2 -> uu___1 uu___)))) uu___)))
+           | Pulse_Syntax_Base.Tm_Unreachable ->
+               Obj.magic
+                 (Obj.repr
+                    (FStar_Tactics_Effect.lift_div_tac
+                       (fun uu___ -> "unreachable ()")))
+           | Pulse_Syntax_Base.Tm_ProofHintWithBinders
+               { Pulse_Syntax_Base.hint_type = hint_type;
+                 Pulse_Syntax_Base.binders = binders;
+                 Pulse_Syntax_Base.t3 = t1;_}
+               ->
+               Obj.magic
+                 (Obj.repr
+                    (FStar_Tactics_Effect.tac_bind
+                       (FStar_Sealed.seal
+                          (Obj.magic
+                             (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
+                                (Prims.of_int (314)) (Prims.of_int (8))
+                                (Prims.of_int (316)) (Prims.of_int (86)))))
+                       (FStar_Sealed.seal
+                          (Obj.magic
+                             (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
+                                (Prims.of_int (317)) (Prims.of_int (8))
+                                (Prims.of_int (340)) (Prims.of_int (36)))))
+                       (match binders with
+                        | [] ->
+                            Obj.magic
+                              (Obj.repr
+                                 (FStar_Tactics_Effect.lift_div_tac
+                                    (fun uu___ -> "")))
+                        | uu___ ->
+                            Obj.magic
+                              (Obj.repr
+                                 (FStar_Tactics_Effect.tac_bind
+                                    (FStar_Sealed.seal
+                                       (Obj.magic
+                                          (FStar_Range.mk_range
+                                             "Pulse.Syntax.Printer.fst"
+                                             (Prims.of_int (316))
+                                             (Prims.of_int (34))
+                                             (Prims.of_int (316))
+                                             (Prims.of_int (86)))))
+                                    (FStar_Sealed.seal
+                                       (Obj.magic
+                                          (FStar_Range.mk_range "prims.fst"
+                                             (Prims.of_int (590))
+                                             (Prims.of_int (19))
+                                             (Prims.of_int (590))
+                                             (Prims.of_int (31)))))
+                                    (Obj.magic
+                                       (FStar_Tactics_Effect.tac_bind
+                                          (FStar_Sealed.seal
+                                             (Obj.magic
+                                                (FStar_Range.mk_range
+                                                   "Pulse.Syntax.Printer.fst"
+                                                   (Prims.of_int (316))
+                                                   (Prims.of_int (53))
+                                                   (Prims.of_int (316))
+                                                   (Prims.of_int (85)))))
+                                          (FStar_Sealed.seal
+                                             (Obj.magic
+                                                (FStar_Range.mk_range
+                                                   "Pulse.Syntax.Printer.fst"
+                                                   (Prims.of_int (316))
+                                                   (Prims.of_int (34))
+                                                   (Prims.of_int (316))
+                                                   (Prims.of_int (86)))))
+                                          (Obj.magic
+                                             (FStar_Tactics_Util.map
+                                                binder_to_string binders))
+                                          (fun uu___1 ->
+                                             FStar_Tactics_Effect.lift_div_tac
+                                               (fun uu___2 ->
+                                                  FStar_String.concat " "
+                                                    uu___1))))
+                                    (fun uu___1 ->
+                                       FStar_Tactics_Effect.lift_div_tac
+                                         (fun uu___2 ->
+                                            Prims.strcat "with "
+                                              (Prims.strcat uu___1 "."))))))
+                       (fun uu___ ->
+                          (fun with_prefix ->
+                             Obj.magic
+                               (FStar_Tactics_Effect.tac_bind
+                                  (FStar_Sealed.seal
+                                     (Obj.magic
+                                        (FStar_Range.mk_range
+                                           "Pulse.Syntax.Printer.fst"
+                                           (Prims.of_int (318))
+                                           (Prims.of_int (28))
+                                           (Prims.of_int (320))
+                                           (Prims.of_int (58)))))
+                                  (FStar_Sealed.seal
+                                     (Obj.magic
+                                        (FStar_Range.mk_range
+                                           "Pulse.Syntax.Printer.fst"
+                                           (Prims.of_int (321))
+                                           (Prims.of_int (8))
+                                           (Prims.of_int (340))
+                                           (Prims.of_int (36)))))
+                                  (FStar_Tactics_Effect.lift_div_tac
+                                     (fun uu___ ->
+                                        fun uu___1 ->
+                                          match uu___1 with
+                                          | FStar_Pervasives_Native.None ->
+                                              ""
+                                          | FStar_Pervasives_Native.Some l ->
+                                              Prims.strcat " ["
+                                                (Prims.strcat
+                                                   (FStar_String.concat "; "
+                                                      l) "]")))
+                                  (fun uu___ ->
+                                     (fun names_to_string ->
+                                        Obj.magic
+                                          (FStar_Tactics_Effect.tac_bind
+                                             (FStar_Sealed.seal
+                                                (Obj.magic
+                                                   (FStar_Range.mk_range
+                                                      "Pulse.Syntax.Printer.fst"
+                                                      (Prims.of_int (323))
+                                                      (Prims.of_int (8))
+                                                      (Prims.of_int (337))
+                                                      (Prims.of_int (80)))))
+                                             (FStar_Sealed.seal
+                                                (Obj.magic
+                                                   (FStar_Range.mk_range
+                                                      "Pulse.Syntax.Printer.fst"
+                                                      (Prims.of_int (321))
+                                                      (Prims.of_int (8))
+                                                      (Prims.of_int (340))
+                                                      (Prims.of_int (36)))))
+                                             (match hint_type with
+                                              | Pulse_Syntax_Base.ASSERT
+                                                  {
+                                                    Pulse_Syntax_Base.p = p;_}
+                                                  ->
+                                                  Obj.magic
+                                                    (FStar_Tactics_Effect.tac_bind
+                                                       (FStar_Sealed.seal
+                                                          (Obj.magic
+                                                             (FStar_Range.mk_range
+                                                                "Pulse.Syntax.Printer.fst"
+                                                                (Prims.of_int (324))
+                                                                (Prims.of_int (36))
+                                                                (Prims.of_int (324))
+                                                                (Prims.of_int (52)))))
+                                                       (FStar_Sealed.seal
+                                                          (Obj.magic
+                                                             (FStar_Range.mk_range
+                                                                "Pulse.Syntax.Printer.fst"
+                                                                (Prims.of_int (324))
+                                                                (Prims.of_int (26))
+                                                                (Prims.of_int (324))
+                                                                (Prims.of_int (52)))))
+                                                       (Obj.magic
+                                                          (term_to_string p))
+                                                       (fun uu___ ->
+                                                          FStar_Tactics_Effect.lift_div_tac
+                                                            (fun uu___1 ->
+                                                               ("assert",
+                                                                 uu___))))
+                                              | Pulse_Syntax_Base.UNFOLD
+                                                  {
+                                                    Pulse_Syntax_Base.names1
+                                                      = names;
+                                                    Pulse_Syntax_Base.p2 = p;_}
+                                                  ->
+                                                  Obj.magic
+                                                    (FStar_Tactics_Effect.tac_bind
+                                                       (FStar_Sealed.seal
+                                                          (Obj.magic
+                                                             (FStar_Range.mk_range
+                                                                "Pulse.Syntax.Printer.fst"
+                                                                (Prims.of_int (325))
+                                                                (Prims.of_int (77))
+                                                                (Prims.of_int (325))
+                                                                (Prims.of_int (93)))))
+                                                       (FStar_Sealed.seal
+                                                          (Obj.magic
+                                                             (FStar_Range.mk_range
+                                                                "Pulse.Syntax.Printer.fst"
+                                                                (Prims.of_int (325))
+                                                                (Prims.of_int (33))
+                                                                (Prims.of_int (325))
+                                                                (Prims.of_int (93)))))
+                                                       (Obj.magic
+                                                          (term_to_string p))
+                                                       (fun uu___ ->
+                                                          FStar_Tactics_Effect.lift_div_tac
+                                                            (fun uu___1 ->
+                                                               ((Prims.strcat
+                                                                   "unfold"
+                                                                   (Prims.strcat
+                                                                    (names_to_string
+                                                                    names) "")),
+                                                                 uu___))))
+                                              | Pulse_Syntax_Base.FOLD
+                                                  {
+                                                    Pulse_Syntax_Base.names =
+                                                      names;
+                                                    Pulse_Syntax_Base.p1 = p;_}
+                                                  ->
+                                                  Obj.magic
+                                                    (FStar_Tactics_Effect.tac_bind
+                                                       (FStar_Sealed.seal
+                                                          (Obj.magic
+                                                             (FStar_Range.mk_range
+                                                                "Pulse.Syntax.Printer.fst"
+                                                                (Prims.of_int (326))
+                                                                (Prims.of_int (73))
+                                                                (Prims.of_int (326))
+                                                                (Prims.of_int (89)))))
+                                                       (FStar_Sealed.seal
+                                                          (Obj.magic
+                                                             (FStar_Range.mk_range
+                                                                "Pulse.Syntax.Printer.fst"
+                                                                (Prims.of_int (326))
+                                                                (Prims.of_int (31))
+                                                                (Prims.of_int (326))
+                                                                (Prims.of_int (89)))))
+                                                       (Obj.magic
+                                                          (term_to_string p))
+                                                       (fun uu___ ->
+                                                          FStar_Tactics_Effect.lift_div_tac
+                                                            (fun uu___1 ->
+                                                               ((Prims.strcat
+                                                                   "fold"
+                                                                   (Prims.strcat
+                                                                    (names_to_string
+                                                                    names) "")),
+                                                                 uu___))))
+                                              | Pulse_Syntax_Base.RENAME
+                                                  {
+                                                    Pulse_Syntax_Base.pairs =
+                                                      pairs;
+                                                    Pulse_Syntax_Base.goal =
+                                                      goal;_}
+                                                  ->
+                                                  Obj.magic
+                                                    (FStar_Tactics_Effect.tac_bind
+                                                       (FStar_Sealed.seal
+                                                          (Obj.magic
+                                                             (FStar_Range.mk_range
+                                                                "Pulse.Syntax.Printer.fst"
+                                                                (Prims.of_int (328))
+                                                                (Prims.of_int (10))
+                                                                (Prims.of_int (332))
+                                                                (Prims.of_int (21)))))
+                                                       (FStar_Sealed.seal
+                                                          (Obj.magic
+                                                             (FStar_Range.mk_range
+                                                                "Pulse.Syntax.Printer.fst"
+                                                                (Prims.of_int (328))
+                                                                (Prims.of_int (10))
+                                                                (Prims.of_int (335))
+                                                                (Prims.of_int (60)))))
+                                                       (Obj.magic
+                                                          (FStar_Tactics_Effect.tac_bind
+                                                             (FStar_Sealed.seal
+                                                                (Obj.magic
+                                                                   (FStar_Range.mk_range
+                                                                    "Pulse.Syntax.Printer.fst"
+                                                                    (Prims.of_int (329))
+                                                                    (Prims.of_int (12))
+                                                                    (Prims.of_int (332))
+                                                                    (Prims.of_int (21)))))
+                                                             (FStar_Sealed.seal
+                                                                (Obj.magic
+                                                                   (FStar_Range.mk_range
+                                                                    "prims.fst"
+                                                                    (Prims.of_int (590))
+                                                                    (Prims.of_int (19))
+                                                                    (Prims.of_int (590))
+                                                                    (Prims.of_int (31)))))
+                                                             (Obj.magic
+                                                                (FStar_Tactics_Effect.tac_bind
+                                                                   (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Syntax.Printer.fst"
+                                                                    (Prims.of_int (330))
+                                                                    (Prims.of_int (14))
+                                                                    (Prims.of_int (332))
+                                                                    (Prims.of_int (20)))))
+                                                                   (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Syntax.Printer.fst"
+                                                                    (Prims.of_int (329))
+                                                                    (Prims.of_int (12))
+                                                                    (Prims.of_int (332))
+                                                                    (Prims.of_int (21)))))
+                                                                   (Obj.magic
+                                                                    (FStar_Tactics_Util.map
+                                                                    (fun
+                                                                    uu___ ->
+                                                                    match uu___
+                                                                    with
+                                                                    | 
+                                                                    (x, y) ->
                                                                     FStar_Tactics_Effect.tac_bind
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (329))
+                                                                    (Prims.of_int (331))
                                                                     (Prims.of_int (69))
-                                                                    (Prims.of_int (329))
+                                                                    (Prims.of_int (331))
                                                                     (Prims.of_int (87)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (329))
+                                                                    (Prims.of_int (331))
                                                                     (Prims.of_int (31))
-                                                                    (Prims.of_int (329))
+                                                                    (Prims.of_int (331))
                                                                     (Prims.of_int (87)))))
                                                                     (Obj.magic
                                                                     (term_to_string
@@ -4263,17 +4526,17 @@ let rec (st_term_to_string' :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (329))
+                                                                    (Prims.of_int (331))
                                                                     (Prims.of_int (31))
-                                                                    (Prims.of_int (329))
+                                                                    (Prims.of_int (331))
                                                                     (Prims.of_int (87)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (329))
+                                                                    (Prims.of_int (331))
                                                                     (Prims.of_int (31))
-                                                                    (Prims.of_int (329))
+                                                                    (Prims.of_int (331))
                                                                     (Prims.of_int (87)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -4281,9 +4544,9 @@ let rec (st_term_to_string' :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (329))
+                                                                    (Prims.of_int (331))
                                                                     (Prims.of_int (50))
-                                                                    (Prims.of_int (329))
+                                                                    (Prims.of_int (331))
                                                                     (Prims.of_int (68)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -4318,65 +4581,69 @@ let rec (st_term_to_string' :
                                                                     uu___2
                                                                     uu___1))))
                                                                     uu___1))
-                                                              pairs))
-                                                        (fun uu___ ->
-                                                           FStar_Tactics_Effect.lift_div_tac
-                                                             (fun uu___1 ->
-                                                                FStar_String.concat
-                                                                  ", " uu___))))
-                                                  (fun uu___ ->
-                                                     FStar_Tactics_Effect.lift_div_tac
-                                                       (fun uu___1 ->
-                                                          Prims.strcat
-                                                            "rewrite each "
-                                                            (Prims.strcat
-                                                               uu___ "")))))
-                                            (fun uu___ ->
-                                               (fun uu___ ->
-                                                  Obj.magic
-                                                    (FStar_Tactics_Effect.tac_bind
-                                                       (FStar_Sealed.seal
-                                                          (Obj.magic
-                                                             (FStar_Range.mk_range
-                                                                "Pulse.Syntax.Printer.fst"
-                                                                (Prims.of_int (331))
-                                                                (Prims.of_int (12))
-                                                                (Prims.of_int (333))
-                                                                (Prims.of_int (60)))))
-                                                       (FStar_Sealed.seal
-                                                          (Obj.magic
-                                                             (FStar_Range.mk_range
-                                                                "Pulse.Syntax.Printer.fst"
-                                                                (Prims.of_int (326))
-                                                                (Prims.of_int (10))
-                                                                (Prims.of_int (333))
-                                                                (Prims.of_int (60)))))
-                                                       (match goal with
-                                                        | FStar_Pervasives_Native.None
-                                                            ->
-                                                            Obj.magic
-                                                              (Obj.repr
-                                                                 (FStar_Tactics_Effect.lift_div_tac
-                                                                    (
-                                                                    fun
+                                                                    pairs))
+                                                                   (fun uu___
+                                                                    ->
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
                                                                     uu___1 ->
-                                                                    "")))
-                                                        | FStar_Pervasives_Native.Some
-                                                            t2 ->
-                                                            Obj.magic
-                                                              (Obj.repr
-                                                                 (FStar_Tactics_Effect.tac_bind
-                                                                    (
-                                                                    FStar_Sealed.seal
+                                                                    FStar_String.concat
+                                                                    ", "
+                                                                    uu___))))
+                                                             (fun uu___ ->
+                                                                FStar_Tactics_Effect.lift_div_tac
+                                                                  (fun uu___1
+                                                                    ->
+                                                                    Prims.strcat
+                                                                    "rewrite each "
+                                                                    (Prims.strcat
+                                                                    uu___ "")))))
+                                                       (fun uu___ ->
+                                                          (fun uu___ ->
+                                                             Obj.magic
+                                                               (FStar_Tactics_Effect.tac_bind
+                                                                  (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
                                                                     (Prims.of_int (333))
+                                                                    (Prims.of_int (12))
+                                                                    (Prims.of_int (335))
+                                                                    (Prims.of_int (60)))))
+                                                                  (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Syntax.Printer.fst"
+                                                                    (Prims.of_int (328))
+                                                                    (Prims.of_int (10))
+                                                                    (Prims.of_int (335))
+                                                                    (Prims.of_int (60)))))
+                                                                  (match goal
+                                                                   with
+                                                                   | 
+                                                                   FStar_Pervasives_Native.None
+                                                                    ->
+                                                                    Obj.magic
+                                                                    (Obj.repr
+                                                                    (FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___1 ->
+                                                                    "")))
+                                                                   | 
+                                                                   FStar_Pervasives_Native.Some
+                                                                    t2 ->
+                                                                    Obj.magic
+                                                                    (Obj.repr
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Syntax.Printer.fst"
+                                                                    (Prims.of_int (335))
                                                                     (Prims.of_int (41))
-                                                                    (Prims.of_int (333))
+                                                                    (Prims.of_int (335))
                                                                     (Prims.of_int (59)))))
-                                                                    (
-                                                                    FStar_Sealed.seal
+                                                                    (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
@@ -4384,12 +4651,10 @@ let rec (st_term_to_string' :
                                                                     (Prims.of_int (19))
                                                                     (Prims.of_int (590))
                                                                     (Prims.of_int (31)))))
-                                                                    (
-                                                                    Obj.magic
+                                                                    (Obj.magic
                                                                     (term_to_string
                                                                     t2))
-                                                                    (
-                                                                    fun
+                                                                    (fun
                                                                     uu___1 ->
                                                                     FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -4398,85 +4663,90 @@ let rec (st_term_to_string' :
                                                                     " in "
                                                                     (Prims.strcat
                                                                     uu___1 ""))))))
-                                                       (fun uu___1 ->
-                                                          FStar_Tactics_Effect.lift_div_tac
-                                                            (fun uu___2 ->
-                                                               (uu___,
-                                                                 uu___1)))))
-                                                 uu___))
-                                   | Pulse_Syntax_Base.REWRITE
-                                       { Pulse_Syntax_Base.t1 = t11;
-                                         Pulse_Syntax_Base.t2 = t2;_}
-                                       ->
-                                       Obj.magic
-                                         (FStar_Tactics_Effect.tac_bind
-                                            (FStar_Sealed.seal
-                                               (Obj.magic
-                                                  (FStar_Range.mk_range
-                                                     "Pulse.Syntax.Printer.fst"
-                                                     (Prims.of_int (335))
-                                                     (Prims.of_int (10))
-                                                     (Prims.of_int (335))
-                                                     (Prims.of_int (76)))))
-                                            (FStar_Sealed.seal
-                                               (Obj.magic
-                                                  (FStar_Range.mk_range
-                                                     "Pulse.Syntax.Printer.fst"
-                                                     (Prims.of_int (335))
-                                                     (Prims.of_int (10))
-                                                     (Prims.of_int (335))
-                                                     (Prims.of_int (80)))))
-                                            (Obj.magic
-                                               (FStar_Tactics_Effect.tac_bind
-                                                  (FStar_Sealed.seal
-                                                     (Obj.magic
-                                                        (FStar_Range.mk_range
-                                                           "Pulse.Syntax.Printer.fst"
-                                                           (Prims.of_int (335))
-                                                           (Prims.of_int (57))
-                                                           (Prims.of_int (335))
-                                                           (Prims.of_int (76)))))
-                                                  (FStar_Sealed.seal
-                                                     (Obj.magic
-                                                        (FStar_Range.mk_range
-                                                           "Pulse.Syntax.Printer.fst"
-                                                           (Prims.of_int (335))
-                                                           (Prims.of_int (10))
-                                                           (Prims.of_int (335))
-                                                           (Prims.of_int (76)))))
-                                                  (Obj.magic
-                                                     (term_to_string t2))
-                                                  (fun uu___ ->
-                                                     (fun uu___ ->
-                                                        Obj.magic
+                                                                  (fun uu___1
+                                                                    ->
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___2 ->
+                                                                    (uu___,
+                                                                    uu___1)))))
+                                                            uu___))
+                                              | Pulse_Syntax_Base.REWRITE
+                                                  {
+                                                    Pulse_Syntax_Base.t1 =
+                                                      t11;
+                                                    Pulse_Syntax_Base.t2 = t2;_}
+                                                  ->
+                                                  Obj.magic
+                                                    (FStar_Tactics_Effect.tac_bind
+                                                       (FStar_Sealed.seal
+                                                          (Obj.magic
+                                                             (FStar_Range.mk_range
+                                                                "Pulse.Syntax.Printer.fst"
+                                                                (Prims.of_int (337))
+                                                                (Prims.of_int (10))
+                                                                (Prims.of_int (337))
+                                                                (Prims.of_int (76)))))
+                                                       (FStar_Sealed.seal
+                                                          (Obj.magic
+                                                             (FStar_Range.mk_range
+                                                                "Pulse.Syntax.Printer.fst"
+                                                                (Prims.of_int (337))
+                                                                (Prims.of_int (10))
+                                                                (Prims.of_int (337))
+                                                                (Prims.of_int (80)))))
+                                                       (Obj.magic
                                                           (FStar_Tactics_Effect.tac_bind
                                                              (FStar_Sealed.seal
                                                                 (Obj.magic
                                                                    (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (335))
-                                                                    (Prims.of_int (10))
-                                                                    (Prims.of_int (335))
+                                                                    (Prims.of_int (337))
+                                                                    (Prims.of_int (57))
+                                                                    (Prims.of_int (337))
                                                                     (Prims.of_int (76)))))
                                                              (FStar_Sealed.seal
                                                                 (Obj.magic
                                                                    (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (335))
+                                                                    (Prims.of_int (337))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (335))
+                                                                    (Prims.of_int (337))
                                                                     (Prims.of_int (76)))))
                                                              (Obj.magic
-                                                                (FStar_Tactics_Effect.tac_bind
-                                                                   (FStar_Sealed.seal
+                                                                (term_to_string
+                                                                   t2))
+                                                             (fun uu___ ->
+                                                                (fun uu___ ->
+                                                                   Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (335))
+                                                                    (Prims.of_int (337))
+                                                                    (Prims.of_int (10))
+                                                                    (Prims.of_int (337))
+                                                                    (Prims.of_int (76)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Syntax.Printer.fst"
+                                                                    (Prims.of_int (337))
+                                                                    (Prims.of_int (10))
+                                                                    (Prims.of_int (337))
+                                                                    (Prims.of_int (76)))))
+                                                                    (Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Syntax.Printer.fst"
+                                                                    (Prims.of_int (337))
                                                                     (Prims.of_int (37))
-                                                                    (Prims.of_int (335))
+                                                                    (Prims.of_int (337))
                                                                     (Prims.of_int (56)))))
-                                                                   (FStar_Sealed.seal
+                                                                    (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Printf.fst"
@@ -4484,10 +4754,10 @@ let rec (st_term_to_string' :
                                                                     (Prims.of_int (8))
                                                                     (Prims.of_int (124))
                                                                     (Prims.of_int (44)))))
-                                                                   (Obj.magic
+                                                                    (Obj.magic
                                                                     (term_to_string
                                                                     t11))
-                                                                   (fun
+                                                                    (fun
                                                                     uu___1 ->
                                                                     FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -4501,170 +4771,187 @@ let rec (st_term_to_string' :
                                                                     " as "))
                                                                     (Prims.strcat
                                                                     x "")))))
-                                                             (fun uu___1 ->
-                                                                FStar_Tactics_Effect.lift_div_tac
-                                                                  (fun uu___2
-                                                                    ->
+                                                                    (fun
+                                                                    uu___1 ->
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___2 ->
                                                                     uu___1
                                                                     uu___))))
-                                                       uu___)))
-                                            (fun uu___ ->
-                                               FStar_Tactics_Effect.lift_div_tac
-                                                 (fun uu___1 -> (uu___, "")))))
-                                  (fun uu___ ->
-                                     (fun uu___ ->
-                                        match uu___ with
-                                        | (ht, p) ->
-                                            Obj.magic
-                                              (FStar_Tactics_Effect.tac_bind
-                                                 (FStar_Sealed.seal
-                                                    (Obj.magic
-                                                       (FStar_Range.mk_range
-                                                          "Pulse.Syntax.Printer.fst"
-                                                          (Prims.of_int (338))
-                                                          (Prims.of_int (8))
-                                                          (Prims.of_int (338))
-                                                          (Prims.of_int (36)))))
-                                                 (FStar_Sealed.seal
-                                                    (Obj.magic
-                                                       (FStar_Range.mk_range
-                                                          "prims.fst"
-                                                          (Prims.of_int (590))
-                                                          (Prims.of_int (19))
-                                                          (Prims.of_int (590))
-                                                          (Prims.of_int (31)))))
-                                                 (Obj.magic
-                                                    (st_term_to_string' level
-                                                       t1))
-                                                 (fun uu___1 ->
-                                                    FStar_Tactics_Effect.lift_div_tac
-                                                      (fun uu___2 ->
-                                                         Prims.strcat
-                                                           (Prims.strcat
-                                                              (Prims.strcat
-                                                                 (Prims.strcat
-                                                                    ""
-                                                                    (
+                                                                  uu___)))
+                                                       (fun uu___ ->
+                                                          FStar_Tactics_Effect.lift_div_tac
+                                                            (fun uu___1 ->
+                                                               (uu___, "")))))
+                                             (fun uu___ ->
+                                                (fun uu___ ->
+                                                   match uu___ with
+                                                   | (ht, p) ->
+                                                       Obj.magic
+                                                         (FStar_Tactics_Effect.tac_bind
+                                                            (FStar_Sealed.seal
+                                                               (Obj.magic
+                                                                  (FStar_Range.mk_range
+                                                                    "Pulse.Syntax.Printer.fst"
+                                                                    (Prims.of_int (340))
+                                                                    (Prims.of_int (8))
+                                                                    (Prims.of_int (340))
+                                                                    (Prims.of_int (36)))))
+                                                            (FStar_Sealed.seal
+                                                               (Obj.magic
+                                                                  (FStar_Range.mk_range
+                                                                    "prims.fst"
+                                                                    (Prims.of_int (590))
+                                                                    (Prims.of_int (19))
+                                                                    (Prims.of_int (590))
+                                                                    (Prims.of_int (31)))))
+                                                            (Obj.magic
+                                                               (st_term_to_string'
+                                                                  level t1))
+                                                            (fun uu___1 ->
+                                                               FStar_Tactics_Effect.lift_div_tac
+                                                                 (fun uu___2
+                                                                    ->
                                                                     Prims.strcat
+                                                                    (Prims.strcat
+                                                                    (Prims.strcat
+                                                                    (Prims.strcat
+                                                                    ""
+                                                                    (Prims.strcat
                                                                     with_prefix
                                                                     " "))
-                                                                 (Prims.strcat
+                                                                    (Prims.strcat
                                                                     ht " "))
-                                                              (Prims.strcat p
-                                                                 "; "))
-                                                           (Prims.strcat
-                                                              uu___1 "")))))
-                                       uu___))) uu___))) uu___)
-      | Pulse_Syntax_Base.Tm_WithInv
-          { Pulse_Syntax_Base.name1 = name; Pulse_Syntax_Base.body6 = body;
-            Pulse_Syntax_Base.returns_inv = returns_inv;_}
-          ->
-          FStar_Tactics_Effect.tac_bind
-            (FStar_Sealed.seal
-               (Obj.magic
-                  (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                     (Prims.of_int (344)) (Prims.of_int (8))
-                     (Prims.of_int (344)) (Prims.of_int (40)))))
-            (FStar_Sealed.seal
-               (Obj.magic
-                  (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                     (Prims.of_int (341)) (Prims.of_int (6))
-                     (Prims.of_int (344)) (Prims.of_int (40)))))
-            (Obj.magic (term_opt_to_string returns_inv))
-            (fun uu___ ->
-               (fun uu___ ->
-                  Obj.magic
+                                                                    (Prims.strcat
+                                                                    p "; "))
+                                                                    (Prims.strcat
+                                                                    uu___1 "")))))
+                                                  uu___))) uu___))) uu___)))
+           | Pulse_Syntax_Base.Tm_WithInv
+               { Pulse_Syntax_Base.name1 = name;
+                 Pulse_Syntax_Base.body6 = body;
+                 Pulse_Syntax_Base.returns_inv = returns_inv;_}
+               ->
+               Obj.magic
+                 (Obj.repr
                     (FStar_Tactics_Effect.tac_bind
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (341)) (Prims.of_int (6))
-                                (Prims.of_int (344)) (Prims.of_int (40)))))
+                                (Prims.of_int (346)) (Prims.of_int (8))
+                                (Prims.of_int (346)) (Prims.of_int (40)))))
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (341)) (Prims.of_int (6))
-                                (Prims.of_int (344)) (Prims.of_int (40)))))
-                       (Obj.magic
-                          (FStar_Tactics_Effect.tac_bind
-                             (FStar_Sealed.seal
-                                (Obj.magic
-                                   (FStar_Range.mk_range
-                                      "Pulse.Syntax.Printer.fst"
-                                      (Prims.of_int (343)) (Prims.of_int (8))
-                                      (Prims.of_int (343))
-                                      (Prims.of_int (39)))))
-                             (FStar_Sealed.seal
-                                (Obj.magic
-                                   (FStar_Range.mk_range
-                                      "Pulse.Syntax.Printer.fst"
-                                      (Prims.of_int (341)) (Prims.of_int (6))
-                                      (Prims.of_int (344))
-                                      (Prims.of_int (40)))))
-                             (Obj.magic (st_term_to_string' level body))
-                             (fun uu___1 ->
-                                (fun uu___1 ->
-                                   Obj.magic
+                                (Prims.of_int (343)) (Prims.of_int (6))
+                                (Prims.of_int (346)) (Prims.of_int (40)))))
+                       (Obj.magic (term_opt_to_string returns_inv))
+                       (fun uu___ ->
+                          (fun uu___ ->
+                             Obj.magic
+                               (FStar_Tactics_Effect.tac_bind
+                                  (FStar_Sealed.seal
+                                     (Obj.magic
+                                        (FStar_Range.mk_range
+                                           "Pulse.Syntax.Printer.fst"
+                                           (Prims.of_int (343))
+                                           (Prims.of_int (6))
+                                           (Prims.of_int (346))
+                                           (Prims.of_int (40)))))
+                                  (FStar_Sealed.seal
+                                     (Obj.magic
+                                        (FStar_Range.mk_range
+                                           "Pulse.Syntax.Printer.fst"
+                                           (Prims.of_int (343))
+                                           (Prims.of_int (6))
+                                           (Prims.of_int (346))
+                                           (Prims.of_int (40)))))
+                                  (Obj.magic
                                      (FStar_Tactics_Effect.tac_bind
                                         (FStar_Sealed.seal
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.Syntax.Printer.fst"
-                                                 (Prims.of_int (341))
-                                                 (Prims.of_int (6))
-                                                 (Prims.of_int (344))
-                                                 (Prims.of_int (40)))))
+                                                 (Prims.of_int (345))
+                                                 (Prims.of_int (8))
+                                                 (Prims.of_int (345))
+                                                 (Prims.of_int (39)))))
                                         (FStar_Sealed.seal
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.Syntax.Printer.fst"
-                                                 (Prims.of_int (341))
+                                                 (Prims.of_int (343))
                                                  (Prims.of_int (6))
-                                                 (Prims.of_int (344))
+                                                 (Prims.of_int (346))
                                                  (Prims.of_int (40)))))
                                         (Obj.magic
-                                           (FStar_Tactics_Effect.tac_bind
-                                              (FStar_Sealed.seal
-                                                 (Obj.magic
-                                                    (FStar_Range.mk_range
-                                                       "Pulse.Syntax.Printer.fst"
-                                                       (Prims.of_int (342))
-                                                       (Prims.of_int (8))
-                                                       (Prims.of_int (342))
-                                                       (Prims.of_int (29)))))
-                                              (FStar_Sealed.seal
-                                                 (Obj.magic
-                                                    (FStar_Range.mk_range
-                                                       "FStar.Printf.fst"
-                                                       (Prims.of_int (122))
-                                                       (Prims.of_int (8))
-                                                       (Prims.of_int (124))
-                                                       (Prims.of_int (44)))))
-                                              (Obj.magic
-                                                 (term_to_string name))
-                                              (fun uu___2 ->
-                                                 FStar_Tactics_Effect.lift_div_tac
-                                                   (fun uu___3 ->
-                                                      fun x ->
-                                                        fun x1 ->
-                                                          Prims.strcat
-                                                            (Prims.strcat
-                                                               (Prims.strcat
-                                                                  "with_inv "
-                                                                  (Prims.strcat
+                                           (st_term_to_string' level body))
+                                        (fun uu___1 ->
+                                           (fun uu___1 ->
+                                              Obj.magic
+                                                (FStar_Tactics_Effect.tac_bind
+                                                   (FStar_Sealed.seal
+                                                      (Obj.magic
+                                                         (FStar_Range.mk_range
+                                                            "Pulse.Syntax.Printer.fst"
+                                                            (Prims.of_int (343))
+                                                            (Prims.of_int (6))
+                                                            (Prims.of_int (346))
+                                                            (Prims.of_int (40)))))
+                                                   (FStar_Sealed.seal
+                                                      (Obj.magic
+                                                         (FStar_Range.mk_range
+                                                            "Pulse.Syntax.Printer.fst"
+                                                            (Prims.of_int (343))
+                                                            (Prims.of_int (6))
+                                                            (Prims.of_int (346))
+                                                            (Prims.of_int (40)))))
+                                                   (Obj.magic
+                                                      (FStar_Tactics_Effect.tac_bind
+                                                         (FStar_Sealed.seal
+                                                            (Obj.magic
+                                                               (FStar_Range.mk_range
+                                                                  "Pulse.Syntax.Printer.fst"
+                                                                  (Prims.of_int (344))
+                                                                  (Prims.of_int (8))
+                                                                  (Prims.of_int (344))
+                                                                  (Prims.of_int (29)))))
+                                                         (FStar_Sealed.seal
+                                                            (Obj.magic
+                                                               (FStar_Range.mk_range
+                                                                  "FStar.Printf.fst"
+                                                                  (Prims.of_int (122))
+                                                                  (Prims.of_int (8))
+                                                                  (Prims.of_int (124))
+                                                                  (Prims.of_int (44)))))
+                                                         (Obj.magic
+                                                            (term_to_string
+                                                               name))
+                                                         (fun uu___2 ->
+                                                            FStar_Tactics_Effect.lift_div_tac
+                                                              (fun uu___3 ->
+                                                                 fun x ->
+                                                                   fun x1 ->
+                                                                    Prims.strcat
+                                                                    (Prims.strcat
+                                                                    (Prims.strcat
+                                                                    "with_inv "
+                                                                    (Prims.strcat
                                                                     uu___2
                                                                     " "))
-                                                               (Prims.strcat
-                                                                  x " "))
-                                                            (Prims.strcat x1
-                                                               "")))))
-                                        (fun uu___2 ->
-                                           FStar_Tactics_Effect.lift_div_tac
-                                             (fun uu___3 -> uu___2 uu___1))))
-                                  uu___1)))
-                       (fun uu___1 ->
-                          FStar_Tactics_Effect.lift_div_tac
-                            (fun uu___2 -> uu___1 uu___)))) uu___)
+                                                                    (Prims.strcat
+                                                                    x " "))
+                                                                    (Prims.strcat
+                                                                    x1 "")))))
+                                                   (fun uu___2 ->
+                                                      FStar_Tactics_Effect.lift_div_tac
+                                                        (fun uu___3 ->
+                                                           uu___2 uu___1))))
+                                             uu___1)))
+                                  (fun uu___1 ->
+                                     FStar_Tactics_Effect.lift_div_tac
+                                       (fun uu___2 -> uu___1 uu___)))) uu___))))
+        uu___1 uu___
 and (branches_to_string :
   (Pulse_Syntax_Base.pattern * Pulse_Syntax_Base.st_term) Prims.list ->
     (Prims.string, unit) FStar_Tactics_Effect.tac_repr)
@@ -4682,13 +4969,13 @@ and (branches_to_string :
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                            (Prims.of_int (349)) (Prims.of_int (13))
-                            (Prims.of_int (349)) (Prims.of_int (31)))))
+                            (Prims.of_int (351)) (Prims.of_int (13))
+                            (Prims.of_int (351)) (Prims.of_int (31)))))
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                            (Prims.of_int (349)) (Prims.of_int (13))
-                            (Prims.of_int (349)) (Prims.of_int (55)))))
+                            (Prims.of_int (351)) (Prims.of_int (13))
+                            (Prims.of_int (351)) (Prims.of_int (55)))))
                    (Obj.magic (branch_to_string b))
                    (fun uu___ ->
                       (fun uu___ ->
@@ -4698,9 +4985,9 @@ and (branches_to_string :
                                  (Obj.magic
                                     (FStar_Range.mk_range
                                        "Pulse.Syntax.Printer.fst"
-                                       (Prims.of_int (349))
+                                       (Prims.of_int (351))
                                        (Prims.of_int (34))
-                                       (Prims.of_int (349))
+                                       (Prims.of_int (351))
                                        (Prims.of_int (55)))))
                               (FStar_Sealed.seal
                                  (Obj.magic
@@ -4723,12 +5010,12 @@ and (branch_to_string :
       (FStar_Sealed.seal
          (Obj.magic
             (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-               (Prims.of_int (352)) (Prims.of_int (17)) (Prims.of_int (352))
+               (Prims.of_int (354)) (Prims.of_int (17)) (Prims.of_int (354))
                (Prims.of_int (19)))))
       (FStar_Sealed.seal
          (Obj.magic
             (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-               (Prims.of_int (351)) (Prims.of_int (35)) (Prims.of_int (355))
+               (Prims.of_int (353)) (Prims.of_int (35)) (Prims.of_int (357))
                (Prims.of_int (29)))))
       (FStar_Tactics_Effect.lift_div_tac (fun uu___ -> br))
       (fun uu___ ->
@@ -4740,13 +5027,13 @@ and (branch_to_string :
                      (FStar_Sealed.seal
                         (Obj.magic
                            (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                              (Prims.of_int (355)) (Prims.of_int (4))
-                              (Prims.of_int (355)) (Prims.of_int (29)))))
+                              (Prims.of_int (357)) (Prims.of_int (4))
+                              (Prims.of_int (357)) (Prims.of_int (29)))))
                      (FStar_Sealed.seal
                         (Obj.magic
                            (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                              (Prims.of_int (353)) (Prims.of_int (2))
-                              (Prims.of_int (355)) (Prims.of_int (29)))))
+                              (Prims.of_int (355)) (Prims.of_int (2))
+                              (Prims.of_int (357)) (Prims.of_int (29)))))
                      (Obj.magic (st_term_to_string' "" e))
                      (fun uu___1 ->
                         (fun uu___1 ->
@@ -4756,17 +5043,17 @@ and (branch_to_string :
                                    (Obj.magic
                                       (FStar_Range.mk_range
                                          "Pulse.Syntax.Printer.fst"
-                                         (Prims.of_int (353))
-                                         (Prims.of_int (2))
                                          (Prims.of_int (355))
+                                         (Prims.of_int (2))
+                                         (Prims.of_int (357))
                                          (Prims.of_int (29)))))
                                 (FStar_Sealed.seal
                                    (Obj.magic
                                       (FStar_Range.mk_range
                                          "Pulse.Syntax.Printer.fst"
-                                         (Prims.of_int (353))
-                                         (Prims.of_int (2))
                                          (Prims.of_int (355))
+                                         (Prims.of_int (2))
+                                         (Prims.of_int (357))
                                          (Prims.of_int (29)))))
                                 (Obj.magic
                                    (FStar_Tactics_Effect.tac_bind
@@ -4774,9 +5061,9 @@ and (branch_to_string :
                                          (Obj.magic
                                             (FStar_Range.mk_range
                                                "Pulse.Syntax.Printer.fst"
-                                               (Prims.of_int (354))
+                                               (Prims.of_int (356))
                                                (Prims.of_int (4))
-                                               (Prims.of_int (354))
+                                               (Prims.of_int (356))
                                                (Prims.of_int (27)))))
                                       (FStar_Sealed.seal
                                          (Obj.magic
@@ -4814,8 +5101,8 @@ and (pattern_to_string :
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                            (Prims.of_int (362)) (Prims.of_int (6))
-                            (Prims.of_int (362)) (Prims.of_int (74)))))
+                            (Prims.of_int (364)) (Prims.of_int (6))
+                            (Prims.of_int (364)) (Prims.of_int (74)))))
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "prims.fst"
@@ -4827,14 +5114,14 @@ and (pattern_to_string :
                             (Obj.magic
                                (FStar_Range.mk_range
                                   "Pulse.Syntax.Printer.fst"
-                                  (Prims.of_int (362)) (Prims.of_int (25))
-                                  (Prims.of_int (362)) (Prims.of_int (73)))))
+                                  (Prims.of_int (364)) (Prims.of_int (25))
+                                  (Prims.of_int (364)) (Prims.of_int (73)))))
                          (FStar_Sealed.seal
                             (Obj.magic
                                (FStar_Range.mk_range
                                   "Pulse.Syntax.Printer.fst"
-                                  (Prims.of_int (362)) (Prims.of_int (6))
-                                  (Prims.of_int (362)) (Prims.of_int (74)))))
+                                  (Prims.of_int (364)) (Prims.of_int (6))
+                                  (Prims.of_int (364)) (Prims.of_int (74)))))
                          (Obj.magic
                             (FStar_Tactics_Util.map
                                (fun uu___ ->
@@ -4906,6 +5193,7 @@ let (tag_of_st_term : Pulse_Syntax_Base.st_term -> Prims.string) =
     | Pulse_Syntax_Base.Tm_WithLocalArray uu___ -> "Tm_WithLocalArray"
     | Pulse_Syntax_Base.Tm_Rewrite uu___ -> "Tm_Rewrite"
     | Pulse_Syntax_Base.Tm_Admit uu___ -> "Tm_Admit"
+    | Pulse_Syntax_Base.Tm_Unreachable -> "Tm_Unreachable"
     | Pulse_Syntax_Base.Tm_ProofHintWithBinders uu___ ->
         "Tm_ProofHintWithBinders"
     | Pulse_Syntax_Base.Tm_WithInv uu___ -> "Tm_WithInv"
@@ -4931,8 +5219,8 @@ let (tag_of_comp :
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                            (Prims.of_int (417)) (Prims.of_int (31))
-                            (Prims.of_int (417)) (Prims.of_int (49)))))
+                            (Prims.of_int (420)) (Prims.of_int (31))
+                            (Prims.of_int (420)) (Prims.of_int (49)))))
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "prims.fst"
@@ -4950,8 +5238,8 @@ let (tag_of_comp :
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                            (Prims.of_int (419)) (Prims.of_int (30))
-                            (Prims.of_int (419)) (Prims.of_int (48)))))
+                            (Prims.of_int (422)) (Prims.of_int (30))
+                            (Prims.of_int (422)) (Prims.of_int (48)))))
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "prims.fst"
@@ -4974,6 +5262,7 @@ let rec (print_st_head : Pulse_Syntax_Base.st_term -> Prims.string) =
     | Pulse_Syntax_Base.Tm_Match uu___ -> "Match"
     | Pulse_Syntax_Base.Tm_While uu___ -> "While"
     | Pulse_Syntax_Base.Tm_Admit uu___ -> "Admit"
+    | Pulse_Syntax_Base.Tm_Unreachable -> "Unreachable"
     | Pulse_Syntax_Base.Tm_Par uu___ -> "Par"
     | Pulse_Syntax_Base.Tm_Rewrite uu___ -> "Rewrite"
     | Pulse_Syntax_Base.Tm_WithLocal uu___ -> "WithLocal"
@@ -5016,6 +5305,7 @@ let rec (print_skel : Pulse_Syntax_Base.st_term -> Prims.string) =
     | Pulse_Syntax_Base.Tm_Match uu___ -> "Match"
     | Pulse_Syntax_Base.Tm_While uu___ -> "While"
     | Pulse_Syntax_Base.Tm_Admit uu___ -> "Admit"
+    | Pulse_Syntax_Base.Tm_Unreachable -> "Unreachable"
     | Pulse_Syntax_Base.Tm_Par uu___ -> "Par"
     | Pulse_Syntax_Base.Tm_Rewrite uu___ -> "Rewrite"
     | Pulse_Syntax_Base.Tm_WithLocal uu___ -> "WithLocal"
@@ -5044,8 +5334,8 @@ let (decl_to_string :
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                   (Prims.of_int (474)) (Prims.of_int (12))
-                   (Prims.of_int (477)) (Prims.of_int (42)))))
+                   (Prims.of_int (479)) (Prims.of_int (12))
+                   (Prims.of_int (482)) (Prims.of_int (42)))))
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "prims.fst" (Prims.of_int (590))
@@ -5056,8 +5346,8 @@ let (decl_to_string :
                 (FStar_Sealed.seal
                    (Obj.magic
                       (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                         (Prims.of_int (475)) (Prims.of_int (5))
-                         (Prims.of_int (477)) (Prims.of_int (42)))))
+                         (Prims.of_int (480)) (Prims.of_int (5))
+                         (Prims.of_int (482)) (Prims.of_int (42)))))
                 (FStar_Sealed.seal
                    (Obj.magic
                       (FStar_Range.mk_range "prims.fst" (Prims.of_int (590))
@@ -5068,8 +5358,8 @@ let (decl_to_string :
                       (FStar_Sealed.seal
                          (Obj.magic
                             (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                               (Prims.of_int (475)) (Prims.of_int (32))
-                               (Prims.of_int (477)) (Prims.of_int (42)))))
+                               (Prims.of_int (480)) (Prims.of_int (32))
+                               (Prims.of_int (482)) (Prims.of_int (42)))))
                       (FStar_Sealed.seal
                          (Obj.magic
                             (FStar_Range.mk_range "prims.fst"
@@ -5081,8 +5371,8 @@ let (decl_to_string :
                                (Obj.magic
                                   (FStar_Range.mk_range
                                      "Pulse.Syntax.Printer.fst"
-                                     (Prims.of_int (476)) (Prims.of_int (5))
-                                     (Prims.of_int (477)) (Prims.of_int (42)))))
+                                     (Prims.of_int (481)) (Prims.of_int (5))
+                                     (Prims.of_int (482)) (Prims.of_int (42)))))
                             (FStar_Sealed.seal
                                (Obj.magic
                                   (FStar_Range.mk_range "prims.fst"
@@ -5094,17 +5384,17 @@ let (decl_to_string :
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "Pulse.Syntax.Printer.fst"
-                                           (Prims.of_int (476))
+                                           (Prims.of_int (481))
                                            (Prims.of_int (5))
-                                           (Prims.of_int (476))
+                                           (Prims.of_int (481))
                                            (Prims.of_int (71)))))
                                   (FStar_Sealed.seal
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "Pulse.Syntax.Printer.fst"
-                                           (Prims.of_int (476))
+                                           (Prims.of_int (481))
                                            (Prims.of_int (5))
-                                           (Prims.of_int (477))
+                                           (Prims.of_int (482))
                                            (Prims.of_int (42)))))
                                   (Obj.magic
                                      (FStar_Tactics_Effect.tac_bind
@@ -5112,17 +5402,17 @@ let (decl_to_string :
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.Syntax.Printer.fst"
-                                                 (Prims.of_int (476))
+                                                 (Prims.of_int (481))
                                                  (Prims.of_int (23))
-                                                 (Prims.of_int (476))
+                                                 (Prims.of_int (481))
                                                  (Prims.of_int (71)))))
                                         (FStar_Sealed.seal
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.Syntax.Printer.fst"
-                                                 (Prims.of_int (476))
+                                                 (Prims.of_int (481))
                                                  (Prims.of_int (5))
-                                                 (Prims.of_int (476))
+                                                 (Prims.of_int (481))
                                                  (Prims.of_int (71)))))
                                         (Obj.magic
                                            (FStar_Tactics_Util.map
@@ -5143,9 +5433,9 @@ let (decl_to_string :
                                                 (Obj.magic
                                                    (FStar_Range.mk_range
                                                       "Pulse.Syntax.Printer.fst"
-                                                      (Prims.of_int (477))
+                                                      (Prims.of_int (482))
                                                       (Prims.of_int (6))
-                                                      (Prims.of_int (477))
+                                                      (Prims.of_int (482))
                                                       (Prims.of_int (42)))))
                                              (FStar_Sealed.seal
                                                 (Obj.magic
@@ -5161,9 +5451,9 @@ let (decl_to_string :
                                                       (Obj.magic
                                                          (FStar_Range.mk_range
                                                             "Pulse.Syntax.Printer.fst"
-                                                            (Prims.of_int (477))
+                                                            (Prims.of_int (482))
                                                             (Prims.of_int (14))
-                                                            (Prims.of_int (477))
+                                                            (Prims.of_int (482))
                                                             (Prims.of_int (42)))))
                                                    (FStar_Sealed.seal
                                                       (Obj.magic
@@ -5179,9 +5469,9 @@ let (decl_to_string :
                                                             (Obj.magic
                                                                (FStar_Range.mk_range
                                                                   "Pulse.Syntax.Printer.fst"
-                                                                  (Prims.of_int (477))
+                                                                  (Prims.of_int (482))
                                                                   (Prims.of_int (14))
-                                                                  (Prims.of_int (477))
+                                                                  (Prims.of_int (482))
                                                                   (Prims.of_int (36)))))
                                                          (FStar_Sealed.seal
                                                             (Obj.magic

--- a/src/ocaml/plugin/generated/Pulse_Typing.ml
+++ b/src/ocaml/plugin/generated/Pulse_Typing.ml
@@ -1116,6 +1116,8 @@ type ('dummyV0, 'dummyV1, 'dummyV2) st_typing =
   Pulse_Syntax_Base.vprop * unit * unit 
   | T_Admit of Pulse_Typing_Env.env * Pulse_Syntax_Base.st_comp *
   Pulse_Syntax_Base.ctag * (unit, unit) st_comp_typing 
+  | T_Unreachable of Pulse_Typing_Env.env * Pulse_Syntax_Base.st_comp *
+  Pulse_Syntax_Base.ctag * (unit, unit) st_comp_typing * unit 
   | T_WithInv of Pulse_Typing_Env.env * Pulse_Syntax_Base.term *
   Pulse_Syntax_Base.vprop * unit * unit * Pulse_Syntax_Base.st_term *
   Pulse_Syntax_Base.comp_st * (unit, unit, unit) st_typing 
@@ -1183,6 +1185,8 @@ let uu___is_T_Rewrite uu___2 uu___1 uu___ uu___3 =
   match uu___3 with | T_Rewrite _ -> true | _ -> false
 let uu___is_T_Admit uu___2 uu___1 uu___ uu___3 =
   match uu___3 with | T_Admit _ -> true | _ -> false
+let uu___is_T_Unreachable uu___2 uu___1 uu___ uu___3 =
+  match uu___3 with | T_Unreachable _ -> true | _ -> false
 let uu___is_T_WithInv uu___2 uu___1 uu___ uu___3 =
   match uu___3 with | T_WithInv _ -> true | _ -> false
 let uu___is_PC_Elab uu___3 uu___2 uu___1 uu___ uu___4 =

--- a/src/ocaml/plugin/generated/Pulse_Typing_Metatheory_Base.ml
+++ b/src/ocaml/plugin/generated/Pulse_Typing_Metatheory_Base.ml
@@ -612,6 +612,11 @@ let rec (st_typing_weakening :
                     ((Pulse_Typing_Env.push_env
                         (Pulse_Typing_Env.push_env g g1) g'), s, c1,
                       (st_comp_typing_weakening g g' s d_s g1))
+              | Pulse_Typing.T_Unreachable (uu___, s, c1, d_s, tok) ->
+                  Pulse_Typing.T_Unreachable
+                    ((Pulse_Typing_Env.push_env
+                        (Pulse_Typing_Env.push_env g g1) g'), s, c1,
+                      (st_comp_typing_weakening g g' s d_s g1), ())
               | Pulse_Typing.T_WithInv
                   (uu___, uu___1, uu___2, p_typing, inv_typing, uu___3,
                    uu___4, body_typing)

--- a/src/syntax_extension/PulseSyntaxExtension.Desugar.fst
+++ b/src/syntax_extension/PulseSyntaxExtension.Desugar.fst
@@ -117,10 +117,12 @@ let admit_or_return (env:env_t) (s:S.term)
   : admit_or_return_t
   = let r = s.pos in
     let head, args = U.head_and_args_full s in
-    match head.n with
-    | S.Tm_fvar fv -> (
+    match head.n, args with
+    | S.Tm_fvar fv, [_] -> (
       if S.fv_eq_lid fv admit_lid
-      then STTerm (SW.tm_admit r) 
+      then STTerm (SW.tm_admit r)
+      else if S.fv_eq_lid fv unreachable_lid
+      then STTerm (SW.tm_unreachable r) 
       else Return s
     )
     | _ -> Return s

--- a/src/syntax_extension/PulseSyntaxExtension.Env.fst
+++ b/src/syntax_extension/PulseSyntaxExtension.Env.fst
@@ -27,6 +27,7 @@ let pulse_lib_core_lid l = Ident.lid_of_path (["Pulse"; "Lib"; "Core"]@[l]) r_
 let pulse_lib_ref_lid l = Ident.lid_of_path (["Pulse"; "Lib"; "Reference"]@[l]) r_
 let prims_exists_lid = Ident.lid_of_path ["Prims"; "l_Exists"] r_
 let prims_forall_lid = Ident.lid_of_path ["Prims"; "l_Forall"] r_
+let unreachable_lid = pulse_lib_core_lid "unreachable"
 let exists_lid = pulse_lib_core_lid "op_exists_Star"
 let star_lid = pulse_lib_core_lid "op_Star_Star"
 let emp_lid = pulse_lib_core_lid "emp"

--- a/src/syntax_extension/PulseSyntaxExtension.SyntaxWrapper.fsti
+++ b/src/syntax_extension/PulseSyntaxExtension.SyntaxWrapper.fsti
@@ -83,6 +83,7 @@ val tm_par (p1:term) (p2:term) (q1:term) (q2:term) (b1:st_term) (b2:st_term) (_:
 val tm_rewrite (p1:term) (p2:term) (_:range) : st_term
 val tm_rename (pairs:list (term & term)) (_:range) : st_term
 val tm_admit (_:range) : st_term
+val tm_unreachable (_:range) : st_term
 val tm_proof_hint_with_binders (_:hint_type) (_:list binder) (body:st_term) (_:range) : st_term
 val tm_with_inv (iname:term) (body:st_term) (returns_:option term) (_:range) : st_term
 val close_binders (bs:list binder) (xs:list var) : list binder


### PR DESCRIPTION
You can now write `unreachable ()` to prove `False` in the current context and introduce a computation at any type `stt a p q` (or ghost, or atomic).