### PR TITLE
Eagerly unfold exists and pure from the context at the top of the checker

### DIFF
--- a/lib/steel/pulse/Pulse.Checker.Prover.fst
+++ b/lib/steel/pulse/Pulse.Checker.Prover.fst
@@ -23,6 +23,17 @@ module IntroPure = Pulse.Checker.Prover.IntroPure
 
 let coerce_eq (#a #b:Type) (x:a) (_:squash (a == b)) : y:b{y == x} = x
 
+let elim_exists_and_pure (#g:env) (#ctxt:vprop)
+  (ctxt_typing:tot_typing g ctxt tm_vprop)
+  : T.Tac (g':env { env_extends g' g } &
+           ctxt':term &
+           tot_typing g' ctxt' tm_vprop &
+           continuation_elaborator g ctxt g' ctxt') =
+  
+  let (| g1, ctxt1, d1, k1 |) = ElimExists.elim_exists ctxt_typing in
+  let (| g2, ctxt2, d2, k2 |) = ElimPure.elim_pure d1 in
+  (| g2, ctxt2, d2, k_elab_trans k1 k2 |)
+
 let unsolved_equiv_pst (#preamble:_) (pst:prover_state preamble) (unsolved':list vprop)
   (d:vprop_equiv (push_env pst.pg pst.uvs) (list_as_vprop pst.unsolved) (list_as_vprop unsolved'))
   : prover_state preamble =

--- a/lib/steel/pulse/Pulse.Checker.Prover.fsti
+++ b/lib/steel/pulse/Pulse.Checker.Prover.fsti
@@ -11,6 +11,13 @@ module PS = Pulse.Checker.Prover.Substs
 include Pulse.Checker.Prover.Base
 include Pulse.Checker.Prover.Util
 
+val elim_exists_and_pure (#g:env) (#ctxt:vprop)
+  (ctxt_typing:tot_typing g ctxt tm_vprop)
+  : T.Tac (g':env { env_extends g' g } &
+           ctxt':term &
+           tot_typing g' ctxt' tm_vprop &
+           continuation_elaborator g ctxt g' ctxt')
+
 val prove
   (#g:env) (#ctxt:vprop) (ctxt_typing:tot_typing g ctxt tm_vprop)
   (uvs:env { disjoint g uvs })

--- a/lib/steel/pulse/Pulse.Checker.fst
+++ b/lib/steel/pulse/Pulse.Checker.fst
@@ -32,8 +32,6 @@ module Par = Pulse.Checker.Par
 module Admit = Pulse.Checker.Admit
 module Return = Pulse.Checker.Return
 module Rewrite = Pulse.Checker.Rewrite
-module ElimPure = Pulse.Checker.Prover.ElimPure
-module ElimExists = Pulse.Checker.Prover.ElimExists
 module WithInv = Pulse.Checker.WithInv
 
 let terms_to_string (t:list term)
@@ -141,7 +139,7 @@ let rec check
               (Pulse.Syntax.Printer.tag_of_st_term t));
 
   let (| g, pre, pre_typing, k_elim_pure |) =
-    Pulse.Checker.Prover.ElimPure.elim_pure pre0_typing in
+    Pulse.Checker.Prover.elim_exists_and_pure pre0_typing in
 
   let r : checker_result_t g pre post_hint =
     let g = push_context (P.tag_of_st_term t) t.range g in

--- a/share/steel/examples/pulse/bug-reports/Bug137.fst
+++ b/share/steel/examples/pulse/bug-reports/Bug137.fst
@@ -1,0 +1,23 @@
+module Bug137
+
+open Pulse.Lib.Pervasives
+
+```pulse
+fn test_elim_pure (x:option bool)
+requires exists* q. q ** pure (Some? x)
+ensures exists* q. q ** pure (Some? x)
+{
+    let v = Some?.v x;
+    ()
+}
+```
+
+```pulse
+fn test_elim_pure2 (x:option bool)
+requires exists* p q. p ** (exists* r. r ** pure (Some? x)) ** q
+ensures exists* p q. p ** q ** (exists* r. r ** pure (Some? x))
+{
+    let v = Some?.v x;
+    ()
+}
+```

--- a/share/steel/examples/pulse/lib/Pulse.Lib.ArraySwap.fst
+++ b/share/steel/examples/pulse/lib/Pulse.Lib.ArraySwap.fst
@@ -163,19 +163,15 @@ let seq_slice_full
   (s == Seq.slice s 0 (Seq.length s))
 = assert (s `Seq.equal` Seq.slice s 0 (Seq.length s))
 
-```pulse
-ghost
-fn manurewrite
-  (p: vprop)
-  (q: vprop)
-requires p ** pure (p == q)
-ensures q
-{
-  rewrite p as q
-}
-```
+let intro_array_swap_post1 (lb rb mb:SZ.t) (mb':SZ.t)
+  : Lemma (requires SZ.v lb <= SZ.v mb /\ SZ.v mb <= SZ.v rb /\ lb == mb /\ mb' == rb)
+          (ensures array_swap_post lb rb mb mb') = ()
 
-#push-options "--z3rlimit_factor 4"
+let intro_array_swap_post2 (lb rb mb:SZ.t) (mb':SZ.t)
+  : Lemma (requires SZ.v lb <= SZ.v mb /\ SZ.v mb <= SZ.v rb /\ mb == rb /\ mb' == lb)
+          (ensures array_swap_post lb rb mb mb') = ()
+
+#push-options "--fuel 0 --ifuel 0 --split_queries no"
 inline_for_extraction noextract [@@noextract_to "krml"]
 ```pulse
 fn array_swap0
@@ -207,25 +203,27 @@ ensures (
     with s1' . assert (A.pts_to_range a (SZ.v rb) (SZ.v rb) s1');
     let prf1 : squash (s1' `Seq.equal` s1) = ();
     let prf2 : squash (s2' `Seq.equal` s2) = ();
-    let prf_mb : squash (SZ.v mb == SZ.v lb /\ SZ.v lb + (SZ.v rb - SZ.v mb) == SZ.v rb) = ();
     rewrite (A.pts_to_range a (SZ.v lb) (SZ.v rb) s2')
-      as (A.pts_to_range a (SZ.v lb) (SZ.v rb) s2);
+         as (A.pts_to_range a (SZ.v lb) (SZ.v rb) s2);
     rewrite (A.pts_to_range a (SZ.v rb) (SZ.v rb) s1')
-      as (A.pts_to_range a (SZ.v rb) (SZ.v rb) s1);
+         as (A.pts_to_range a (SZ.v rb) (SZ.v rb) s1);
+    let _p : squash (array_swap_post lb rb mb rb) = intro_array_swap_post1 lb rb mb rb;
     rb
   } else if (mb = rb) {
     let prf_s2 : squash (s2 `Seq.equal` Seq.empty) = ();
     let prf_s : squash (s1 `Seq.equal` s) = ();
     A.pts_to_range_split a (SZ.v lb) (SZ.v lb) (SZ.v rb);
     with s2' . assert (A.pts_to_range a (SZ.v lb) (SZ.v lb) s2');
+    assert (A.pts_to_range a (SZ.v lb) (SZ.v lb) s2');
     with s1' . assert (A.pts_to_range a (SZ.v lb) (SZ.v rb) s1');
+    assert (A.pts_to_range a (SZ.v lb) (SZ.v rb) s1');
     let prf1 : squash (s1' `Seq.equal` s1) = ();
     let prf2 : squash (s2' `Seq.equal` s2) = ();
-    let prf_mb : squash (SZ.v mb == SZ.v rb /\ SZ.v lb + (SZ.v rb - SZ.v mb) == SZ.v lb) = ();
     rewrite (A.pts_to_range a (SZ.v lb) (SZ.v lb) s2')
-      as (A.pts_to_range a (SZ.v lb) (SZ.v lb) s2);
+         as (A.pts_to_range a (SZ.v lb) (SZ.v lb) s2);
     rewrite (A.pts_to_range a (SZ.v lb) (SZ.v rb) s1')
-      as (A.pts_to_range a (SZ.v lb) (SZ.v rb) s1);
+         as (A.pts_to_range a (SZ.v lb) (SZ.v rb) s1);
+    let prf_mb : squash (array_swap_post lb rb mb lb) = intro_array_swap_post2 lb rb mb lb;
     lb
   } else {
     Seq.lemma_split s (SZ.v mb - SZ.v lb);

--- a/share/steel/examples/pulse/lib/Pulse.Lib.LinkedList.fst
+++ b/share/steel/examples/pulse/lib/Pulse.Lib.LinkedList.fst
@@ -121,7 +121,6 @@ fn cases_of_is_list (#t:Type) (x:llist t) (l:list t)
         Cons head tl -> { 
             rewrite (is_list x l) as (is_list x (head::tl));
             elim_is_list_cons x head tl;
-            assert pure (Some? x); //surprising that this is needed
             let v = Some?.v x;
             with tail. assert (is_list #t tail tl);
             with w. assert (pts_to w (mk_node head tail));
@@ -431,7 +430,6 @@ ensures
     }
     Some vtl -> {
       is_list_cases_some node.tail vtl;
-      assert (pure False); //adding this somehow seems necessary; weird
       unreachable ();
     }
   }

--- a/src/ocaml/plugin/generated/Pulse_Checker.ml
+++ b/src/ocaml/plugin/generated/Pulse_Checker.ml
@@ -7,12 +7,12 @@ let (terms_to_string :
     FStar_Tactics_Effect.tac_bind
       (FStar_Sealed.seal
          (Obj.magic
-            (FStar_Range.mk_range "Pulse.Checker.fst" (Prims.of_int (41))
-               (Prims.of_int (23)) (Prims.of_int (41)) (Prims.of_int (68)))))
+            (FStar_Range.mk_range "Pulse.Checker.fst" (Prims.of_int (39))
+               (Prims.of_int (23)) (Prims.of_int (39)) (Prims.of_int (68)))))
       (FStar_Sealed.seal
          (Obj.magic
-            (FStar_Range.mk_range "Pulse.Checker.fst" (Prims.of_int (41))
-               (Prims.of_int (4)) (Prims.of_int (41)) (Prims.of_int (68)))))
+            (FStar_Range.mk_range "Pulse.Checker.fst" (Prims.of_int (39))
+               (Prims.of_int (4)) (Prims.of_int (39)) (Prims.of_int (68)))))
       (Obj.magic
          (FStar_Tactics_Util.map Pulse_Syntax_Printer.term_to_string t))
       (fun uu___ ->
@@ -53,17 +53,17 @@ let rec (gen_names_for_unknowns :
                                   (Obj.magic
                                      (FStar_Range.mk_range
                                         "Pulse.Checker.fst"
-                                        (Prims.of_int (58))
+                                        (Prims.of_int (56))
                                         (Prims.of_int (10))
-                                        (Prims.of_int (64))
+                                        (Prims.of_int (62))
                                         (Prims.of_int (27)))))
                                (FStar_Sealed.seal
                                   (Obj.magic
                                      (FStar_Range.mk_range
                                         "Pulse.Checker.fst"
-                                        (Prims.of_int (56))
+                                        (Prims.of_int (54))
                                         (Prims.of_int (31))
-                                        (Prims.of_int (72))
+                                        (Prims.of_int (70))
                                         (Prims.of_int (39)))))
                                (FStar_Tactics_Effect.lift_div_tac
                                   (fun uu___1 ->
@@ -94,17 +94,17 @@ let rec (gen_names_for_unknowns :
                                                  (Obj.magic
                                                     (FStar_Range.mk_range
                                                        "Pulse.Checker.fst"
-                                                       (Prims.of_int (65))
+                                                       (Prims.of_int (63))
                                                        (Prims.of_int (23))
-                                                       (Prims.of_int (65))
+                                                       (Prims.of_int (63))
                                                        (Prims.of_int (42)))))
                                               (FStar_Sealed.seal
                                                  (Obj.magic
                                                     (FStar_Range.mk_range
                                                        "Pulse.Checker.fst"
-                                                       (Prims.of_int (65))
+                                                       (Prims.of_int (63))
                                                        (Prims.of_int (45))
-                                                       (Prims.of_int (72))
+                                                       (Prims.of_int (70))
                                                        (Prims.of_int (39)))))
                                               (FStar_Tactics_Effect.lift_div_tac
                                                  (fun uu___2 ->
@@ -118,17 +118,17 @@ let rec (gen_names_for_unknowns :
                                                             (Obj.magic
                                                                (FStar_Range.mk_range
                                                                   "Pulse.Checker.fst"
-                                                                  (Prims.of_int (66))
+                                                                  (Prims.of_int (64))
                                                                   (Prims.of_int (31))
-                                                                  (Prims.of_int (66))
+                                                                  (Prims.of_int (64))
                                                                   (Prims.of_int (60)))))
                                                          (FStar_Sealed.seal
                                                             (Obj.magic
                                                                (FStar_Range.mk_range
                                                                   "Pulse.Checker.fst"
-                                                                  (Prims.of_int (65))
+                                                                  (Prims.of_int (63))
                                                                   (Prims.of_int (45))
-                                                                  (Prims.of_int (72))
+                                                                  (Prims.of_int (70))
                                                                   (Prims.of_int (39)))))
                                                          (Obj.magic
                                                             (gen_names_for_unknowns
@@ -177,12 +177,12 @@ let (instantiate_unknown_witnesses :
       FStar_Tactics_Effect.tac_bind
         (FStar_Sealed.seal
            (Obj.magic
-              (FStar_Range.mk_range "Pulse.Checker.fst" (Prims.of_int (78))
-                 (Prims.of_int (43)) (Prims.of_int (78)) (Prims.of_int (49)))))
+              (FStar_Range.mk_range "Pulse.Checker.fst" (Prims.of_int (76))
+                 (Prims.of_int (43)) (Prims.of_int (76)) (Prims.of_int (49)))))
         (FStar_Sealed.seal
            (Obj.magic
-              (FStar_Range.mk_range "Pulse.Checker.fst" (Prims.of_int (76))
-                 (Prims.of_int (28)) (Prims.of_int (102)) (Prims.of_int (10)))))
+              (FStar_Range.mk_range "Pulse.Checker.fst" (Prims.of_int (74))
+                 (Prims.of_int (28)) (Prims.of_int (100)) (Prims.of_int (10)))))
         (FStar_Tactics_Effect.lift_div_tac
            (fun uu___ -> t.Pulse_Syntax_Base.term1))
         (fun uu___ ->
@@ -197,13 +197,13 @@ let (instantiate_unknown_witnesses :
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Checker.fst"
-                                (Prims.of_int (80)) (Prims.of_int (36))
-                                (Prims.of_int (80)) (Prims.of_int (65)))))
+                                (Prims.of_int (78)) (Prims.of_int (36))
+                                (Prims.of_int (78)) (Prims.of_int (65)))))
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Checker.fst"
-                                (Prims.of_int (78)) (Prims.of_int (52))
-                                (Prims.of_int (102)) (Prims.of_int (10)))))
+                                (Prims.of_int (76)) (Prims.of_int (52))
+                                (Prims.of_int (100)) (Prims.of_int (10)))))
                        (Obj.magic (gen_names_for_unknowns g p ws))
                        (fun uu___1 ->
                           FStar_Tactics_Effect.lift_div_tac
@@ -355,17 +355,17 @@ let rec (transform_to_unary_intro_exists :
                                   (Obj.magic
                                      (FStar_Range.mk_range
                                         "Pulse.Checker.fst"
-                                        (Prims.of_int (116))
+                                        (Prims.of_int (114))
                                         (Prims.of_int (17))
-                                        (Prims.of_int (116))
+                                        (Prims.of_int (114))
                                         (Prims.of_int (43)))))
                                (FStar_Sealed.seal
                                   (Obj.magic
                                      (FStar_Range.mk_range
                                         "Pulse.Checker.fst"
-                                        (Prims.of_int (116))
+                                        (Prims.of_int (114))
                                         (Prims.of_int (46))
-                                        (Prims.of_int (123))
+                                        (Prims.of_int (121))
                                         (Prims.of_int (34)))))
                                (FStar_Tactics_Effect.lift_div_tac
                                   (fun uu___ ->
@@ -380,17 +380,17 @@ let rec (transform_to_unary_intro_exists :
                                              (Obj.magic
                                                 (FStar_Range.mk_range
                                                    "Pulse.Checker.fst"
-                                                   (Prims.of_int (117))
+                                                   (Prims.of_int (115))
                                                    (Prims.of_int (15))
-                                                   (Prims.of_int (117))
+                                                   (Prims.of_int (115))
                                                    (Prims.of_int (56)))))
                                           (FStar_Sealed.seal
                                              (Obj.magic
                                                 (FStar_Range.mk_range
                                                    "Pulse.Checker.fst"
-                                                   (Prims.of_int (120))
+                                                   (Prims.of_int (118))
                                                    (Prims.of_int (6))
-                                                   (Prims.of_int (123))
+                                                   (Prims.of_int (121))
                                                    (Prims.of_int (34)))))
                                           (Obj.magic
                                              (transform_to_unary_intro_exists
@@ -438,13 +438,13 @@ let rec (check : Pulse_Checker_Base.check_t) =
                 (FStar_Sealed.seal
                    (Obj.magic
                       (FStar_Range.mk_range "Pulse.Checker.fst"
-                         (Prims.of_int (136)) (Prims.of_int (2))
-                         (Prims.of_int (141)) (Prims.of_int (54)))))
+                         (Prims.of_int (134)) (Prims.of_int (2))
+                         (Prims.of_int (139)) (Prims.of_int (54)))))
                 (FStar_Sealed.seal
                    (Obj.magic
                       (FStar_Range.mk_range "Pulse.Checker.fst"
-                         (Prims.of_int (141)) (Prims.of_int (55))
-                         (Prims.of_int (268)) (Prims.of_int (50)))))
+                         (Prims.of_int (139)) (Prims.of_int (55))
+                         (Prims.of_int (266)) (Prims.of_int (50)))))
                 (if
                    Pulse_RuntimeUtils.debug_at_level
                      (Pulse_Typing_Env.fstar_env g0) "pulse.checker"
@@ -455,30 +455,30 @@ let rec (check : Pulse_Checker_Base.check_t) =
                            (FStar_Sealed.seal
                               (Obj.magic
                                  (FStar_Range.mk_range "Pulse.Checker.fst"
-                                    (Prims.of_int (137)) (Prims.of_int (12))
-                                    (Prims.of_int (141)) (Prims.of_int (54)))))
+                                    (Prims.of_int (135)) (Prims.of_int (12))
+                                    (Prims.of_int (139)) (Prims.of_int (54)))))
                            (FStar_Sealed.seal
                               (Obj.magic
                                  (FStar_Range.mk_range "Pulse.Checker.fst"
-                                    (Prims.of_int (137)) (Prims.of_int (4))
-                                    (Prims.of_int (141)) (Prims.of_int (54)))))
+                                    (Prims.of_int (135)) (Prims.of_int (4))
+                                    (Prims.of_int (139)) (Prims.of_int (54)))))
                            (Obj.magic
                               (FStar_Tactics_Effect.tac_bind
                                  (FStar_Sealed.seal
                                     (Obj.magic
                                        (FStar_Range.mk_range
                                           "Pulse.Checker.fst"
-                                          (Prims.of_int (137))
+                                          (Prims.of_int (135))
                                           (Prims.of_int (12))
-                                          (Prims.of_int (141))
+                                          (Prims.of_int (139))
                                           (Prims.of_int (54)))))
                                  (FStar_Sealed.seal
                                     (Obj.magic
                                        (FStar_Range.mk_range
                                           "Pulse.Checker.fst"
-                                          (Prims.of_int (137))
+                                          (Prims.of_int (135))
                                           (Prims.of_int (12))
-                                          (Prims.of_int (141))
+                                          (Prims.of_int (139))
                                           (Prims.of_int (54)))))
                                  (Obj.magic
                                     (FStar_Tactics_Effect.tac_bind
@@ -486,17 +486,17 @@ let rec (check : Pulse_Checker_Base.check_t) =
                                           (Obj.magic
                                              (FStar_Range.mk_range
                                                 "Pulse.Checker.fst"
-                                                (Prims.of_int (140))
+                                                (Prims.of_int (138))
                                                 (Prims.of_int (14))
-                                                (Prims.of_int (140))
+                                                (Prims.of_int (138))
                                                 (Prims.of_int (56)))))
                                        (FStar_Sealed.seal
                                           (Obj.magic
                                              (FStar_Range.mk_range
                                                 "Pulse.Checker.fst"
-                                                (Prims.of_int (137))
+                                                (Prims.of_int (135))
                                                 (Prims.of_int (12))
-                                                (Prims.of_int (141))
+                                                (Prims.of_int (139))
                                                 (Prims.of_int (54)))))
                                        (Obj.magic
                                           (Pulse_Syntax_Printer.st_term_to_string
@@ -509,17 +509,17 @@ let rec (check : Pulse_Checker_Base.check_t) =
                                                      (Obj.magic
                                                         (FStar_Range.mk_range
                                                            "Pulse.Checker.fst"
-                                                           (Prims.of_int (137))
+                                                           (Prims.of_int (135))
                                                            (Prims.of_int (12))
-                                                           (Prims.of_int (141))
+                                                           (Prims.of_int (139))
                                                            (Prims.of_int (54)))))
                                                   (FStar_Sealed.seal
                                                      (Obj.magic
                                                         (FStar_Range.mk_range
                                                            "Pulse.Checker.fst"
-                                                           (Prims.of_int (137))
+                                                           (Prims.of_int (135))
                                                            (Prims.of_int (12))
-                                                           (Prims.of_int (141))
+                                                           (Prims.of_int (139))
                                                            (Prims.of_int (54)))))
                                                   (Obj.magic
                                                      (FStar_Tactics_Effect.tac_bind
@@ -527,17 +527,17 @@ let rec (check : Pulse_Checker_Base.check_t) =
                                                            (Obj.magic
                                                               (FStar_Range.mk_range
                                                                  "Pulse.Checker.fst"
-                                                                 (Prims.of_int (139))
+                                                                 (Prims.of_int (137))
                                                                  (Prims.of_int (14))
-                                                                 (Prims.of_int (139))
+                                                                 (Prims.of_int (137))
                                                                  (Prims.of_int (56)))))
                                                         (FStar_Sealed.seal
                                                            (Obj.magic
                                                               (FStar_Range.mk_range
                                                                  "Pulse.Checker.fst"
-                                                                 (Prims.of_int (137))
+                                                                 (Prims.of_int (135))
                                                                  (Prims.of_int (12))
-                                                                 (Prims.of_int (141))
+                                                                 (Prims.of_int (139))
                                                                  (Prims.of_int (54)))))
                                                         (Obj.magic
                                                            (Pulse_Syntax_Printer.term_to_string
@@ -550,17 +550,17 @@ let rec (check : Pulse_Checker_Base.check_t) =
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (137))
+                                                                    (Prims.of_int (135))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (141))
+                                                                    (Prims.of_int (139))
                                                                     (Prims.of_int (54)))))
                                                                    (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (137))
+                                                                    (Prims.of_int (135))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (141))
+                                                                    (Prims.of_int (139))
                                                                     (Prims.of_int (54)))))
                                                                    (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -568,9 +568,9 @@ let rec (check : Pulse_Checker_Base.check_t) =
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (138))
+                                                                    (Prims.of_int (136))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (138))
+                                                                    (Prims.of_int (136))
                                                                     (Prims.of_int (41)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -642,15 +642,15 @@ let rec (check : Pulse_Checker_Base.check_t) =
                            (FStar_Sealed.seal
                               (Obj.magic
                                  (FStar_Range.mk_range "Pulse.Checker.fst"
-                                    (Prims.of_int (144)) (Prims.of_int (4))
-                                    (Prims.of_int (144)) (Prims.of_int (55)))))
+                                    (Prims.of_int (142)) (Prims.of_int (4))
+                                    (Prims.of_int (142)) (Prims.of_int (57)))))
                            (FStar_Sealed.seal
                               (Obj.magic
                                  (FStar_Range.mk_range "Pulse.Checker.fst"
-                                    (Prims.of_int (141)) (Prims.of_int (55))
-                                    (Prims.of_int (268)) (Prims.of_int (50)))))
+                                    (Prims.of_int (139)) (Prims.of_int (55))
+                                    (Prims.of_int (266)) (Prims.of_int (50)))))
                            (Obj.magic
-                              (Pulse_Checker_Prover_ElimPure.elim_pure g0
+                              (Pulse_Checker_Prover.elim_exists_and_pure g0
                                  pre0 ()))
                            (fun uu___1 ->
                               (fun uu___1 ->
@@ -663,17 +663,17 @@ let rec (check : Pulse_Checker_Base.check_t) =
                                              (Obj.magic
                                                 (FStar_Range.mk_range
                                                    "Pulse.Checker.fst"
-                                                   (Prims.of_int (146))
+                                                   (Prims.of_int (144))
                                                    (Prims.of_int (44))
-                                                   (Prims.of_int (264))
+                                                   (Prims.of_int (262))
                                                    (Prims.of_int (48)))))
                                           (FStar_Sealed.seal
                                              (Obj.magic
                                                 (FStar_Range.mk_range
                                                    "Pulse.Checker.fst"
-                                                   (Prims.of_int (265))
+                                                   (Prims.of_int (263))
                                                    (Prims.of_int (4))
-                                                   (Prims.of_int (268))
+                                                   (Prims.of_int (266))
                                                    (Prims.of_int (50)))))
                                           (Obj.magic
                                              (FStar_Tactics_Effect.tac_bind
@@ -681,17 +681,17 @@ let rec (check : Pulse_Checker_Base.check_t) =
                                                    (Obj.magic
                                                       (FStar_Range.mk_range
                                                          "Pulse.Checker.fst"
-                                                         (Prims.of_int (147))
+                                                         (Prims.of_int (145))
                                                          (Prims.of_int (12))
-                                                         (Prims.of_int (147))
+                                                         (Prims.of_int (145))
                                                          (Prims.of_int (55)))))
                                                 (FStar_Sealed.seal
                                                    (Obj.magic
                                                       (FStar_Range.mk_range
                                                          "Pulse.Checker.fst"
-                                                         (Prims.of_int (148))
+                                                         (Prims.of_int (146))
                                                          (Prims.of_int (4))
-                                                         (Prims.of_int (264))
+                                                         (Prims.of_int (262))
                                                          (Prims.of_int (48)))))
                                                 (FStar_Tactics_Effect.lift_div_tac
                                                    (fun uu___2 ->
@@ -751,17 +751,17 @@ let rec (check : Pulse_Checker_Base.check_t) =
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (168))
+                                                                    (Prims.of_int (166))
                                                                     (Prims.of_int (13))
-                                                                    (Prims.of_int (168))
+                                                                    (Prims.of_int (166))
                                                                     (Prims.of_int (46)))))
                                                                   (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (168))
+                                                                    (Prims.of_int (166))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (178))
+                                                                    (Prims.of_int (176))
                                                                     (Prims.of_int (57)))))
                                                                   (Obj.magic
                                                                     (instantiate_unknown_witnesses
@@ -812,17 +812,17 @@ let rec (check : Pulse_Checker_Base.check_t) =
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (177))
+                                                                    (Prims.of_int (175))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (177))
+                                                                    (Prims.of_int (175))
                                                                     (Prims.of_int (64)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (178))
+                                                                    (Prims.of_int (176))
                                                                     (Prims.of_int (11))
-                                                                    (Prims.of_int (178))
+                                                                    (Prims.of_int (176))
                                                                     (Prims.of_int (56)))))
                                                                     (Obj.magic
                                                                     (transform_to_unary_intro_exists
@@ -876,17 +876,17 @@ let rec (check : Pulse_Checker_Base.check_t) =
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (187))
+                                                                    (Prims.of_int (185))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (203))
+                                                                    (Prims.of_int (201))
                                                                     (Prims.of_int (97)))))
                                                                   (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (204))
+                                                                    (Prims.of_int (202))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (207))
+                                                                    (Prims.of_int (205))
                                                                     (Prims.of_int (29)))))
                                                                   (match 
                                                                     (post_if,
@@ -926,17 +926,17 @@ let rec (check : Pulse_Checker_Base.check_t) =
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (193))
+                                                                    (Prims.of_int (191))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (198))
+                                                                    (Prims.of_int (196))
                                                                     (Prims.of_int (37)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (192))
+                                                                    (Prims.of_int (190))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (198))
+                                                                    (Prims.of_int (196))
                                                                     (Prims.of_int (37)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -944,17 +944,17 @@ let rec (check : Pulse_Checker_Base.check_t) =
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (198))
+                                                                    (Prims.of_int (196))
                                                                     (Prims.of_int (16))
-                                                                    (Prims.of_int (198))
+                                                                    (Prims.of_int (196))
                                                                     (Prims.of_int (36)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (193))
+                                                                    (Prims.of_int (191))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (198))
+                                                                    (Prims.of_int (196))
                                                                     (Prims.of_int (37)))))
                                                                     (Obj.magic
                                                                     (Pulse_Syntax_Printer.term_to_string
@@ -969,17 +969,17 @@ let rec (check : Pulse_Checker_Base.check_t) =
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (193))
+                                                                    (Prims.of_int (191))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (198))
+                                                                    (Prims.of_int (196))
                                                                     (Prims.of_int (37)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (193))
+                                                                    (Prims.of_int (191))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (198))
+                                                                    (Prims.of_int (196))
                                                                     (Prims.of_int (37)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -987,9 +987,9 @@ let rec (check : Pulse_Checker_Base.check_t) =
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (197))
+                                                                    (Prims.of_int (195))
                                                                     (Prims.of_int (16))
-                                                                    (Prims.of_int (197))
+                                                                    (Prims.of_int (195))
                                                                     (Prims.of_int (58)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -1056,17 +1056,17 @@ let rec (check : Pulse_Checker_Base.check_t) =
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (206))
+                                                                    (Prims.of_int (204))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (206))
+                                                                    (Prims.of_int (204))
                                                                     (Prims.of_int (63)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (204))
+                                                                    (Prims.of_int (202))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (207))
+                                                                    (Prims.of_int (205))
                                                                     (Prims.of_int (29)))))
                                                                     (Obj.magic
                                                                     (Pulse_Checker_If.check
@@ -1118,17 +1118,17 @@ let rec (check : Pulse_Checker_Base.check_t) =
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (215))
+                                                                    (Prims.of_int (213))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (231))
+                                                                    (Prims.of_int (229))
                                                                     (Prims.of_int (97)))))
                                                                   (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (232))
+                                                                    (Prims.of_int (230))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (235))
+                                                                    (Prims.of_int (233))
                                                                     (Prims.of_int (30)))))
                                                                   (match 
                                                                     (post_match,
@@ -1168,17 +1168,17 @@ let rec (check : Pulse_Checker_Base.check_t) =
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (221))
+                                                                    (Prims.of_int (219))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (226))
+                                                                    (Prims.of_int (224))
                                                                     (Prims.of_int (37)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (220))
+                                                                    (Prims.of_int (218))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (226))
+                                                                    (Prims.of_int (224))
                                                                     (Prims.of_int (37)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1186,17 +1186,17 @@ let rec (check : Pulse_Checker_Base.check_t) =
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (226))
+                                                                    (Prims.of_int (224))
                                                                     (Prims.of_int (16))
-                                                                    (Prims.of_int (226))
+                                                                    (Prims.of_int (224))
                                                                     (Prims.of_int (36)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (221))
+                                                                    (Prims.of_int (219))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (226))
+                                                                    (Prims.of_int (224))
                                                                     (Prims.of_int (37)))))
                                                                     (Obj.magic
                                                                     (Pulse_Syntax_Printer.term_to_string
@@ -1211,17 +1211,17 @@ let rec (check : Pulse_Checker_Base.check_t) =
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (221))
+                                                                    (Prims.of_int (219))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (226))
+                                                                    (Prims.of_int (224))
                                                                     (Prims.of_int (37)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (221))
+                                                                    (Prims.of_int (219))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (226))
+                                                                    (Prims.of_int (224))
                                                                     (Prims.of_int (37)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1229,9 +1229,9 @@ let rec (check : Pulse_Checker_Base.check_t) =
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (225))
+                                                                    (Prims.of_int (223))
                                                                     (Prims.of_int (16))
-                                                                    (Prims.of_int (225))
+                                                                    (Prims.of_int (223))
                                                                     (Prims.of_int (58)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -1298,17 +1298,17 @@ let rec (check : Pulse_Checker_Base.check_t) =
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (234))
+                                                                    (Prims.of_int (232))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (234))
+                                                                    (Prims.of_int (232))
                                                                     (Prims.of_int (65)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (232))
+                                                                    (Prims.of_int (230))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (235))
+                                                                    (Prims.of_int (233))
                                                                     (Prims.of_int (30)))))
                                                                     (Obj.magic
                                                                     (Pulse_Checker_Match.check

--- a/src/ocaml/plugin/generated/Pulse_Checker_Prover.ml
+++ b/src/ocaml/plugin/generated/Pulse_Checker_Prover.ml
@@ -1,6 +1,63 @@
 open Prims
 let coerce_eq : 'a 'b . 'a -> unit -> 'b =
   fun uu___1 -> fun uu___ -> (fun x -> fun uu___ -> Obj.magic x) uu___1 uu___
+let (elim_exists_and_pure :
+  Pulse_Typing_Env.env ->
+    Pulse_Syntax_Base.vprop ->
+      unit ->
+        ((Pulse_Typing_Env.env, Pulse_Syntax_Base.term, unit,
+           (unit, unit, unit, unit)
+             Pulse_Checker_Base.continuation_elaborator)
+           FStar_Pervasives.dtuple4,
+          unit) FStar_Tactics_Effect.tac_repr)
+  =
+  fun g ->
+    fun ctxt ->
+      fun ctxt_typing ->
+        FStar_Tactics_Effect.tac_bind
+          (FStar_Sealed.seal
+             (Obj.magic
+                (FStar_Range.mk_range "Pulse.Checker.Prover.fst"
+                   (Prims.of_int (33)) (Prims.of_int (32))
+                   (Prims.of_int (33)) (Prims.of_int (66)))))
+          (FStar_Sealed.seal
+             (Obj.magic
+                (FStar_Range.mk_range "Pulse.Checker.Prover.fst"
+                   (Prims.of_int (31)) (Prims.of_int (53))
+                   (Prims.of_int (35)) (Prims.of_int (41)))))
+          (Obj.magic (Pulse_Checker_Prover_ElimExists.elim_exists g ctxt ()))
+          (fun uu___ ->
+             (fun uu___ ->
+                match uu___ with
+                | FStar_Pervasives.Mkdtuple4 (g1, ctxt1, d1, k1) ->
+                    Obj.magic
+                      (FStar_Tactics_Effect.tac_bind
+                         (FStar_Sealed.seal
+                            (Obj.magic
+                               (FStar_Range.mk_range
+                                  "Pulse.Checker.Prover.fst"
+                                  (Prims.of_int (34)) (Prims.of_int (32))
+                                  (Prims.of_int (34)) (Prims.of_int (53)))))
+                         (FStar_Sealed.seal
+                            (Obj.magic
+                               (FStar_Range.mk_range
+                                  "Pulse.Checker.Prover.fst"
+                                  (Prims.of_int (33)) (Prims.of_int (69))
+                                  (Prims.of_int (35)) (Prims.of_int (41)))))
+                         (Obj.magic
+                            (Pulse_Checker_Prover_ElimPure.elim_pure g1 ctxt1
+                               ()))
+                         (fun uu___1 ->
+                            FStar_Tactics_Effect.lift_div_tac
+                              (fun uu___2 ->
+                                 match uu___1 with
+                                 | FStar_Pervasives.Mkdtuple4
+                                     (g2, ctxt2, d2, k2) ->
+                                     FStar_Pervasives.Mkdtuple4
+                                       (g2, ctxt2, (),
+                                         (Pulse_Checker_Base.k_elab_trans g
+                                            g1 g2 ctxt ctxt1 ctxt2 k1 k2))))))
+               uu___)
 let (unsolved_equiv_pst :
   Pulse_Checker_Prover_Base.preamble ->
     unit Pulse_Checker_Prover_Base.prover_state ->
@@ -171,17 +228,17 @@ let rec (match_q :
                                              (Obj.magic
                                                 (FStar_Range.mk_range
                                                    "Pulse.Checker.Prover.fst"
-                                                   (Prims.of_int (79))
+                                                   (Prims.of_int (90))
                                                    (Prims.of_int (12))
-                                                   (Prims.of_int (79))
+                                                   (Prims.of_int (90))
                                                    (Prims.of_int (35)))))
                                           (FStar_Sealed.seal
                                              (Obj.magic
                                                 (FStar_Range.mk_range
                                                    "Pulse.Checker.Prover.fst"
-                                                   (Prims.of_int (79))
+                                                   (Prims.of_int (90))
                                                    (Prims.of_int (38))
-                                                   (Prims.of_int (88))
+                                                   (Prims.of_int (99))
                                                    (Prims.of_int (38)))))
                                           (FStar_Tactics_Effect.lift_div_tac
                                              (fun uu___3 ->
@@ -195,17 +252,17 @@ let rec (match_q :
                                                         (Obj.magic
                                                            (FStar_Range.mk_range
                                                               "Pulse.Checker.Prover.fst"
-                                                              (Prims.of_int (81))
+                                                              (Prims.of_int (92))
                                                               (Prims.of_int (6))
-                                                              (Prims.of_int (81))
+                                                              (Prims.of_int (92))
                                                               (Prims.of_int (69)))))
                                                      (FStar_Sealed.seal
                                                         (Obj.magic
                                                            (FStar_Range.mk_range
                                                               "Pulse.Checker.Prover.fst"
-                                                              (Prims.of_int (82))
+                                                              (Prims.of_int (93))
                                                               (Prims.of_int (4))
-                                                              (Prims.of_int (88))
+                                                              (Prims.of_int (99))
                                                               (Prims.of_int (38)))))
                                                      (Obj.magic
                                                         (Pulse_Checker_Prover_Match.match_step
@@ -236,17 +293,17 @@ let rec (match_q :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (86))
+                                                                    (Prims.of_int (97))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (87))
+                                                                    (Prims.of_int (98))
                                                                     (Prims.of_int (49)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (88))
+                                                                    (Prims.of_int (99))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (88))
+                                                                    (Prims.of_int (99))
                                                                     (Prims.of_int (38)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -299,13 +356,13 @@ let rec (prove_pures :
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Checker.Prover.fst"
-                                (Prims.of_int (97)) (Prims.of_int (18))
-                                (Prims.of_int (97)) (Prims.of_int (57)))))
+                                (Prims.of_int (108)) (Prims.of_int (18))
+                                (Prims.of_int (108)) (Prims.of_int (57)))))
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Checker.Prover.fst"
-                                (Prims.of_int (98)) (Prims.of_int (4))
-                                (Prims.of_int (110)) (Prims.of_int (12)))))
+                                (Prims.of_int (109)) (Prims.of_int (4))
+                                (Prims.of_int (121)) (Prims.of_int (12)))))
                        (Obj.magic
                           (Pulse_Checker_Prover_IntroPure.intro_pure preamble
                              pst p unsolved' ()))
@@ -319,17 +376,17 @@ let rec (prove_pures :
                                          (Obj.magic
                                             (FStar_Range.mk_range
                                                "Pulse.Checker.Prover.fst"
-                                               (Prims.of_int (101))
+                                               (Prims.of_int (112))
                                                (Prims.of_int (28))
-                                               (Prims.of_int (104))
+                                               (Prims.of_int (115))
                                                (Prims.of_int (8)))))
                                       (FStar_Sealed.seal
                                          (Obj.magic
                                             (FStar_Range.mk_range
                                                "Pulse.Checker.Prover.fst"
-                                               (Prims.of_int (101))
+                                               (Prims.of_int (112))
                                                (Prims.of_int (7))
-                                               (Prims.of_int (104))
+                                               (Prims.of_int (115))
                                                (Prims.of_int (8)))))
                                       (Obj.magic
                                          (FStar_Tactics_Effect.tac_bind
@@ -337,17 +394,17 @@ let rec (prove_pures :
                                                (Obj.magic
                                                   (FStar_Range.mk_range
                                                      "Pulse.Checker.Prover.fst"
-                                                     (Prims.of_int (102))
+                                                     (Prims.of_int (113))
                                                      (Prims.of_int (9))
-                                                     (Prims.of_int (103))
+                                                     (Prims.of_int (114))
                                                      (Prims.of_int (15)))))
                                             (FStar_Sealed.seal
                                                (Obj.magic
                                                   (FStar_Range.mk_range
                                                      "Pulse.Checker.Prover.fst"
-                                                     (Prims.of_int (101))
+                                                     (Prims.of_int (112))
                                                      (Prims.of_int (28))
-                                                     (Prims.of_int (104))
+                                                     (Prims.of_int (115))
                                                      (Prims.of_int (8)))))
                                             (Obj.magic
                                                (FStar_Tactics_Effect.tac_bind
@@ -355,17 +412,17 @@ let rec (prove_pures :
                                                      (Obj.magic
                                                         (FStar_Range.mk_range
                                                            "Pulse.Checker.Prover.fst"
-                                                           (Prims.of_int (103))
+                                                           (Prims.of_int (114))
                                                            (Prims.of_int (11))
-                                                           (Prims.of_int (103))
+                                                           (Prims.of_int (114))
                                                            (Prims.of_int (15)))))
                                                   (FStar_Sealed.seal
                                                      (Obj.magic
                                                         (FStar_Range.mk_range
                                                            "Pulse.Checker.Prover.fst"
-                                                           (Prims.of_int (102))
+                                                           (Prims.of_int (113))
                                                            (Prims.of_int (9))
-                                                           (Prims.of_int (103))
+                                                           (Prims.of_int (114))
                                                            (Prims.of_int (15)))))
                                                   (Obj.magic
                                                      (Pulse_PP.pp
@@ -394,17 +451,17 @@ let rec (prove_pures :
                                          (Obj.magic
                                             (FStar_Range.mk_range
                                                "Pulse.Checker.Prover.fst"
-                                               (Prims.of_int (106))
+                                               (Prims.of_int (117))
                                                (Prims.of_int (18))
-                                               (Prims.of_int (106))
+                                               (Prims.of_int (117))
                                                (Prims.of_int (34)))))
                                       (FStar_Sealed.seal
                                          (Obj.magic
                                             (FStar_Range.mk_range
                                                "Pulse.Checker.Prover.fst"
-                                               (Prims.of_int (106))
+                                               (Prims.of_int (117))
                                                (Prims.of_int (11))
-                                               (Prims.of_int (106))
+                                               (Prims.of_int (117))
                                                (Prims.of_int (15)))))
                                       (Obj.magic (prove_pures preamble pst1))
                                       (fun pst2 ->
@@ -417,21 +474,21 @@ let rec (prove_pures :
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Checker.Prover.fst"
-                                (Prims.of_int (113)) (Prims.of_int (6))
-                                (Prims.of_int (114)) (Prims.of_int (48)))))
+                                (Prims.of_int (124)) (Prims.of_int (6))
+                                (Prims.of_int (125)) (Prims.of_int (48)))))
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Checker.Prover.fst"
-                                (Prims.of_int (112)) (Prims.of_int (4))
-                                (Prims.of_int (114)) (Prims.of_int (48)))))
+                                (Prims.of_int (123)) (Prims.of_int (4))
+                                (Prims.of_int (125)) (Prims.of_int (48)))))
                        (Obj.magic
                           (FStar_Tactics_Effect.tac_bind
                              (FStar_Sealed.seal
                                 (Obj.magic
                                    (FStar_Range.mk_range
                                       "Pulse.Checker.Prover.fst"
-                                      (Prims.of_int (114)) (Prims.of_int (9))
-                                      (Prims.of_int (114))
+                                      (Prims.of_int (125)) (Prims.of_int (9))
+                                      (Prims.of_int (125))
                                       (Prims.of_int (47)))))
                              (FStar_Sealed.seal
                                 (Obj.magic
@@ -470,12 +527,12 @@ let rec (prover :
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.Prover.fst"
-                 (Prims.of_int (123)) (Prims.of_int (2)) (Prims.of_int (126))
+                 (Prims.of_int (134)) (Prims.of_int (2)) (Prims.of_int (137))
                  (Prims.of_int (55)))))
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.Prover.fst"
-                 (Prims.of_int (128)) (Prims.of_int (2)) (Prims.of_int (185))
+                 (Prims.of_int (139)) (Prims.of_int (2)) (Prims.of_int (196))
                  (Prims.of_int (32)))))
         (Obj.magic
            (Pulse_Checker_Prover_Util.debug_prover
@@ -485,13 +542,13 @@ let rec (prover :
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Checker.Prover.fst"
-                            (Prims.of_int (126)) (Prims.of_int (6))
-                            (Prims.of_int (126)) (Prims.of_int (54)))))
+                            (Prims.of_int (137)) (Prims.of_int (6))
+                            (Prims.of_int (137)) (Prims.of_int (54)))))
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Checker.Prover.fst"
-                            (Prims.of_int (124)) (Prims.of_int (4))
-                            (Prims.of_int (126)) (Prims.of_int (54)))))
+                            (Prims.of_int (135)) (Prims.of_int (4))
+                            (Prims.of_int (137)) (Prims.of_int (54)))))
                    (Obj.magic
                       (Pulse_Syntax_Printer.term_to_string
                          (Pulse_Typing_Combinators.list_as_vprop
@@ -504,17 +561,17 @@ let rec (prover :
                                  (Obj.magic
                                     (FStar_Range.mk_range
                                        "Pulse.Checker.Prover.fst"
-                                       (Prims.of_int (124))
+                                       (Prims.of_int (135))
                                        (Prims.of_int (4))
-                                       (Prims.of_int (126))
+                                       (Prims.of_int (137))
                                        (Prims.of_int (54)))))
                               (FStar_Sealed.seal
                                  (Obj.magic
                                     (FStar_Range.mk_range
                                        "Pulse.Checker.Prover.fst"
-                                       (Prims.of_int (124))
+                                       (Prims.of_int (135))
                                        (Prims.of_int (4))
-                                       (Prims.of_int (126))
+                                       (Prims.of_int (137))
                                        (Prims.of_int (54)))))
                               (Obj.magic
                                  (FStar_Tactics_Effect.tac_bind
@@ -522,9 +579,9 @@ let rec (prover :
                                        (Obj.magic
                                           (FStar_Range.mk_range
                                              "Pulse.Checker.Prover.fst"
-                                             (Prims.of_int (125))
+                                             (Prims.of_int (136))
                                              (Prims.of_int (6))
-                                             (Prims.of_int (125))
+                                             (Prims.of_int (136))
                                              (Prims.of_int (60)))))
                                     (FStar_Sealed.seal
                                        (Obj.magic
@@ -567,14 +624,14 @@ let rec (prover :
                              (Obj.magic
                                 (FStar_Range.mk_range
                                    "Pulse.Checker.Prover.fst"
-                                   (Prims.of_int (131)) (Prims.of_int (14))
-                                   (Prims.of_int (131)) (Prims.of_int (45)))))
+                                   (Prims.of_int (142)) (Prims.of_int (14))
+                                   (Prims.of_int (142)) (Prims.of_int (45)))))
                           (FStar_Sealed.seal
                              (Obj.magic
                                 (FStar_Range.mk_range
                                    "Pulse.Checker.Prover.fst"
-                                   (Prims.of_int (133)) (Prims.of_int (4))
-                                   (Prims.of_int (185)) (Prims.of_int (32)))))
+                                   (Prims.of_int (144)) (Prims.of_int (4))
+                                   (Prims.of_int (196)) (Prims.of_int (32)))))
                           (Obj.magic
                              (Pulse_Checker_Prover_ElimExists.elim_exists_pst
                                 preamble pst0))
@@ -586,17 +643,17 @@ let rec (prover :
                                         (Obj.magic
                                            (FStar_Range.mk_range
                                               "Pulse.Checker.Prover.fst"
-                                              (Prims.of_int (133))
+                                              (Prims.of_int (144))
                                               (Prims.of_int (4))
-                                              (Prims.of_int (135))
+                                              (Prims.of_int (146))
                                               (Prims.of_int (62)))))
                                      (FStar_Sealed.seal
                                         (Obj.magic
                                            (FStar_Range.mk_range
                                               "Pulse.Checker.Prover.fst"
-                                              (Prims.of_int (135))
+                                              (Prims.of_int (146))
                                               (Prims.of_int (63))
-                                              (Prims.of_int (185))
+                                              (Prims.of_int (196))
                                               (Prims.of_int (32)))))
                                      (Obj.magic
                                         (Pulse_Checker_Prover_Util.debug_prover
@@ -607,9 +664,9 @@ let rec (prover :
                                                    (Obj.magic
                                                       (FStar_Range.mk_range
                                                          "Pulse.Checker.Prover.fst"
-                                                         (Prims.of_int (135))
+                                                         (Prims.of_int (146))
                                                          (Prims.of_int (8))
-                                                         (Prims.of_int (135))
+                                                         (Prims.of_int (146))
                                                          (Prims.of_int (61)))))
                                                 (FStar_Sealed.seal
                                                    (Obj.magic
@@ -638,17 +695,17 @@ let rec (prover :
                                                    (Obj.magic
                                                       (FStar_Range.mk_range
                                                          "Pulse.Checker.Prover.fst"
-                                                         (Prims.of_int (137))
+                                                         (Prims.of_int (148))
                                                          (Prims.of_int (14))
-                                                         (Prims.of_int (137))
+                                                         (Prims.of_int (148))
                                                          (Prims.of_int (40)))))
                                                 (FStar_Sealed.seal
                                                    (Obj.magic
                                                       (FStar_Range.mk_range
                                                          "Pulse.Checker.Prover.fst"
-                                                         (Prims.of_int (139))
+                                                         (Prims.of_int (150))
                                                          (Prims.of_int (4))
-                                                         (Prims.of_int (185))
+                                                         (Prims.of_int (196))
                                                          (Prims.of_int (32)))))
                                                 (Obj.magic
                                                    (Pulse_Checker_Prover_ElimPure.elim_pure_pst
@@ -661,17 +718,17 @@ let rec (prover :
                                                               (Obj.magic
                                                                  (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (139))
+                                                                    (Prims.of_int (150))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (141))
+                                                                    (Prims.of_int (152))
                                                                     (Prims.of_int (62)))))
                                                            (FStar_Sealed.seal
                                                               (Obj.magic
                                                                  (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (141))
+                                                                    (Prims.of_int (152))
                                                                     (Prims.of_int (63))
-                                                                    (Prims.of_int (185))
+                                                                    (Prims.of_int (196))
                                                                     (Prims.of_int (32)))))
                                                            (Obj.magic
                                                               (Pulse_Checker_Prover_Util.debug_prover
@@ -683,9 +740,9 @@ let rec (prover :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (141))
+                                                                    (Prims.of_int (152))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (141))
+                                                                    (Prims.of_int (152))
                                                                     (Prims.of_int (61)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -717,17 +774,17 @@ let rec (prover :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (143))
+                                                                    (Prims.of_int (154))
                                                                     (Prims.of_int (29))
-                                                                    (Prims.of_int (143))
+                                                                    (Prims.of_int (154))
                                                                     (Prims.of_int (82)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (141))
+                                                                    (Prims.of_int (152))
                                                                     (Prims.of_int (63))
-                                                                    (Prims.of_int (185))
+                                                                    (Prims.of_int (196))
                                                                     (Prims.of_int (32)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -754,17 +811,17 @@ let rec (prover :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (145))
+                                                                    (Prims.of_int (156))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (147))
+                                                                    (Prims.of_int (158))
                                                                     (Prims.of_int (87)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (147))
+                                                                    (Prims.of_int (158))
                                                                     (Prims.of_int (88))
-                                                                    (Prims.of_int (185))
+                                                                    (Prims.of_int (196))
                                                                     (Prims.of_int (32)))))
                                                                     (Obj.magic
                                                                     (Pulse_Checker_Prover_Util.debug_prover
@@ -776,17 +833,17 @@ let rec (prover :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (147))
+                                                                    (Prims.of_int (158))
                                                                     (Prims.of_int (47))
-                                                                    (Prims.of_int (147))
+                                                                    (Prims.of_int (158))
                                                                     (Prims.of_int (86)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (146))
+                                                                    (Prims.of_int (157))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (147))
+                                                                    (Prims.of_int (158))
                                                                     (Prims.of_int (86)))))
                                                                     (Obj.magic
                                                                     (Pulse_Syntax_Printer.term_to_string
@@ -802,17 +859,17 @@ let rec (prover :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (146))
+                                                                    (Prims.of_int (157))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (147))
+                                                                    (Prims.of_int (158))
                                                                     (Prims.of_int (86)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (146))
+                                                                    (Prims.of_int (157))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (147))
+                                                                    (Prims.of_int (158))
                                                                     (Prims.of_int (86)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -820,9 +877,9 @@ let rec (prover :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (147))
+                                                                    (Prims.of_int (158))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (147))
+                                                                    (Prims.of_int (158))
                                                                     (Prims.of_int (46)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -868,17 +925,17 @@ let rec (prover :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (149))
+                                                                    (Prims.of_int (160))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (149))
+                                                                    (Prims.of_int (160))
                                                                     (Prims.of_int (49)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (151))
+                                                                    (Prims.of_int (162))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (185))
+                                                                    (Prims.of_int (196))
                                                                     (Prims.of_int (32)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -899,17 +956,17 @@ let rec (prover :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (151))
+                                                                    (Prims.of_int (162))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (153))
+                                                                    (Prims.of_int (164))
                                                                     (Prims.of_int (56)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (155))
+                                                                    (Prims.of_int (166))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (185))
+                                                                    (Prims.of_int (196))
                                                                     (Prims.of_int (32)))))
                                                                     (Obj.magic
                                                                     (Pulse_Checker_Prover_Util.debug_prover
@@ -921,9 +978,9 @@ let rec (prover :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (153))
+                                                                    (Prims.of_int (164))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (153))
+                                                                    (Prims.of_int (164))
                                                                     (Prims.of_int (55)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -979,17 +1036,17 @@ let rec (prover :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (159))
+                                                                    (Prims.of_int (170))
                                                                     (Prims.of_int (33))
-                                                                    (Prims.of_int (159))
+                                                                    (Prims.of_int (170))
                                                                     (Prims.of_int (85)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (158))
+                                                                    (Prims.of_int (169))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (185))
+                                                                    (Prims.of_int (196))
                                                                     (Prims.of_int (32)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -1016,17 +1073,17 @@ let rec (prover :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (160))
+                                                                    (Prims.of_int (171))
                                                                     (Prims.of_int (16))
-                                                                    (Prims.of_int (160))
+                                                                    (Prims.of_int (171))
                                                                     (Prims.of_int (53)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (161))
+                                                                    (Prims.of_int (172))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (185))
+                                                                    (Prims.of_int (196))
                                                                     (Prims.of_int (32)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -1065,17 +1122,17 @@ let rec (prover :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (164))
+                                                                    (Prims.of_int (175))
                                                                     (Prims.of_int (22))
-                                                                    (Prims.of_int (164))
+                                                                    (Prims.of_int (175))
                                                                     (Prims.of_int (43)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (165))
+                                                                    (Prims.of_int (176))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (185))
+                                                                    (Prims.of_int (196))
                                                                     (Prims.of_int (32)))))
                                                                     (Obj.magic
                                                                     (match_q
@@ -1099,17 +1156,17 @@ let rec (prover :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (169))
-                                                                    (Prims.of_int (20))
                                                                     (Prims.of_int (180))
+                                                                    (Prims.of_int (20))
+                                                                    (Prims.of_int (191))
                                                                     (Prims.of_int (25)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (184))
+                                                                    (Prims.of_int (195))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (184))
+                                                                    (Prims.of_int (195))
                                                                     (Prims.of_int (34)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1117,17 +1174,17 @@ let rec (prover :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (169))
+                                                                    (Prims.of_int (180))
                                                                     (Prims.of_int (20))
-                                                                    (Prims.of_int (175))
+                                                                    (Prims.of_int (186))
                                                                     (Prims.of_int (11)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (169))
-                                                                    (Prims.of_int (20))
                                                                     (Prims.of_int (180))
+                                                                    (Prims.of_int (20))
+                                                                    (Prims.of_int (191))
                                                                     (Prims.of_int (25)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1135,17 +1192,17 @@ let rec (prover :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (169))
+                                                                    (Prims.of_int (180))
                                                                     (Prims.of_int (20))
-                                                                    (Prims.of_int (175))
+                                                                    (Prims.of_int (186))
                                                                     (Prims.of_int (11)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (169))
+                                                                    (Prims.of_int (180))
                                                                     (Prims.of_int (20))
-                                                                    (Prims.of_int (175))
+                                                                    (Prims.of_int (186))
                                                                     (Prims.of_int (11)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1153,17 +1210,17 @@ let rec (prover :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (171))
+                                                                    (Prims.of_int (182))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (172))
+                                                                    (Prims.of_int (183))
                                                                     (Prims.of_int (29)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (169))
+                                                                    (Prims.of_int (180))
                                                                     (Prims.of_int (20))
-                                                                    (Prims.of_int (175))
+                                                                    (Prims.of_int (186))
                                                                     (Prims.of_int (11)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1171,17 +1228,17 @@ let rec (prover :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (172))
+                                                                    (Prims.of_int (183))
                                                                     (Prims.of_int (16))
-                                                                    (Prims.of_int (172))
+                                                                    (Prims.of_int (183))
                                                                     (Prims.of_int (29)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (171))
+                                                                    (Prims.of_int (182))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (172))
+                                                                    (Prims.of_int (183))
                                                                     (Prims.of_int (29)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1189,17 +1246,17 @@ let rec (prover :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (172))
+                                                                    (Prims.of_int (183))
                                                                     (Prims.of_int (23))
-                                                                    (Prims.of_int (172))
+                                                                    (Prims.of_int (183))
                                                                     (Prims.of_int (29)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (172))
+                                                                    (Prims.of_int (183))
                                                                     (Prims.of_int (16))
-                                                                    (Prims.of_int (172))
+                                                                    (Prims.of_int (183))
                                                                     (Prims.of_int (29)))))
                                                                     (Obj.magic
                                                                     (Pulse_PP.pp
@@ -1233,17 +1290,17 @@ let rec (prover :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (169))
+                                                                    (Prims.of_int (180))
                                                                     (Prims.of_int (20))
-                                                                    (Prims.of_int (175))
+                                                                    (Prims.of_int (186))
                                                                     (Prims.of_int (11)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (169))
+                                                                    (Prims.of_int (180))
                                                                     (Prims.of_int (20))
-                                                                    (Prims.of_int (175))
+                                                                    (Prims.of_int (186))
                                                                     (Prims.of_int (11)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1251,17 +1308,17 @@ let rec (prover :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (173))
+                                                                    (Prims.of_int (184))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (174))
+                                                                    (Prims.of_int (185))
                                                                     (Prims.of_int (62)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (169))
+                                                                    (Prims.of_int (180))
                                                                     (Prims.of_int (20))
-                                                                    (Prims.of_int (175))
+                                                                    (Prims.of_int (186))
                                                                     (Prims.of_int (11)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1269,17 +1326,17 @@ let rec (prover :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (174))
+                                                                    (Prims.of_int (185))
                                                                     (Prims.of_int (16))
-                                                                    (Prims.of_int (174))
+                                                                    (Prims.of_int (185))
                                                                     (Prims.of_int (62)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (173))
+                                                                    (Prims.of_int (184))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (174))
+                                                                    (Prims.of_int (185))
                                                                     (Prims.of_int (62)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1287,17 +1344,17 @@ let rec (prover :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (174))
+                                                                    (Prims.of_int (185))
                                                                     (Prims.of_int (23))
-                                                                    (Prims.of_int (174))
+                                                                    (Prims.of_int (185))
                                                                     (Prims.of_int (62)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (174))
+                                                                    (Prims.of_int (185))
                                                                     (Prims.of_int (16))
-                                                                    (Prims.of_int (174))
+                                                                    (Prims.of_int (185))
                                                                     (Prims.of_int (62)))))
                                                                     (Obj.magic
                                                                     (Pulse_PP.pp
@@ -1361,17 +1418,17 @@ let rec (prover :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (175))
+                                                                    (Prims.of_int (186))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (180))
+                                                                    (Prims.of_int (191))
                                                                     (Prims.of_int (25)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (169))
-                                                                    (Prims.of_int (20))
                                                                     (Prims.of_int (180))
+                                                                    (Prims.of_int (20))
+                                                                    (Prims.of_int (191))
                                                                     (Prims.of_int (25)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1379,17 +1436,17 @@ let rec (prover :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (175))
+                                                                    (Prims.of_int (186))
                                                                     (Prims.of_int (18))
-                                                                    (Prims.of_int (175))
+                                                                    (Prims.of_int (186))
                                                                     (Prims.of_int (64)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (175))
+                                                                    (Prims.of_int (186))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (180))
+                                                                    (Prims.of_int (191))
                                                                     (Prims.of_int (25)))))
                                                                     (Obj.magic
                                                                     (Pulse_Config.debug_flag
@@ -1410,17 +1467,17 @@ let rec (prover :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (176))
+                                                                    (Prims.of_int (187))
                                                                     (Prims.of_int (16))
-                                                                    (Prims.of_int (177))
+                                                                    (Prims.of_int (188))
                                                                     (Prims.of_int (46)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (175))
+                                                                    (Prims.of_int (186))
                                                                     (Prims.of_int (70))
-                                                                    (Prims.of_int (180))
+                                                                    (Prims.of_int (191))
                                                                     (Prims.of_int (16)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1428,17 +1485,17 @@ let rec (prover :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (177))
+                                                                    (Prims.of_int (188))
                                                                     (Prims.of_int (20))
-                                                                    (Prims.of_int (177))
+                                                                    (Prims.of_int (188))
                                                                     (Prims.of_int (46)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (176))
+                                                                    (Prims.of_int (187))
                                                                     (Prims.of_int (16))
-                                                                    (Prims.of_int (177))
+                                                                    (Prims.of_int (188))
                                                                     (Prims.of_int (46)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1446,17 +1503,17 @@ let rec (prover :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (177))
+                                                                    (Prims.of_int (188))
                                                                     (Prims.of_int (27))
-                                                                    (Prims.of_int (177))
+                                                                    (Prims.of_int (188))
                                                                     (Prims.of_int (46)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (177))
+                                                                    (Prims.of_int (188))
                                                                     (Prims.of_int (20))
-                                                                    (Prims.of_int (177))
+                                                                    (Prims.of_int (188))
                                                                     (Prims.of_int (46)))))
                                                                     (Obj.magic
                                                                     (Pulse_PP.pp
@@ -1494,17 +1551,17 @@ let rec (prover :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (175))
+                                                                    (Prims.of_int (186))
                                                                     (Prims.of_int (70))
-                                                                    (Prims.of_int (180))
+                                                                    (Prims.of_int (191))
                                                                     (Prims.of_int (16)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (175))
+                                                                    (Prims.of_int (186))
                                                                     (Prims.of_int (70))
-                                                                    (Prims.of_int (180))
+                                                                    (Prims.of_int (191))
                                                                     (Prims.of_int (16)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1512,17 +1569,17 @@ let rec (prover :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (178))
+                                                                    (Prims.of_int (189))
                                                                     (Prims.of_int (16))
-                                                                    (Prims.of_int (179))
+                                                                    (Prims.of_int (190))
                                                                     (Prims.of_int (45)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (175))
+                                                                    (Prims.of_int (186))
                                                                     (Prims.of_int (70))
-                                                                    (Prims.of_int (180))
+                                                                    (Prims.of_int (191))
                                                                     (Prims.of_int (16)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1530,17 +1587,17 @@ let rec (prover :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (179))
+                                                                    (Prims.of_int (190))
                                                                     (Prims.of_int (20))
-                                                                    (Prims.of_int (179))
+                                                                    (Prims.of_int (190))
                                                                     (Prims.of_int (45)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (178))
+                                                                    (Prims.of_int (189))
                                                                     (Prims.of_int (16))
-                                                                    (Prims.of_int (179))
+                                                                    (Prims.of_int (190))
                                                                     (Prims.of_int (45)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1548,17 +1605,17 @@ let rec (prover :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (179))
+                                                                    (Prims.of_int (190))
                                                                     (Prims.of_int (27))
-                                                                    (Prims.of_int (179))
+                                                                    (Prims.of_int (190))
                                                                     (Prims.of_int (45)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (179))
+                                                                    (Prims.of_int (190))
                                                                     (Prims.of_int (20))
-                                                                    (Prims.of_int (179))
+                                                                    (Prims.of_int (190))
                                                                     (Prims.of_int (45)))))
                                                                     (Obj.magic
                                                                     (Pulse_PP.pp
@@ -1692,13 +1749,13 @@ let (prove :
                 (FStar_Sealed.seal
                    (Obj.magic
                       (FStar_Range.mk_range "Pulse.Checker.Prover.fst"
-                         (Prims.of_int (210)) (Prims.of_int (2))
-                         (Prims.of_int (212)) (Prims.of_int (55)))))
+                         (Prims.of_int (221)) (Prims.of_int (2))
+                         (Prims.of_int (223)) (Prims.of_int (55)))))
                 (FStar_Sealed.seal
                    (Obj.magic
                       (FStar_Range.mk_range "Pulse.Checker.Prover.fst"
-                         (Prims.of_int (212)) (Prims.of_int (56))
-                         (Prims.of_int (284)) (Prims.of_int (126)))))
+                         (Prims.of_int (223)) (Prims.of_int (56))
+                         (Prims.of_int (295)) (Prims.of_int (126)))))
                 (Obj.magic
                    (Pulse_Checker_Prover_Util.debug_prover g
                       (fun uu___ ->
@@ -1707,14 +1764,14 @@ let (prove :
                               (Obj.magic
                                  (FStar_Range.mk_range
                                     "Pulse.Checker.Prover.fst"
-                                    (Prims.of_int (212)) (Prims.of_int (30))
-                                    (Prims.of_int (212)) (Prims.of_int (54)))))
+                                    (Prims.of_int (223)) (Prims.of_int (30))
+                                    (Prims.of_int (223)) (Prims.of_int (54)))))
                            (FStar_Sealed.seal
                               (Obj.magic
                                  (FStar_Range.mk_range
                                     "Pulse.Checker.Prover.fst"
-                                    (Prims.of_int (211)) (Prims.of_int (4))
-                                    (Prims.of_int (212)) (Prims.of_int (54)))))
+                                    (Prims.of_int (222)) (Prims.of_int (4))
+                                    (Prims.of_int (223)) (Prims.of_int (54)))))
                            (Obj.magic
                               (Pulse_Syntax_Printer.term_to_string goals))
                            (fun uu___1 ->
@@ -1725,17 +1782,17 @@ let (prove :
                                          (Obj.magic
                                             (FStar_Range.mk_range
                                                "Pulse.Checker.Prover.fst"
-                                               (Prims.of_int (211))
+                                               (Prims.of_int (222))
                                                (Prims.of_int (4))
-                                               (Prims.of_int (212))
+                                               (Prims.of_int (223))
                                                (Prims.of_int (54)))))
                                       (FStar_Sealed.seal
                                          (Obj.magic
                                             (FStar_Range.mk_range
                                                "Pulse.Checker.Prover.fst"
-                                               (Prims.of_int (211))
+                                               (Prims.of_int (222))
                                                (Prims.of_int (4))
-                                               (Prims.of_int (212))
+                                               (Prims.of_int (223))
                                                (Prims.of_int (54)))))
                                       (Obj.magic
                                          (FStar_Tactics_Effect.tac_bind
@@ -1743,9 +1800,9 @@ let (prove :
                                                (Obj.magic
                                                   (FStar_Range.mk_range
                                                      "Pulse.Checker.Prover.fst"
-                                                     (Prims.of_int (212))
+                                                     (Prims.of_int (223))
                                                      (Prims.of_int (6))
-                                                     (Prims.of_int (212))
+                                                     (Prims.of_int (223))
                                                      (Prims.of_int (29)))))
                                             (FStar_Sealed.seal
                                                (Obj.magic
@@ -1781,14 +1838,14 @@ let (prove :
                               (Obj.magic
                                  (FStar_Range.mk_range
                                     "Pulse.Checker.Prover.fst"
-                                    (Prims.of_int (214)) (Prims.of_int (15))
-                                    (Prims.of_int (214)) (Prims.of_int (33)))))
+                                    (Prims.of_int (225)) (Prims.of_int (15))
+                                    (Prims.of_int (225)) (Prims.of_int (33)))))
                            (FStar_Sealed.seal
                               (Obj.magic
                                  (FStar_Range.mk_range
                                     "Pulse.Checker.Prover.fst"
-                                    (Prims.of_int (229)) (Prims.of_int (75))
-                                    (Prims.of_int (284)) (Prims.of_int (126)))))
+                                    (Prims.of_int (240)) (Prims.of_int (75))
+                                    (Prims.of_int (295)) (Prims.of_int (126)))))
                            (FStar_Tactics_Effect.lift_div_tac
                               (fun uu___1 ->
                                  Pulse_Typing_Combinators.vprop_as_list ctxt))
@@ -1800,17 +1857,17 @@ let (prove :
                                          (Obj.magic
                                             (FStar_Range.mk_range
                                                "Pulse.Checker.Prover.fst"
-                                               (Prims.of_int (231))
+                                               (Prims.of_int (242))
                                                (Prims.of_int (6))
-                                               (Prims.of_int (235))
+                                               (Prims.of_int (246))
                                                (Prims.of_int (12)))))
                                       (FStar_Sealed.seal
                                          (Obj.magic
                                             (FStar_Range.mk_range
                                                "Pulse.Checker.Prover.fst"
-                                               (Prims.of_int (238))
+                                               (Prims.of_int (249))
                                                (Prims.of_int (43))
-                                               (Prims.of_int (284))
+                                               (Prims.of_int (295))
                                                (Prims.of_int (126)))))
                                       (FStar_Tactics_Effect.lift_div_tac
                                          (fun uu___1 ->
@@ -1834,17 +1891,17 @@ let (prove :
                                                     (Obj.magic
                                                        (FStar_Range.mk_range
                                                           "Pulse.Checker.Prover.fst"
-                                                          (Prims.of_int (240))
+                                                          (Prims.of_int (251))
                                                           (Prims.of_int (6))
-                                                          (Prims.of_int (249))
+                                                          (Prims.of_int (260))
                                                           (Prims.of_int (21)))))
                                                  (FStar_Sealed.seal
                                                     (Obj.magic
                                                        (FStar_Range.mk_range
                                                           "Pulse.Checker.Prover.fst"
-                                                          (Prims.of_int (250))
+                                                          (Prims.of_int (261))
                                                           (Prims.of_int (8))
-                                                          (Prims.of_int (284))
+                                                          (Prims.of_int (295))
                                                           (Prims.of_int (126)))))
                                                  (FStar_Tactics_Effect.lift_div_tac
                                                     (fun uu___1 ->
@@ -1903,17 +1960,17 @@ let (prove :
                                                                (Obj.magic
                                                                   (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (252))
+                                                                    (Prims.of_int (263))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (252))
+                                                                    (Prims.of_int (263))
                                                                     (Prims.of_int (25)))))
                                                             (FStar_Sealed.seal
                                                                (Obj.magic
                                                                   (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (252))
+                                                                    (Prims.of_int (263))
                                                                     (Prims.of_int (28))
-                                                                    (Prims.of_int (284))
+                                                                    (Prims.of_int (295))
                                                                     (Prims.of_int (126)))))
                                                             (Obj.magic
                                                                (prover
@@ -1928,17 +1985,17 @@ let (prove :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (259))
+                                                                    (Prims.of_int (270))
                                                                     (Prims.of_int (7))
-                                                                    (Prims.of_int (265))
+                                                                    (Prims.of_int (276))
                                                                     (Prims.of_int (22)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (252))
+                                                                    (Prims.of_int (263))
                                                                     (Prims.of_int (28))
-                                                                    (Prims.of_int (284))
+                                                                    (Prims.of_int (295))
                                                                     (Prims.of_int (126)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1946,17 +2003,17 @@ let (prove :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (260))
+                                                                    (Prims.of_int (271))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (260))
+                                                                    (Prims.of_int (271))
                                                                     (Prims.of_int (54)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (261))
+                                                                    (Prims.of_int (272))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (265))
+                                                                    (Prims.of_int (276))
                                                                     (Prims.of_int (22)))))
                                                                     (Obj.magic
                                                                     (Pulse_Checker_Prover_Substs.ss_to_nt_substs
@@ -2068,13 +2125,13 @@ let (try_frame_pre_uvs :
                 (FStar_Sealed.seal
                    (Obj.magic
                       (FStar_Range.mk_range "Pulse.Checker.Prover.fst"
-                         (Prims.of_int (295)) (Prims.of_int (22))
-                         (Prims.of_int (295)) (Prims.of_int (23)))))
+                         (Prims.of_int (306)) (Prims.of_int (22))
+                         (Prims.of_int (306)) (Prims.of_int (23)))))
                 (FStar_Sealed.seal
                    (Obj.magic
                       (FStar_Range.mk_range "Pulse.Checker.Prover.fst"
-                         (Prims.of_int (293)) (Prims.of_int (42))
-                         (Prims.of_int (360)) (Prims.of_int (88)))))
+                         (Prims.of_int (304)) (Prims.of_int (42))
+                         (Prims.of_int (371)) (Prims.of_int (88)))))
                 (FStar_Tactics_Effect.lift_div_tac (fun uu___ -> d))
                 (fun uu___ ->
                    (fun uu___ ->
@@ -2086,17 +2143,17 @@ let (try_frame_pre_uvs :
                                   (Obj.magic
                                      (FStar_Range.mk_range
                                         "Pulse.Checker.Prover.fst"
-                                        (Prims.of_int (297))
+                                        (Prims.of_int (308))
                                         (Prims.of_int (10))
-                                        (Prims.of_int (297))
+                                        (Prims.of_int (308))
                                         (Prims.of_int (48)))))
                                (FStar_Sealed.seal
                                   (Obj.magic
                                      (FStar_Range.mk_range
                                         "Pulse.Checker.Prover.fst"
-                                        (Prims.of_int (297))
+                                        (Prims.of_int (308))
                                         (Prims.of_int (51))
-                                        (Prims.of_int (360))
+                                        (Prims.of_int (371))
                                         (Prims.of_int (88)))))
                                (FStar_Tactics_Effect.lift_div_tac
                                   (fun uu___1 ->
@@ -2111,17 +2168,17 @@ let (try_frame_pre_uvs :
                                              (Obj.magic
                                                 (FStar_Range.mk_range
                                                    "Pulse.Checker.Prover.fst"
-                                                   (Prims.of_int (300))
+                                                   (Prims.of_int (311))
                                                    (Prims.of_int (4))
-                                                   (Prims.of_int (300))
+                                                   (Prims.of_int (311))
                                                    (Prims.of_int (59)))))
                                           (FStar_Sealed.seal
                                              (Obj.magic
                                                 (FStar_Range.mk_range
                                                    "Pulse.Checker.Prover.fst"
-                                                   (Prims.of_int (297))
+                                                   (Prims.of_int (308))
                                                    (Prims.of_int (51))
-                                                   (Prims.of_int (360))
+                                                   (Prims.of_int (371))
                                                    (Prims.of_int (88)))))
                                           (Obj.magic
                                              (prove g1 ctxt () uvs
@@ -2140,17 +2197,17 @@ let (try_frame_pre_uvs :
                                                             (Obj.magic
                                                                (FStar_Range.mk_range
                                                                   "Pulse.Checker.Prover.fst"
-                                                                  (Prims.of_int (304))
+                                                                  (Prims.of_int (315))
                                                                   (Prims.of_int (4))
-                                                                  (Prims.of_int (304))
+                                                                  (Prims.of_int (315))
                                                                   (Prims.of_int (49)))))
                                                          (FStar_Sealed.seal
                                                             (Obj.magic
                                                                (FStar_Range.mk_range
                                                                   "Pulse.Checker.Prover.fst"
-                                                                  (Prims.of_int (306))
+                                                                  (Prims.of_int (317))
                                                                   (Prims.of_int (82))
-                                                                  (Prims.of_int (360))
+                                                                  (Prims.of_int (371))
                                                                   (Prims.of_int (88)))))
                                                          (FStar_Tactics_Effect.lift_div_tac
                                                             (fun uu___2 ->
@@ -2166,18 +2223,18 @@ let (try_frame_pre_uvs :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (307))
+                                                                    (Prims.of_int (318))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (307))
+                                                                    (Prims.of_int (318))
                                                                     (Prims.of_int (35)))))
                                                                     (
                                                                     FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (307))
+                                                                    (Prims.of_int (318))
                                                                     (Prims.of_int (38))
-                                                                    (Prims.of_int (360))
+                                                                    (Prims.of_int (371))
                                                                     (Prims.of_int (88)))))
                                                                     (
                                                                     FStar_Tactics_Effect.lift_div_tac
@@ -2196,17 +2253,17 @@ let (try_frame_pre_uvs :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (308))
+                                                                    (Prims.of_int (319))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (308))
+                                                                    (Prims.of_int (319))
                                                                     (Prims.of_int (32)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (308))
+                                                                    (Prims.of_int (319))
                                                                     (Prims.of_int (35))
-                                                                    (Prims.of_int (360))
+                                                                    (Prims.of_int (371))
                                                                     (Prims.of_int (88)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -2223,17 +2280,17 @@ let (try_frame_pre_uvs :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (310))
+                                                                    (Prims.of_int (321))
                                                                     (Prims.of_int (28))
-                                                                    (Prims.of_int (318))
+                                                                    (Prims.of_int (329))
                                                                     (Prims.of_int (16)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (318))
+                                                                    (Prims.of_int (329))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (360))
+                                                                    (Prims.of_int (371))
                                                                     (Prims.of_int (88)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -2241,17 +2298,17 @@ let (try_frame_pre_uvs :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (311))
+                                                                    (Prims.of_int (322))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (311))
+                                                                    (Prims.of_int (322))
                                                                     (Prims.of_int (69)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (312))
+                                                                    (Prims.of_int (323))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (318))
+                                                                    (Prims.of_int (329))
                                                                     (Prims.of_int (16)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -2276,17 +2333,17 @@ let (try_frame_pre_uvs :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (315))
+                                                                    (Prims.of_int (326))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (317))
+                                                                    (Prims.of_int (328))
                                                                     (Prims.of_int (34)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (314))
+                                                                    (Prims.of_int (325))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (317))
+                                                                    (Prims.of_int (328))
                                                                     (Prims.of_int (34)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -2294,17 +2351,17 @@ let (try_frame_pre_uvs :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (317))
+                                                                    (Prims.of_int (328))
                                                                     (Prims.of_int (11))
-                                                                    (Prims.of_int (317))
+                                                                    (Prims.of_int (328))
                                                                     (Prims.of_int (33)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (315))
+                                                                    (Prims.of_int (326))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (317))
+                                                                    (Prims.of_int (328))
                                                                     (Prims.of_int (34)))))
                                                                     (Obj.magic
                                                                     (Pulse_Syntax_Printer.term_to_string
@@ -2319,17 +2376,17 @@ let (try_frame_pre_uvs :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (315))
+                                                                    (Prims.of_int (326))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (317))
+                                                                    (Prims.of_int (328))
                                                                     (Prims.of_int (34)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (315))
+                                                                    (Prims.of_int (326))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (317))
+                                                                    (Prims.of_int (328))
                                                                     (Prims.of_int (34)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -2337,9 +2394,9 @@ let (try_frame_pre_uvs :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (316))
+                                                                    (Prims.of_int (327))
                                                                     (Prims.of_int (11))
-                                                                    (Prims.of_int (316))
+                                                                    (Prims.of_int (327))
                                                                     (Prims.of_int (34)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -2406,17 +2463,17 @@ let (try_frame_pre_uvs :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (320))
+                                                                    (Prims.of_int (331))
                                                                     (Prims.of_int (82))
-                                                                    (Prims.of_int (320))
+                                                                    (Prims.of_int (331))
                                                                     (Prims.of_int (102)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (320))
+                                                                    (Prims.of_int (331))
                                                                     (Prims.of_int (105))
-                                                                    (Prims.of_int (360))
+                                                                    (Prims.of_int (371))
                                                                     (Prims.of_int (88)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -2435,17 +2492,17 @@ let (try_frame_pre_uvs :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (322))
+                                                                    (Prims.of_int (333))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (322))
+                                                                    (Prims.of_int (333))
                                                                     (Prims.of_int (18)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (322))
+                                                                    (Prims.of_int (333))
                                                                     (Prims.of_int (21))
-                                                                    (Prims.of_int (360))
+                                                                    (Prims.of_int (371))
                                                                     (Prims.of_int (88)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -2461,17 +2518,17 @@ let (try_frame_pre_uvs :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (323))
+                                                                    (Prims.of_int (334))
                                                                     (Prims.of_int (11))
-                                                                    (Prims.of_int (323))
+                                                                    (Prims.of_int (334))
                                                                     (Prims.of_int (21)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (323))
+                                                                    (Prims.of_int (334))
                                                                     (Prims.of_int (24))
-                                                                    (Prims.of_int (360))
+                                                                    (Prims.of_int (371))
                                                                     (Prims.of_int (88)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -2488,17 +2545,17 @@ let (try_frame_pre_uvs :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (324))
+                                                                    (Prims.of_int (335))
                                                                     (Prims.of_int (11))
-                                                                    (Prims.of_int (324))
+                                                                    (Prims.of_int (335))
                                                                     (Prims.of_int (42)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (325))
+                                                                    (Prims.of_int (336))
                                                                     (Prims.of_int (31))
-                                                                    (Prims.of_int (360))
+                                                                    (Prims.of_int (371))
                                                                     (Prims.of_int (88)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -2517,17 +2574,17 @@ let (try_frame_pre_uvs :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (326))
+                                                                    (Prims.of_int (337))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (326))
+                                                                    (Prims.of_int (337))
                                                                     (Prims.of_int (75)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (326))
+                                                                    (Prims.of_int (337))
                                                                     (Prims.of_int (78))
-                                                                    (Prims.of_int (360))
+                                                                    (Prims.of_int (371))
                                                                     (Prims.of_int (88)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -2549,17 +2606,17 @@ let (try_frame_pre_uvs :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (328))
+                                                                    (Prims.of_int (339))
                                                                     (Prims.of_int (29))
-                                                                    (Prims.of_int (328))
+                                                                    (Prims.of_int (339))
                                                                     (Prims.of_int (73)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (328))
+                                                                    (Prims.of_int (339))
                                                                     (Prims.of_int (76))
-                                                                    (Prims.of_int (360))
+                                                                    (Prims.of_int (371))
                                                                     (Prims.of_int (88)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -2577,17 +2634,17 @@ let (try_frame_pre_uvs :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (333))
+                                                                    (Prims.of_int (344))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (333))
+                                                                    (Prims.of_int (344))
                                                                     (Prims.of_int (104)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (340))
+                                                                    (Prims.of_int (351))
                                                                     (Prims.of_int (35))
-                                                                    (Prims.of_int (360))
+                                                                    (Prims.of_int (371))
                                                                     (Prims.of_int (88)))))
                                                                     (Obj.magic
                                                                     (Pulse_Checker_Base.continuation_elaborator_with_bind
@@ -2678,13 +2735,13 @@ let (try_frame_pre :
               (FStar_Sealed.seal
                  (Obj.magic
                     (FStar_Range.mk_range "Pulse.Checker.Prover.fst"
-                       (Prims.of_int (369)) (Prims.of_int (12))
-                       (Prims.of_int (369)) (Prims.of_int (32)))))
+                       (Prims.of_int (380)) (Prims.of_int (12))
+                       (Prims.of_int (380)) (Prims.of_int (32)))))
               (FStar_Sealed.seal
                  (Obj.magic
                     (FStar_Range.mk_range "Pulse.Checker.Prover.fst"
-                       (Prims.of_int (371)) (Prims.of_int (2))
-                       (Prims.of_int (371)) (Prims.of_int (48)))))
+                       (Prims.of_int (382)) (Prims.of_int (2))
+                       (Prims.of_int (382)) (Prims.of_int (48)))))
               (FStar_Tactics_Effect.lift_div_tac
                  (fun uu___ ->
                     Pulse_Typing_Env.mk_env (Pulse_Typing_Env.fstar_env g)))
@@ -2710,13 +2767,13 @@ let (prove_post_hint :
               (FStar_Sealed.seal
                  (Obj.magic
                     (FStar_Range.mk_range "Pulse.Checker.Prover.fst"
-                       (Prims.of_int (380)) (Prims.of_int (10))
-                       (Prims.of_int (380)) (Prims.of_int (46)))))
+                       (Prims.of_int (391)) (Prims.of_int (10))
+                       (Prims.of_int (391)) (Prims.of_int (46)))))
               (FStar_Sealed.seal
                  (Obj.magic
                     (FStar_Range.mk_range "Pulse.Checker.Prover.fst"
-                       (Prims.of_int (382)) (Prims.of_int (2))
-                       (Prims.of_int (436)) (Prims.of_int (99)))))
+                       (Prims.of_int (393)) (Prims.of_int (2))
+                       (Prims.of_int (447)) (Prims.of_int (99)))))
               (FStar_Tactics_Effect.lift_div_tac
                  (fun uu___ ->
                     Pulse_Typing_Env.push_context g "prove_post_hint" rng))
@@ -2736,17 +2793,17 @@ let (prove_post_hint :
                                    (Obj.magic
                                       (FStar_Range.mk_range
                                          "Pulse.Checker.Prover.fst"
-                                         (Prims.of_int (385))
+                                         (Prims.of_int (396))
                                          (Prims.of_int (79))
-                                         (Prims.of_int (385))
+                                         (Prims.of_int (396))
                                          (Prims.of_int (80)))))
                                 (FStar_Sealed.seal
                                    (Obj.magic
                                       (FStar_Range.mk_range
                                          "Pulse.Checker.Prover.fst"
-                                         (Prims.of_int (384))
+                                         (Prims.of_int (395))
                                          (Prims.of_int (21))
-                                         (Prims.of_int (436))
+                                         (Prims.of_int (447))
                                          (Prims.of_int (99)))))
                                 (FStar_Tactics_Effect.lift_div_tac
                                    (fun uu___ -> r))
@@ -2765,17 +2822,17 @@ let (prove_post_hint :
                                                   (Obj.magic
                                                      (FStar_Range.mk_range
                                                         "Pulse.Checker.Prover.fst"
-                                                        (Prims.of_int (387))
+                                                        (Prims.of_int (398))
                                                         (Prims.of_int (17))
-                                                        (Prims.of_int (387))
+                                                        (Prims.of_int (398))
                                                         (Prims.of_int (44)))))
                                                (FStar_Sealed.seal
                                                   (Obj.magic
                                                      (FStar_Range.mk_range
                                                         "Pulse.Checker.Prover.fst"
-                                                        (Prims.of_int (387))
+                                                        (Prims.of_int (398))
                                                         (Prims.of_int (47))
-                                                        (Prims.of_int (436))
+                                                        (Prims.of_int (447))
                                                         (Prims.of_int (99)))))
                                                (FStar_Tactics_Effect.lift_div_tac
                                                   (fun uu___1 ->
@@ -2789,17 +2846,17 @@ let (prove_post_hint :
                                                              (Obj.magic
                                                                 (FStar_Range.mk_range
                                                                    "Pulse.Checker.Prover.fst"
-                                                                   (Prims.of_int (388))
+                                                                   (Prims.of_int (399))
                                                                    (Prims.of_int (27))
-                                                                   (Prims.of_int (388))
+                                                                   (Prims.of_int (399))
                                                                    (Prims.of_int (66)))))
                                                           (FStar_Sealed.seal
                                                              (Obj.magic
                                                                 (FStar_Range.mk_range
                                                                    "Pulse.Checker.Prover.fst"
-                                                                   (Prims.of_int (391))
+                                                                   (Prims.of_int (402))
                                                                    (Prims.of_int (4))
-                                                                   (Prims.of_int (436))
+                                                                   (Prims.of_int (447))
                                                                    (Prims.of_int (99)))))
                                                           (FStar_Tactics_Effect.lift_div_tac
                                                              (fun uu___1 ->
@@ -2825,17 +2882,17 @@ let (prove_post_hint :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (394))
+                                                                    (Prims.of_int (405))
                                                                     (Prims.of_int (28))
-                                                                    (Prims.of_int (400))
+                                                                    (Prims.of_int (411))
                                                                     (Prims.of_int (7)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (394))
+                                                                    (Prims.of_int (405))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (400))
+                                                                    (Prims.of_int (411))
                                                                     (Prims.of_int (7)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -2843,17 +2900,17 @@ let (prove_post_hint :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (394))
+                                                                    (Prims.of_int (405))
                                                                     (Prims.of_int (28))
-                                                                    (Prims.of_int (400))
+                                                                    (Prims.of_int (411))
                                                                     (Prims.of_int (7)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (394))
+                                                                    (Prims.of_int (405))
                                                                     (Prims.of_int (28))
-                                                                    (Prims.of_int (400))
+                                                                    (Prims.of_int (411))
                                                                     (Prims.of_int (7)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -2861,17 +2918,17 @@ let (prove_post_hint :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (396))
+                                                                    (Prims.of_int (407))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (399))
+                                                                    (Prims.of_int (410))
                                                                     (Prims.of_int (38)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (394))
+                                                                    (Prims.of_int (405))
                                                                     (Prims.of_int (28))
-                                                                    (Prims.of_int (400))
+                                                                    (Prims.of_int (411))
                                                                     (Prims.of_int (7)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -2879,17 +2936,17 @@ let (prove_post_hint :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (397))
+                                                                    (Prims.of_int (408))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (399))
+                                                                    (Prims.of_int (410))
                                                                     (Prims.of_int (38)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (396))
+                                                                    (Prims.of_int (407))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (399))
+                                                                    (Prims.of_int (410))
                                                                     (Prims.of_int (38)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -2897,17 +2954,17 @@ let (prove_post_hint :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (397))
+                                                                    (Prims.of_int (408))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (397))
+                                                                    (Prims.of_int (408))
                                                                     (Prims.of_int (24)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (397))
+                                                                    (Prims.of_int (408))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (399))
+                                                                    (Prims.of_int (410))
                                                                     (Prims.of_int (38)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -2915,17 +2972,17 @@ let (prove_post_hint :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (397))
+                                                                    (Prims.of_int (408))
                                                                     (Prims.of_int (17))
-                                                                    (Prims.of_int (397))
+                                                                    (Prims.of_int (408))
                                                                     (Prims.of_int (24)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (397))
+                                                                    (Prims.of_int (408))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (397))
+                                                                    (Prims.of_int (408))
                                                                     (Prims.of_int (24)))))
                                                                     (Obj.magic
                                                                     (Pulse_PP.pp
@@ -2948,17 +3005,17 @@ let (prove_post_hint :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (398))
+                                                                    (Prims.of_int (409))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (399))
+                                                                    (Prims.of_int (410))
                                                                     (Prims.of_int (38)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (397))
+                                                                    (Prims.of_int (408))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (399))
+                                                                    (Prims.of_int (410))
                                                                     (Prims.of_int (38)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -2966,17 +3023,17 @@ let (prove_post_hint :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (399))
+                                                                    (Prims.of_int (410))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (399))
+                                                                    (Prims.of_int (410))
                                                                     (Prims.of_int (38)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (398))
+                                                                    (Prims.of_int (409))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (399))
+                                                                    (Prims.of_int (410))
                                                                     (Prims.of_int (38)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -2984,17 +3041,17 @@ let (prove_post_hint :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (399))
+                                                                    (Prims.of_int (410))
                                                                     (Prims.of_int (17))
-                                                                    (Prims.of_int (399))
+                                                                    (Prims.of_int (410))
                                                                     (Prims.of_int (38)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (399))
+                                                                    (Prims.of_int (410))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (399))
+                                                                    (Prims.of_int (410))
                                                                     (Prims.of_int (38)))))
                                                                     (Obj.magic
                                                                     (Pulse_PP.pp
@@ -3087,17 +3144,17 @@ let (prove_post_hint :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (405))
+                                                                    (Prims.of_int (416))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (405))
+                                                                    (Prims.of_int (416))
                                                                     (Prims.of_int (93)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (403))
+                                                                    (Prims.of_int (414))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (436))
+                                                                    (Prims.of_int (447))
                                                                     (Prims.of_int (99)))))
                                                                     (Obj.magic
                                                                     (prove g2
@@ -3126,17 +3183,17 @@ let (prove_post_hint :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (410))
+                                                                    (Prims.of_int (421))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (410))
+                                                                    (Prims.of_int (421))
                                                                     (Prims.of_int (27)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (412))
+                                                                    (Prims.of_int (423))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (436))
+                                                                    (Prims.of_int (447))
                                                                     (Prims.of_int (99)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -3163,17 +3220,17 @@ let (prove_post_hint :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (415))
+                                                                    (Prims.of_int (426))
                                                                     (Prims.of_int (30))
-                                                                    (Prims.of_int (422))
+                                                                    (Prims.of_int (433))
                                                                     (Prims.of_int (9)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (415))
+                                                                    (Prims.of_int (426))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (422))
+                                                                    (Prims.of_int (433))
                                                                     (Prims.of_int (9)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -3181,17 +3238,17 @@ let (prove_post_hint :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (415))
+                                                                    (Prims.of_int (426))
                                                                     (Prims.of_int (30))
-                                                                    (Prims.of_int (422))
+                                                                    (Prims.of_int (433))
                                                                     (Prims.of_int (9)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (415))
+                                                                    (Prims.of_int (426))
                                                                     (Prims.of_int (30))
-                                                                    (Prims.of_int (422))
+                                                                    (Prims.of_int (433))
                                                                     (Prims.of_int (9)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -3199,17 +3256,17 @@ let (prove_post_hint :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (417))
+                                                                    (Prims.of_int (428))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (418))
+                                                                    (Prims.of_int (429))
                                                                     (Prims.of_int (38)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (415))
+                                                                    (Prims.of_int (426))
                                                                     (Prims.of_int (30))
-                                                                    (Prims.of_int (422))
+                                                                    (Prims.of_int (433))
                                                                     (Prims.of_int (9)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -3217,17 +3274,17 @@ let (prove_post_hint :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (418))
+                                                                    (Prims.of_int (429))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (418))
+                                                                    (Prims.of_int (429))
                                                                     (Prims.of_int (38)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (417))
+                                                                    (Prims.of_int (428))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (418))
+                                                                    (Prims.of_int (429))
                                                                     (Prims.of_int (38)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -3235,17 +3292,17 @@ let (prove_post_hint :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (418))
+                                                                    (Prims.of_int (429))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (418))
+                                                                    (Prims.of_int (429))
                                                                     (Prims.of_int (38)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (418))
+                                                                    (Prims.of_int (429))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (418))
+                                                                    (Prims.of_int (429))
                                                                     (Prims.of_int (38)))))
                                                                     (Obj.magic
                                                                     (Pulse_PP.pp


### PR DESCRIPTION
To handle some unexpected behaviors noticed in https://github.com/FStarLang/steel/issues/137 and https://github.com/FStarLang/steel/pull/135.