### PR TITLE
More support for unobservable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,4 +117,6 @@ boot:
 	+$(MAKE) verify-pulse
 	+$(MAKE) -C src extract-pulse-plugin
 	+$(MAKE) ocaml
-  
+
+ci:
+	+$(MAKE) -C src ci

--- a/lib/steel/pulse/Pulse.Checker.Abs.fst
+++ b/lib/steel/pulse/Pulse.Checker.Abs.fst
@@ -207,6 +207,7 @@ let check_effect_annotation g r (asc:comp_ascription) (c_computed:comp) : T.Tac 
     | C_ST _, C_ST _ -> nop
 
     | C_STAtomic i Observable c1, C_STAtomic j Observable c2
+    | C_STAtomic i Unobservable c1, C_STAtomic j Unobservable c2
     | C_STGhost i c1, C_STGhost j c2 ->
       // This should be true since we used the annotated computation type
       // to check the body of the function, but this fact is not exposed
@@ -238,7 +239,7 @@ let check_effect_annotation g r (asc:comp_ascription) (c_computed:comp) : T.Tac 
       let d_sub : st_sub g c_computed c =
         match c_computed with
         | C_STGhost _ _ -> STS_GhostInvs g c2 j i tok
-        | C_STAtomic _ obs _ -> STS_AtomicInvs g c2 j i Observable Observable tok
+        | C_STAtomic _ obs _ -> STS_AtomicInvs g c2 j i obs obs tok
       in
       (| c, d_sub |)
 

--- a/lib/steel/pulse/Pulse.Checker.Abs.fst
+++ b/lib/steel/pulse/Pulse.Checker.Abs.fst
@@ -32,6 +32,7 @@ module RU = Pulse.RuntimeUtils
 module Env = Pulse.Typing.Env
 module U = Pulse.Syntax.Pure
 
+open Pulse.Show
 
 let debug_abs g (s: unit -> T.Tac string) : T.Tac unit =
   if RU.debug_at_level (fstar_env g) "pulse.abs"
@@ -197,6 +198,25 @@ let preprocess_abs
                  (Printf.sprintf "Expected an arrow type as an annotation, got %s"
                           (P.term_to_string annot))
 
+let sub_effect_comp g r (asc:comp_ascription) (c_computed:comp) : T.Tac (option (c2:comp & lift_comp g c_computed c2)) =
+  let nop = None in
+  match asc.elaborated with
+  | None -> nop
+  | Some c ->
+    match c_computed, c with
+    | C_Tot t1, C_Tot t2 -> nop
+    | C_ST _, C_ST _ -> nop
+    | C_STAtomic i Observable c1, C_STAtomic j Observable c2 -> nop
+    | C_STAtomic i Unobservable c1, C_STAtomic j Unobservable c2 -> nop
+    | C_STGhost i c1, C_STGhost j c2 -> nop
+
+    | C_STAtomic i Unobservable c1, C_STAtomic _ Observable _ ->
+      let lift = Lift_STUnobservable_STAtomic g c_computed in
+      Some (| C_STAtomic i Observable c1, lift |)
+
+    (* FIXME: more lifts here *) 
+    | _ -> nop
+
 let check_effect_annotation g r (asc:comp_ascription) (c_computed:comp) : T.Tac (c2:comp & st_sub g c_computed c2) =
   let nop = (| c_computed, STS_Refl _ _ |) in
   match asc.elaborated with
@@ -308,6 +328,15 @@ let rec check_abs_core
       (* Check the opened body *)
       let (| body, c_body, body_typing |) = check_abs_core g' body_opened check in
 
+      (* First lift into annotated effect *)
+      let (| c_body, body_typing |) : ( c_body:comp & st_typing g' body c_body ) =
+        match sub_effect_comp g' body.range asc c_body with
+        | None -> (| c_body, body_typing |)
+        | Some (| c_body, lift |) ->
+          let body_typing = T_Lift _ _ _ _ body_typing lift in
+          (| c_body, body_typing |)
+      in
+
       (* Check if it matches annotation (if any, likely not), and adjust derivation
       if needed. Currently this only subtypes the invariants. *)
       let (| c_body, d_sub |) = check_effect_annotation g' body.range asc c_body in
@@ -370,6 +399,16 @@ let rec check_abs_core
         apply_checker_result_k #_ #_ #(Some?.v post) r ppname_ret in
 
       let c_opened : comp_ascription = { annotated = None; elaborated = Some (open_comp_nv elab_c px) } in
+
+      (* First lift into annotated effect *)
+      let (| c_body, body_typing |) : ( c_body:comp & st_typing g' body c_body ) =
+        match sub_effect_comp g' body.range c_opened c_body with
+        | None -> (| c_body, body_typing |)
+        | Some (| c_body, lift |) ->
+          let body_typing = T_Lift _ _ _ _ body_typing lift in
+          (| c_body, body_typing |)
+      in
+
       let (| c_body, d_sub |) = check_effect_annotation g' body.range c_opened c_body in
       let body_typing = T_Sub _ _ _ _ body_typing d_sub in
 

--- a/lib/steel/pulse/Pulse.Checker.If.fst
+++ b/lib/steel/pulse/Pulse.Checker.If.fst
@@ -73,7 +73,7 @@ let lift_ghost_to_atomic
   let w = get_non_informative_witness g (comp_u c) (comp_res c) in
   let c' = C_STAtomic inames Unobservable c_st in
   let d' : st_typing g e c' =
-    T_Lift g e c c' d (Lift_STGhost_STAtomic g c w)
+    T_Lift g e c c' d (Lift_STGhost_STUnobservable g c w)
   in
   (| c', d' |)
 

--- a/lib/steel/pulse/Pulse.Checker.WithInv.fst
+++ b/lib/steel/pulse/Pulse.Checker.WithInv.fst
@@ -216,7 +216,7 @@ let check
   let tm : st_term =
     { term = Tm_WithInv {name=inv_tm; body; returns_inv = None};
       range = t.range;
-      effect_tag = Sealed.seal (Some STT_Atomic) } // fix
+      effect_tag = Sealed.seal ctag_hint' }
   in
 
   let tok = check_iname_disjoint g inv_tm_range inv_p (comp_inames c_body) { inv_tm with range = inv_tm_range } in

--- a/lib/steel/pulse/Pulse.Checker.WithInv.fst
+++ b/lib/steel/pulse/Pulse.Checker.WithInv.fst
@@ -168,10 +168,10 @@ let check
   in
   let post_p'_typing = Pulse.Checker.Base.post_typing_as_abstraction (E post_p'_typing_src) in
   let ctag_hint' =
-    // if None? post.ctag_hint || post.ctag_hint = Some STT then
+    if None? post.ctag_hint || post.ctag_hint = Some STT then
       Some STT_Atomic
-    // else
-    //   post.ctag_hint
+    else
+      post.ctag_hint
   in
 
 
@@ -208,7 +208,7 @@ let check
                `with_invariants` blocks can only contain atomic computations.";
          prefix 4 1 (text "Computed type:") (arbitrary_string (P.comp_to_string c_body))]
     | C_STAtomic inames obs st ->
-      C_STAtomic inames Observable (st_comp_remove_inv inv_p st)
+      C_STAtomic inames obs (st_comp_remove_inv inv_p st)
   //  | C_STGhost inames st -> C_STAtomic (add_iname inames inv_tm) Observable (st_comp_remove_inv inv_p st)
   in
   assume (add_inv c_out inv_p == c_body);

--- a/lib/steel/pulse/Pulse.Elaborate.Core.fst
+++ b/lib/steel/pulse/Pulse.Elaborate.Core.fst
@@ -120,9 +120,9 @@ let elab_lift #g #c1 #c2 (d:lift_comp g c1 c2) (e:R.term)
         (mk_abs t R.Q_Explicit (elab_term (comp_post c1)))
         e
         
-    | Lift_STGhost_STAtomic _ _ (| reveal_a, reveal_a_typing |) ->
+    | Lift_STGhost_STUnobservable _ _ (| reveal_a, reveal_a_typing |) ->
       let t = elab_term (comp_res c1) in
-      mk_lift_ghost_atomic
+      mk_lift_ghost_unobservable
         (comp_u c1)
         t
         (elab_term (comp_inames c1))
@@ -130,6 +130,16 @@ let elab_lift #g #c1 #c2 (d:lift_comp g c1 c2) (e:R.term)
         (mk_abs t R.Q_Explicit (elab_term (comp_post c1)))
         e
         (elab_term reveal_a)
+
+    | Lift_STUnobservable_STAtomic _ _ ->
+      let t = elab_term (comp_res c1) in
+      mk_lift_unobservable_atomic
+        (comp_u c1)
+        t
+        (elab_term (comp_inames c1))
+        (elab_term (comp_pre c1))
+        (mk_abs t R.Q_Explicit (elab_term (comp_post c1)))
+        e
 
 let intro_pure_tm (p:term) =
   let open Pulse.Reflection.Util in

--- a/lib/steel/pulse/Pulse.Reflection.Util.fst
+++ b/lib/steel/pulse/Pulse.Reflection.Util.fst
@@ -371,10 +371,10 @@ let mk_lift_atomic_stt (u:R.universe) (a pre post e:R.term)  =
   let t = pack_ln (R.Tv_App t (post, Q_Implicit)) in
   pack_ln (R.Tv_App t (e, Q_Explicit))
 
-// Wrapper.lift_stt_ghost<u> #a #opened #pre #post e reveal_a
-let mk_lift_ghost_atomic (u:R.universe) (a opened pre post e reveal_a:R.term) =
+// Wrapper.lift_ghost_unobservable<u> #a #opened #pre #post e reveal_a
+let mk_lift_ghost_unobservable (u:R.universe) (a opened pre post e reveal_a:R.term) =
   let open R in
-  let lid = mk_pulse_lib_core_lid "lift_stt_ghost" in
+  let lid = mk_pulse_lib_core_lid "lift_ghost_unobservable" in
   let t = pack_ln (R.Tv_UInst (R.pack_fv lid) [u]) in
   let t = pack_ln (R.Tv_App t (a, Q_Implicit)) in
   let t = pack_ln (R.Tv_App t (opened, Q_Implicit)) in
@@ -382,6 +382,17 @@ let mk_lift_ghost_atomic (u:R.universe) (a opened pre post e reveal_a:R.term) =
   let t = pack_ln (R.Tv_App t (post, Q_Implicit)) in
   let t = pack_ln (R.Tv_App t (e, Q_Explicit)) in
   pack_ln (R.Tv_App t (reveal_a, Q_Explicit))
+
+// Wrapper.lift_ghost_unobservable<u> #a #opened #pre #post e
+let mk_lift_unobservable_atomic (u:R.universe) (a opened pre post e : R.term) =
+  let open R in
+  let lid = mk_pulse_lib_core_lid "lift_unobservable_atomic" in
+  let t = pack_ln (R.Tv_UInst (R.pack_fv lid) [u]) in
+  let t = pack_ln (R.Tv_App t (a, Q_Implicit)) in
+  let t = pack_ln (R.Tv_App t (opened, Q_Implicit)) in
+  let t = pack_ln (R.Tv_App t (pre, Q_Implicit)) in
+  let t = pack_ln (R.Tv_App t (post, Q_Implicit)) in
+  pack_ln (R.Tv_App t (e, Q_Explicit))
 
 // Wrapper.bind_stt<u1, u2> #a #b #pre1 #post1 #post2 e1 e2
 let mk_bind_stt

--- a/lib/steel/pulse/Pulse.Soundness.Lift.fst
+++ b/lib/steel/pulse/Pulse.Soundness.Lift.fst
@@ -25,13 +25,13 @@ open Pulse.Typing
 open Pulse.Elaborate
 open Pulse.Soundness.Common
 
-let elab_lift_stt_atomic_typing (g:stt_env)
+let elab_lift_stt_atomic_st_typing (g:stt_env)
   (c1 c2:ln_comp)
   (e:R.term)
   (e_typing:RT.tot_typing (elab_env g) e (elab_comp c1))
   (lc:lift_comp g c1 c2) = admit ()
 
-let elab_lift_stt_ghost_typing (g:stt_env)
+let elab_lift_stt_ghost_unobservable_typing (g:stt_env)
   (c1 c2:ln_comp)
   (e:R.term)
   (e_typing:RT.tot_typing (elab_env g) e (elab_comp c1))
@@ -40,3 +40,9 @@ let elab_lift_stt_ghost_typing (g:stt_env)
   (reveal_a_typing:RT.tot_typing (elab_env g) reveal_a
                                  (non_informative_witness_rt (comp_u c1)
                                                              (elab_term (comp_res c1)))) = admit ()
+
+let elab_lift_stt_unobservable_atomic_typing (g:stt_env)
+  (c1 c2:ln_comp)
+  (e:R.term)
+  (e_typing:RT.tot_typing (elab_env g) e (elab_comp c1))
+  (lc:lift_comp g c1 c2) = admit ()

--- a/lib/steel/pulse/Pulse.Soundness.Lift.fsti
+++ b/lib/steel/pulse/Pulse.Soundness.Lift.fsti
@@ -28,7 +28,7 @@ open Pulse.Soundness.Common
 
 (*** Soundness of lift elaboration *)
 
-val elab_lift_stt_atomic_typing
+val elab_lift_stt_atomic_st_typing
       (g:stt_env)
       (c1 c2:ln_comp)
       (e:R.term)
@@ -38,7 +38,7 @@ val elab_lift_stt_atomic_typing
           (requires Lift_STAtomic_ST? lc)
           (ensures fun _ -> True)
 
-val elab_lift_stt_ghost_typing
+val elab_lift_stt_ghost_unobservable_typing
       (g:stt_env)
       (c1 c2:ln_comp)
       (e:R.term)
@@ -49,5 +49,15 @@ val elab_lift_stt_ghost_typing
                                      (non_informative_witness_rt (comp_u c1)
                                                                  (elab_term (comp_res c1))))
     : Ghost (RT.tot_typing (elab_env g) (elab_lift lc e) (elab_comp c2))
-          (requires Lift_STGhost_STAtomic? lc)
+          (requires Lift_STGhost_STUnobservable? lc)
+          (ensures fun _ -> True)
+
+val elab_lift_stt_unobservable_atomic_typing
+      (g:stt_env)
+      (c1 c2:ln_comp)
+      (e:R.term)
+      (e_typing:RT.tot_typing (elab_env g) e (elab_comp c1))
+      (lc:lift_comp g c1 c2)
+    : Ghost (RT.tot_typing (elab_env g) (elab_lift lc e) (elab_comp c2))
+          (requires Lift_STUnobservable_STAtomic? lc)
           (ensures fun _ -> True)

--- a/lib/steel/pulse/Pulse.Soundness.fst
+++ b/lib/steel/pulse/Pulse.Soundness.fst
@@ -74,13 +74,18 @@ let lift_soundness
   LN.st_typing_ln e_typing;
   match lc with
   | Lift_STAtomic_ST _ _ ->
-    Lift.elab_lift_stt_atomic_typing g
+    Lift.elab_lift_stt_atomic_st_typing g
       c1 c2 _ (soundness _ _ _ e_typing) lc
-  | Lift_STGhost_STAtomic _ _ w ->
+
+  | Lift_STGhost_STUnobservable _ _ w ->
     let (| reveal_a, reveal_a_typing |) = w in
-    Lift.elab_lift_stt_ghost_typing g
+    Lift.elab_lift_stt_ghost_unobservable_typing g
       c1 c2 _ (soundness _ _ _ e_typing) lc
       _ (tot_typing_soundness reveal_a_typing)
+
+  | Lift_STUnobservable_STAtomic _ _ ->
+    Lift.elab_lift_stt_unobservable_atomic_typing g
+      c1 c2 _ (soundness _ _ _ e_typing) lc
 
 let frame_soundness
   (g:stt_env)

--- a/lib/steel/pulse/Pulse.Typing.Combinators.fst
+++ b/lib/steel/pulse/Pulse.Typing.Combinators.fst
@@ -326,8 +326,7 @@ let rec mk_bind (g:env)
     if at_most_one_observable obs1 obs2
     then (
       mk_bind_atomic_atomic g pre e1 e2 c1 c2 px d_e1 d_c1res d_e2 res_typing post_typing
-    )
-    else (
+    ) else (
       let c1lifted = C_ST (st_comp_of_comp c1) in
       let d_e1 : st_typing g e1 c1lifted =
         T_Lift _ _ _ c1lifted d_e1 (Lift_STAtomic_ST _ c1) in
@@ -340,8 +339,13 @@ let rec mk_bind (g:env)
     mk_bind g pre e1 e2 c1lifted c2 px d_e1 d_c1res d_e2 res_typing post_typing
   | C_STGhost _ _, C_STAtomic _ _ _ ->
     mk_bind_ghost_atomic g pre e1 e2 c1 c2 px d_e1 d_c1res d_e2 res_typing post_typing
+
   | C_STAtomic inames1 _ _, C_STGhost inames2 _ ->
     mk_bind_atomic_ghost g pre e1 e2 c1 c2 px d_e1 d_c1res d_e2 res_typing post_typing
+
+  | C_STAtomic inames1 _ _, C_STGhost inames2 _ ->
+    mk_bind_atomic_ghost g pre e1 e2 c1 c2 px d_e1 d_c1res d_e2 res_typing post_typing
+
   | C_ST _, C_STAtomic inames _ _ ->
     let c2lifted = C_ST (st_comp_of_comp c2) in
     let g' = push_binding g x (fst px) (comp_res c1) in
@@ -354,7 +358,7 @@ let rec mk_bind (g:env)
       let w = get_non_informative_witness g (comp_u c1) (comp_res c1) in
       let c1lifted = C_STAtomic inames Unobservable (st_comp_of_comp c1) in
       let d_e1 : st_typing g e1 c1lifted =
-        T_Lift _ _ _ c1lifted d_e1 (Lift_STGhost_STAtomic g c1 w) in
+        T_Lift _ _ _ c1lifted d_e1 (Lift_STGhost_STUnobservable g c1 w) in
       mk_bind g pre e1 e2 c1lifted c2 px d_e1 d_c1res d_e2 res_typing post_typing
     end
   | C_ST _, C_STGhost inames _ ->
@@ -362,7 +366,7 @@ let rec mk_bind (g:env)
     let w = get_non_informative_witness g' (comp_u c2) (comp_res c2) in
     let c2lifted = C_STAtomic inames Unobservable (st_comp_of_comp c2) in
     let d_e2 : st_typing g' (open_st_term_nv e2 px) c2lifted =
-      T_Lift _ _ _ c2lifted d_e2 (Lift_STGhost_STAtomic g' c2 w) in
+      T_Lift _ _ _ c2lifted d_e2 (Lift_STGhost_STUnobservable g' c2 w) in
     let (| t, c, d |) = mk_bind g pre e1 e2 c1 c2lifted px d_e1 d_c1res d_e2 res_typing post_typing in
     (| t, c, d |)
   | _, _ -> fail g None "bind either not implemented (e.g. ghost) or not possible"

--- a/lib/steel/pulse/Pulse.Typing.Metatheory.Base.fst
+++ b/lib/steel/pulse/Pulse.Typing.Metatheory.Base.fst
@@ -128,8 +128,9 @@ let lift_comp_weakening (g:env) (g':env { disjoint g g'})
   
   match d with
   | Lift_STAtomic_ST _ c -> Lift_STAtomic_ST _ c
-  | Lift_STGhost_STAtomic _ c non_informative_c ->
-    Lift_STGhost_STAtomic _ c (non_informative_c_weakening g g' g1 _ non_informative_c)
+  | Lift_STGhost_STUnobservable _ c non_informative_c ->
+    Lift_STGhost_STUnobservable _ c (non_informative_c_weakening g g' g1 _ non_informative_c)
+  | Lift_STUnobservable_STAtomic _ c -> Lift_STUnobservable_STAtomic _ c
 
 #push-options "--admit_smt_queries true"
 let st_equiv_weakening (g:env) (g':env { disjoint g g' })
@@ -541,9 +542,12 @@ let lift_comp_subst
   | Lift_STAtomic_ST _ c ->
     Lift_STAtomic_ST _ (subst_comp c ss)
 
-  | Lift_STGhost_STAtomic _ c d_non_informative ->
-    Lift_STGhost_STAtomic _ (subst_comp c ss)
+  | Lift_STGhost_STUnobservable _ c d_non_informative ->
+    Lift_STGhost_STUnobservable _ (subst_comp c ss)
       (non_informative_c_subst g x t g' e_typing _ d_non_informative)
+
+  | Lift_STUnobservable_STAtomic _ c ->
+    Lift_STUnobservable_STAtomic _ (subst_comp c ss)
 
 let bind_comp_subst
   (g:env) (x:var) (t:typ) (g':env { pairwise_disjoint g (singleton_env (fstar_env g) x t) g' })

--- a/lib/steel/pulse/Pulse.Typing.fst
+++ b/lib/steel/pulse/Pulse.Typing.fst
@@ -663,7 +663,14 @@ type lift_comp : env -> comp -> comp -> Type =
       c:comp_st{C_STAtomic? c} -> // Note: we no longer require an empty set of invariants, due to the positive view
       lift_comp g c (C_ST (st_comp_of_comp c))
 
-  | Lift_STGhost_STAtomic :
+  | Lift_STUnobservable_STAtomic :
+      g:env ->
+      c:comp_st{C_STAtomic? c /\ C_STAtomic?.obs c == Unobservable} ->
+      lift_comp g
+        (C_STAtomic (comp_inames c) Unobservable (st_comp_of_comp c))
+        (C_STAtomic (comp_inames c) Observable (st_comp_of_comp c))
+
+  | Lift_STGhost_STUnobservable :
       g:env ->
       c:comp_st{C_STGhost? c} ->
       non_informative_c:non_informative_c g c ->

--- a/share/steel/examples/pulse/Invariant.fst
+++ b/share/steel/examples/pulse/Invariant.fst
@@ -24,6 +24,7 @@ module Invariant
 // #set-options "--trace_error"
 open Pulse.Lib.Pervasives
 open Pulse.Lib.Reference
+open Pulse.Lib
 
 let test (i:inv emp) = assert (
   (add_inv emp_inames i)
@@ -31,15 +32,31 @@ let test (i:inv emp) = assert (
   ((join_inames (((add_inv #emp) emp_inames) i)) emp_inames)
 )
 
-// Atomic doesn't really work yet
-[@@expect_failure]
+assume
+val atomic_write_int (r : ref int) (v : int) :
+  stt_atomic unit emp_inames (exists* v0. pts_to r v0) (fun _ -> pts_to r v)
+
 ```pulse
 atomic
-fn zero (r : ref int)
+fn test_atomic (r : ref int)
   requires pts_to r 'v
   ensures pts_to r 0
 {
-  r := 0;
+  atomic_write_int r 0;
+}
+```
+
+assume
+val unobservable_write_int (r : ref int) (v : int) :
+  stt_unobservable unit emp_inames (exists* v0. pts_to r v0) (fun _ -> pts_to r v)
+
+```pulse
+unobservable
+fn test_unobservable (r : ref int)
+  requires pts_to r 'v
+  ensures pts_to r 0
+{
+  unobservable_write_int r 0;
 }
 ```
 
@@ -59,17 +76,15 @@ fn package (r:ref int)
 ```pulse
 fn test2 ()
   requires emp
-  returns v:(v:int{v == 2})
   ensures emp
 {
-  let r = alloc 123;
-  let i = package r;
-  with_invariants i ensures pure True {
+  let r = alloc #int 123;
+  let i : inv (pts_to r 123) = package r;
+  with_invariants i {
     r := 124;
     r := 123;
     ()
-  };
-  2
+  }
 }
 ```
 

--- a/share/steel/examples/pulse/bug-reports/Bug.Invariants.fst
+++ b/share/steel/examples/pulse/bug-reports/Bug.Invariants.fst
@@ -14,7 +14,6 @@ ensures emp ** pts_to x 1ul
 }
 ```
 
-[@@expect_failure] //returns in Unobservable; need to weaken to observable
 ```pulse
 atomic
 fn return_atomic2 ()

--- a/share/steel/examples/pulse/lib/Pulse.Lib.Core.fst
+++ b/share/steel/examples/pulse/lib/Pulse.Lib.Core.fst
@@ -274,13 +274,21 @@ let bind_stt_ghost_atomic #a #b #opened #pre1 #post1 #post2 e1 e2 reveal_a =
   e2 (reveal_a x) ()
 
 inline_for_extraction
-let lift_stt_ghost #a #opened #pre #post e reveal_a =
+let lift_ghost_unobservable #a #opened #pre #post e reveal_a =
   fun _ ->
   let x =
     let y = e () in
     rewrite (post y) (post (reveal_a (Ghost.hide y)));
     Ghost.hide y in
   Steel.ST.Util.return (reveal_a x)
+
+inline_for_extraction
+let lift_unobservable_atomic #a #opened #pre #post e =
+  fun _ ->
+  let x =
+    let y = e () in
+    y in
+  Steel.ST.Util.return x
 
 inline_for_extraction
 let frame_stt (#a:Type u#a) (#pre:vprop) (#post:a -> vprop) (frame:vprop) (e:stt a pre post)

--- a/share/steel/examples/pulse/lib/Pulse.Lib.Core.fsti
+++ b/share/steel/examples/pulse/lib/Pulse.Lib.Core.fsti
@@ -243,9 +243,14 @@ val bind_stt_ghost_atomic
   : stt_atomic b opens pre1 post2
 
 inline_for_extraction
-val lift_stt_ghost (#a:Type u#a) (#opens:inames) (#pre:vprop) (#post:a -> vprop)
+val lift_ghost_unobservable (#a:Type u#a) (#opens:inames) (#pre:vprop) (#post:a -> vprop)
   (e:stt_ghost a opens pre post)
   (reveal_a:(x:Ghost.erased a -> y:a{y == Ghost.reveal x}))
+  : stt_unobservable a opens pre post
+
+inline_for_extraction
+val lift_unobservable_atomic (#a:Type u#a) (#opens:inames) (#pre:vprop) (#post:a -> vprop)
+  (e:stt_unobservable a opens pre post)
   : stt_atomic a opens pre post
 
 inline_for_extraction

--- a/src/ocaml/plugin/PulseSyntaxExtension_Parser.ml
+++ b/src/ocaml/plugin/PulseSyntaxExtension_Parser.ml
@@ -19,6 +19,7 @@ let rewrite_token (tok:FP.token)
     | IDENT "rewrite" -> PP.REWRITE
     | IDENT "fold" -> PP.FOLD
     | IDENT "atomic" -> PP.ATOMIC
+    | IDENT "unobservable" -> PP.UNOBSERVABLE
     | IDENT "ghost" -> PP.GHOST
     | IDENT "with_invariants" -> PP.WITH_INVS
     | IDENT "opens" -> PP.OPENS

--- a/src/ocaml/plugin/PulseSyntaxExtension_SyntaxWrapper.ml
+++ b/src/ocaml/plugin/PulseSyntaxExtension_SyntaxWrapper.ml
@@ -82,6 +82,9 @@ let mk_comp (pre:term) (ret:binder) (post:term) : comp =
 let ghost_comp (inames:term) (pre:term) (ret:binder) (post:term) : comp =
    C_STGhost (inames, mk_st_comp pre ret post)
 
+let unobservable_comp (inames:term) (pre:term) (ret:binder) (post:term) : comp =
+   C_STAtomic (inames, Unobservable, mk_st_comp pre ret post)
+
 let atomic_comp (inames:term) (pre:term) (ret:binder) (post:term) : comp =
    C_STAtomic (inames, Observable, mk_st_comp pre ret post)
 

--- a/src/ocaml/plugin/generated/PulseSyntaxExtension_Desugar.ml
+++ b/src/ocaml/plugin/generated/PulseSyntaxExtension_Desugar.ml
@@ -70,6 +70,26 @@ let (comp_to_ast_term :
              FStar_Parser_AST.mk_term
                (FStar_Parser_AST.App (h1, is, FStar_Parser_AST.Nothing)) r
                FStar_Parser_AST.Expr
+         | PulseSyntaxExtension_Sugar.STUnobservable ->
+             let is =
+               let uu___ =
+                 let uu___1 =
+                   FStar_Ident.lid_of_str "Pulse.Lib.Core.emp_inames" in
+                 FStar_Parser_AST.Var uu___1 in
+               FStar_Parser_AST.mk_term uu___ r FStar_Parser_AST.Expr in
+             let h =
+               FStar_Parser_AST.mk_term
+                 (FStar_Parser_AST.Var
+                    PulseSyntaxExtension_Env.stt_unobservable_lid) r
+                 FStar_Parser_AST.Expr in
+             let h1 =
+               FStar_Parser_AST.mk_term
+                 (FStar_Parser_AST.App
+                    (h, return_ty, FStar_Parser_AST.Nothing)) r
+                 FStar_Parser_AST.Expr in
+             FStar_Parser_AST.mk_term
+               (FStar_Parser_AST.App (h1, is, FStar_Parser_AST.Nothing)) r
+               FStar_Parser_AST.Expr
          | PulseSyntaxExtension_Sugar.STGhost ->
              let is =
                let uu___ =
@@ -712,6 +732,24 @@ let (desugar_computation_type :
                                                                     c.PulseSyntaxExtension_Sugar.return_name
                                                                     ret1 in
                                                                     PulseSyntaxExtension_SyntaxWrapper.atomic_comp
+                                                                    opens pre
+                                                                    uu___6
+                                                                    post1 in
+                                                                    PulseSyntaxExtension_Err.return
+                                                                    uu___5))
+                                                           | PulseSyntaxExtension_Sugar.STUnobservable
+                                                               ->
+                                                               Obj.magic
+                                                                 (Obj.repr
+                                                                    (
+                                                                    let uu___5
+                                                                    =
+                                                                    let uu___6
+                                                                    =
+                                                                    PulseSyntaxExtension_SyntaxWrapper.mk_binder
+                                                                    c.PulseSyntaxExtension_Sugar.return_name
+                                                                    ret1 in
+                                                                    PulseSyntaxExtension_SyntaxWrapper.unobservable_comp
                                                                     opens pre
                                                                     uu___6
                                                                     post1 in

--- a/src/ocaml/plugin/generated/PulseSyntaxExtension_Env.ml
+++ b/src/ocaml/plugin/generated/PulseSyntaxExtension_Env.ml
@@ -24,6 +24,8 @@ let (pure_lid : FStar_Ident.lident) = pulse_lib_core_lid "pure"
 let (stt_lid : FStar_Ident.lident) = pulse_lib_core_lid "stt"
 let (assign_lid : FStar_Ident.lident) = pulse_lib_ref_lid "op_Colon_Equals"
 let (stt_ghost_lid : FStar_Ident.lident) = pulse_lib_core_lid "stt_ghost"
+let (stt_unobservable_lid : FStar_Ident.lident) =
+  pulse_lib_core_lid "stt_unobservable"
 let (stt_atomic_lid : FStar_Ident.lident) = pulse_lib_core_lid "stt_atomic"
 let (op_colon_equals_lid :
   FStar_Compiler_Range_Type.range -> FStar_Ident.lident) =

--- a/src/ocaml/plugin/generated/PulseSyntaxExtension_Sugar.ml
+++ b/src/ocaml/plugin/generated/PulseSyntaxExtension_Sugar.ml
@@ -20,11 +20,15 @@ let (as_vprop : vprop' -> rng -> vprop) = fun v -> fun r -> { v; vrange = r }
 type st_comp_tag =
   | ST 
   | STAtomic 
+  | STUnobservable 
   | STGhost 
 let (uu___is_ST : st_comp_tag -> Prims.bool) =
   fun projectee -> match projectee with | ST -> true | uu___ -> false
 let (uu___is_STAtomic : st_comp_tag -> Prims.bool) =
   fun projectee -> match projectee with | STAtomic -> true | uu___ -> false
+let (uu___is_STUnobservable : st_comp_tag -> Prims.bool) =
+  fun projectee ->
+    match projectee with | STUnobservable -> true | uu___ -> false
 let (uu___is_STGhost : st_comp_tag -> Prims.bool) =
   fun projectee -> match projectee with | STGhost -> true | uu___ -> false
 type computation_type =

--- a/src/ocaml/plugin/generated/Pulse_Checker_Abs.ml
+++ b/src/ocaml/plugin/generated/Pulse_Checker_Abs.ml
@@ -18,13 +18,13 @@ let (debug_abs :
                      (FStar_Sealed.seal
                         (Obj.magic
                            (FStar_Range.mk_range "Pulse.Checker.Abs.fst"
-                              (Prims.of_int (38)) (Prims.of_int (15))
-                              (Prims.of_int (38)) (Prims.of_int (21)))))
+                              (Prims.of_int (39)) (Prims.of_int (15))
+                              (Prims.of_int (39)) (Prims.of_int (21)))))
                      (FStar_Sealed.seal
                         (Obj.magic
                            (FStar_Range.mk_range "Pulse.Checker.Abs.fst"
-                              (Prims.of_int (38)) (Prims.of_int (7))
-                              (Prims.of_int (38)) (Prims.of_int (21)))))
+                              (Prims.of_int (39)) (Prims.of_int (7))
+                              (Prims.of_int (39)) (Prims.of_int (21)))))
                      (Obj.magic (s ()))
                      (fun uu___ ->
                         (fun uu___ ->
@@ -59,12 +59,12 @@ let rec (arrow_of_abs :
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.Abs.fst"
-                 (Prims.of_int (54)) (Prims.of_int (44)) (Prims.of_int (54))
+                 (Prims.of_int (55)) (Prims.of_int (44)) (Prims.of_int (55))
                  (Prims.of_int (53)))))
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.Abs.fst"
-                 (Prims.of_int (54)) (Prims.of_int (3)) (Prims.of_int (117))
+                 (Prims.of_int (55)) (Prims.of_int (3)) (Prims.of_int (118))
                  (Prims.of_int (5)))))
         (FStar_Tactics_Effect.lift_div_tac
            (fun uu___ -> prog.Pulse_Syntax_Base.term1))
@@ -81,13 +81,13 @@ let rec (arrow_of_abs :
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Checker.Abs.fst"
-                                (Prims.of_int (55)) (Prims.of_int (12))
-                                (Prims.of_int (55)) (Prims.of_int (21)))))
+                                (Prims.of_int (56)) (Prims.of_int (12))
+                                (Prims.of_int (56)) (Prims.of_int (21)))))
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Checker.Abs.fst"
-                                (Prims.of_int (55)) (Prims.of_int (24))
-                                (Prims.of_int (117)) (Prims.of_int (5)))))
+                                (Prims.of_int (56)) (Prims.of_int (24))
+                                (Prims.of_int (118)) (Prims.of_int (5)))))
                        (FStar_Tactics_Effect.lift_div_tac
                           (fun uu___1 -> Pulse_Typing_Env.fresh env))
                        (fun uu___1 ->
@@ -98,17 +98,17 @@ let rec (arrow_of_abs :
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "Pulse.Checker.Abs.fst"
-                                           (Prims.of_int (56))
+                                           (Prims.of_int (57))
                                            (Prims.of_int (13))
-                                           (Prims.of_int (56))
+                                           (Prims.of_int (57))
                                            (Prims.of_int (31)))))
                                   (FStar_Sealed.seal
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "Pulse.Checker.Abs.fst"
-                                           (Prims.of_int (56))
+                                           (Prims.of_int (57))
                                            (Prims.of_int (34))
-                                           (Prims.of_int (117))
+                                           (Prims.of_int (118))
                                            (Prims.of_int (5)))))
                                   (FStar_Tactics_Effect.lift_div_tac
                                      (fun uu___1 ->
@@ -122,17 +122,17 @@ let rec (arrow_of_abs :
                                                 (Obj.magic
                                                    (FStar_Range.mk_range
                                                       "Pulse.Checker.Abs.fst"
-                                                      (Prims.of_int (57))
+                                                      (Prims.of_int (58))
                                                       (Prims.of_int (14))
-                                                      (Prims.of_int (57))
+                                                      (Prims.of_int (58))
                                                       (Prims.of_int (53)))))
                                              (FStar_Sealed.seal
                                                 (Obj.magic
                                                    (FStar_Range.mk_range
                                                       "Pulse.Checker.Abs.fst"
-                                                      (Prims.of_int (57))
+                                                      (Prims.of_int (58))
                                                       (Prims.of_int (56))
-                                                      (Prims.of_int (117))
+                                                      (Prims.of_int (118))
                                                       (Prims.of_int (5)))))
                                              (FStar_Tactics_Effect.lift_div_tac
                                                 (fun uu___1 ->
@@ -149,17 +149,17 @@ let rec (arrow_of_abs :
                                                            (Obj.magic
                                                               (FStar_Range.mk_range
                                                                  "Pulse.Checker.Abs.fst"
-                                                                 (Prims.of_int (58))
+                                                                 (Prims.of_int (59))
                                                                  (Prims.of_int (15))
-                                                                 (Prims.of_int (58))
+                                                                 (Prims.of_int (59))
                                                                  (Prims.of_int (38)))))
                                                         (FStar_Sealed.seal
                                                            (Obj.magic
                                                               (FStar_Range.mk_range
                                                                  "Pulse.Checker.Abs.fst"
-                                                                 (Prims.of_int (58))
+                                                                 (Prims.of_int (59))
                                                                  (Prims.of_int (41))
-                                                                 (Prims.of_int (117))
+                                                                 (Prims.of_int (118))
                                                                  (Prims.of_int (5)))))
                                                         (FStar_Tactics_Effect.lift_div_tac
                                                            (fun uu___1 ->
@@ -173,17 +173,17 @@ let rec (arrow_of_abs :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (59))
+                                                                    (Prims.of_int (60))
                                                                     (Prims.of_int (16))
-                                                                    (Prims.of_int (59))
+                                                                    (Prims.of_int (60))
                                                                     (Prims.of_int (36)))))
                                                                    (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (60))
+                                                                    (Prims.of_int (61))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (117))
+                                                                    (Prims.of_int (118))
                                                                     (Prims.of_int (5)))))
                                                                    (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -199,17 +199,17 @@ let rec (arrow_of_abs :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (60))
-                                                                    (Prims.of_int (4))
                                                                     (Prims.of_int (61))
+                                                                    (Prims.of_int (4))
+                                                                    (Prims.of_int (62))
                                                                     (Prims.of_int (86)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (62))
+                                                                    (Prims.of_int (63))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (117))
+                                                                    (Prims.of_int (118))
                                                                     (Prims.of_int (5)))))
                                                                     (if
                                                                     FStar_Pervasives_Native.uu___is_Some
@@ -249,17 +249,17 @@ let rec (arrow_of_abs :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (67))
+                                                                    (Prims.of_int (68))
                                                                     (Prims.of_int (24))
-                                                                    (Prims.of_int (67))
+                                                                    (Prims.of_int (68))
                                                                     (Prims.of_int (45)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (65))
+                                                                    (Prims.of_int (66))
                                                                     (Prims.of_int (15))
-                                                                    (Prims.of_int (72))
+                                                                    (Prims.of_int (73))
                                                                     (Prims.of_int (16)))))
                                                                     (Obj.magic
                                                                     (arrow_of_abs
@@ -322,17 +322,17 @@ let rec (arrow_of_abs :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (75))
+                                                                    (Prims.of_int (76))
                                                                     (Prims.of_int (16))
-                                                                    (Prims.of_int (75))
+                                                                    (Prims.of_int (76))
                                                                     (Prims.of_int (52)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (76))
+                                                                    (Prims.of_int (77))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (102))
+                                                                    (Prims.of_int (103))
                                                                     (Prims.of_int (37)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -356,17 +356,17 @@ let rec (arrow_of_abs :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (78))
+                                                                    (Prims.of_int (79))
                                                                     (Prims.of_int (24))
-                                                                    (Prims.of_int (78))
+                                                                    (Prims.of_int (79))
                                                                     (Prims.of_int (69)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (79))
+                                                                    (Prims.of_int (80))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (94))
+                                                                    (Prims.of_int (95))
                                                                     (Prims.of_int (20)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -395,17 +395,17 @@ let rec (arrow_of_abs :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (84))
-                                                                    (Prims.of_int (14))
                                                                     (Prims.of_int (85))
+                                                                    (Prims.of_int (14))
+                                                                    (Prims.of_int (86))
                                                                     (Prims.of_int (45)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (81))
+                                                                    (Prims.of_int (82))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (85))
+                                                                    (Prims.of_int (86))
                                                                     (Prims.of_int (45)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -413,9 +413,9 @@ let rec (arrow_of_abs :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (85))
+                                                                    (Prims.of_int (86))
                                                                     (Prims.of_int (18))
-                                                                    (Prims.of_int (85))
+                                                                    (Prims.of_int (86))
                                                                     (Prims.of_int (44)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -513,17 +513,17 @@ let rec (arrow_of_abs :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (101))
-                                                                    (Prims.of_int (12))
                                                                     (Prims.of_int (102))
+                                                                    (Prims.of_int (12))
+                                                                    (Prims.of_int (103))
                                                                     (Prims.of_int (37)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (98))
+                                                                    (Prims.of_int (99))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (102))
+                                                                    (Prims.of_int (103))
                                                                     (Prims.of_int (37)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -531,9 +531,9 @@ let rec (arrow_of_abs :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (102))
+                                                                    (Prims.of_int (103))
                                                                     (Prims.of_int (16))
-                                                                    (Prims.of_int (102))
+                                                                    (Prims.of_int (103))
                                                                     (Prims.of_int (36)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -684,13 +684,13 @@ let rec (rebuild_abs :
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Checker.Abs.fst"
-                   (Prims.of_int (129)) (Prims.of_int (4))
-                   (Prims.of_int (131)) (Prims.of_int (41)))))
+                   (Prims.of_int (130)) (Prims.of_int (4))
+                   (Prims.of_int (132)) (Prims.of_int (41)))))
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Checker.Abs.fst"
-                   (Prims.of_int (132)) (Prims.of_int (4))
-                   (Prims.of_int (181)) (Prims.of_int (47)))))
+                   (Prims.of_int (133)) (Prims.of_int (4))
+                   (Prims.of_int (182)) (Prims.of_int (47)))))
           (Obj.magic
              (debug_abs g
                 (fun uu___ ->
@@ -698,13 +698,13 @@ let rec (rebuild_abs :
                      (FStar_Sealed.seal
                         (Obj.magic
                            (FStar_Range.mk_range "Pulse.Checker.Abs.fst"
-                              (Prims.of_int (131)) (Prims.of_int (16))
-                              (Prims.of_int (131)) (Prims.of_int (40)))))
+                              (Prims.of_int (132)) (Prims.of_int (16))
+                              (Prims.of_int (132)) (Prims.of_int (40)))))
                      (FStar_Sealed.seal
                         (Obj.magic
                            (FStar_Range.mk_range "Pulse.Checker.Abs.fst"
-                              (Prims.of_int (129)) (Prims.of_int (26))
-                              (Prims.of_int (131)) (Prims.of_int (40)))))
+                              (Prims.of_int (130)) (Prims.of_int (26))
+                              (Prims.of_int (132)) (Prims.of_int (40)))))
                      (Obj.magic
                         (FStar_Tactics_V2_Builtins.term_to_string annot))
                      (fun uu___1 ->
@@ -715,17 +715,17 @@ let rec (rebuild_abs :
                                    (Obj.magic
                                       (FStar_Range.mk_range
                                          "Pulse.Checker.Abs.fst"
-                                         (Prims.of_int (129))
+                                         (Prims.of_int (130))
                                          (Prims.of_int (26))
-                                         (Prims.of_int (131))
+                                         (Prims.of_int (132))
                                          (Prims.of_int (40)))))
                                 (FStar_Sealed.seal
                                    (Obj.magic
                                       (FStar_Range.mk_range
                                          "Pulse.Checker.Abs.fst"
-                                         (Prims.of_int (129))
+                                         (Prims.of_int (130))
                                          (Prims.of_int (26))
-                                         (Prims.of_int (131))
+                                         (Prims.of_int (132))
                                          (Prims.of_int (40)))))
                                 (Obj.magic
                                    (FStar_Tactics_Effect.tac_bind
@@ -733,9 +733,9 @@ let rec (rebuild_abs :
                                          (Obj.magic
                                             (FStar_Range.mk_range
                                                "Pulse.Checker.Abs.fst"
-                                               (Prims.of_int (130))
+                                               (Prims.of_int (131))
                                                (Prims.of_int (16))
-                                               (Prims.of_int (130))
+                                               (Prims.of_int (131))
                                                (Prims.of_int (39)))))
                                       (FStar_Sealed.seal
                                          (Obj.magic
@@ -776,13 +776,13 @@ let rec (rebuild_abs :
                          (FStar_Sealed.seal
                             (Obj.magic
                                (FStar_Range.mk_range "Pulse.Checker.Abs.fst"
-                                  (Prims.of_int (134)) (Prims.of_int (15))
-                                  (Prims.of_int (134)) (Prims.of_int (34)))))
+                                  (Prims.of_int (135)) (Prims.of_int (15))
+                                  (Prims.of_int (135)) (Prims.of_int (34)))))
                          (FStar_Sealed.seal
                             (Obj.magic
                                (FStar_Range.mk_range "Pulse.Checker.Abs.fst"
-                                  (Prims.of_int (135)) (Prims.of_int (6))
-                                  (Prims.of_int (175)) (Prims.of_int (41)))))
+                                  (Prims.of_int (136)) (Prims.of_int (6))
+                                  (Prims.of_int (176)) (Prims.of_int (41)))))
                          (FStar_Tactics_Effect.lift_div_tac
                             (fun uu___1 ->
                                FStar_Reflection_V2_Builtins.inspect_binder b'))
@@ -794,17 +794,17 @@ let rec (rebuild_abs :
                                        (Obj.magic
                                           (FStar_Range.mk_range
                                              "Pulse.Checker.Abs.fst"
-                                             (Prims.of_int (135))
+                                             (Prims.of_int (136))
                                              (Prims.of_int (6))
-                                             (Prims.of_int (135))
+                                             (Prims.of_int (136))
                                              (Prims.of_int (56)))))
                                     (FStar_Sealed.seal
                                        (Obj.magic
                                           (FStar_Range.mk_range
                                              "Pulse.Checker.Abs.fst"
-                                             (Prims.of_int (135))
+                                             (Prims.of_int (136))
                                              (Prims.of_int (57))
-                                             (Prims.of_int (175))
+                                             (Prims.of_int (176))
                                              (Prims.of_int (41)))))
                                     (Obj.magic
                                        (qualifier_compat g
@@ -818,17 +818,17 @@ let rec (rebuild_abs :
                                                   (Obj.magic
                                                      (FStar_Range.mk_range
                                                         "Pulse.Checker.Abs.fst"
-                                                        (Prims.of_int (136))
+                                                        (Prims.of_int (137))
                                                         (Prims.of_int (15))
-                                                        (Prims.of_int (136))
+                                                        (Prims.of_int (137))
                                                         (Prims.of_int (34)))))
                                                (FStar_Sealed.seal
                                                   (Obj.magic
                                                      (FStar_Range.mk_range
                                                         "Pulse.Checker.Abs.fst"
-                                                        (Prims.of_int (136))
+                                                        (Prims.of_int (137))
                                                         (Prims.of_int (37))
-                                                        (Prims.of_int (175))
+                                                        (Prims.of_int (176))
                                                         (Prims.of_int (41)))))
                                                (FStar_Tactics_Effect.lift_div_tac
                                                   (fun uu___2 ->
@@ -842,17 +842,17 @@ let rec (rebuild_abs :
                                                              (Obj.magic
                                                                 (FStar_Range.mk_range
                                                                    "Pulse.Checker.Abs.fst"
-                                                                   (Prims.of_int (137))
+                                                                   (Prims.of_int (138))
                                                                    (Prims.of_int (17))
-                                                                   (Prims.of_int (137))
+                                                                   (Prims.of_int (138))
                                                                    (Prims.of_int (34)))))
                                                           (FStar_Sealed.seal
                                                              (Obj.magic
                                                                 (FStar_Range.mk_range
                                                                    "Pulse.Checker.Abs.fst"
-                                                                   (Prims.of_int (138))
+                                                                   (Prims.of_int (139))
                                                                    (Prims.of_int (6))
-                                                                   (Prims.of_int (175))
+                                                                   (Prims.of_int (176))
                                                                    (Prims.of_int (41)))))
                                                           (FStar_Tactics_Effect.lift_div_tac
                                                              (fun uu___2 ->
@@ -879,17 +879,17 @@ let rec (rebuild_abs :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (142))
+                                                                    (Prims.of_int (143))
                                                                     (Prims.of_int (20))
-                                                                    (Prims.of_int (142))
+                                                                    (Prims.of_int (143))
                                                                     (Prims.of_int (68)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (142))
+                                                                    (Prims.of_int (143))
                                                                     (Prims.of_int (73))
-                                                                    (Prims.of_int (145))
+                                                                    (Prims.of_int (146))
                                                                     (Prims.of_int (64)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -911,17 +911,17 @@ let rec (rebuild_abs :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (143))
+                                                                    (Prims.of_int (144))
                                                                     (Prims.of_int (21))
-                                                                    (Prims.of_int (143))
+                                                                    (Prims.of_int (144))
                                                                     (Prims.of_int (46)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (145))
+                                                                    (Prims.of_int (146))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (145))
+                                                                    (Prims.of_int (146))
                                                                     (Prims.of_int (63)))))
                                                                     (Obj.magic
                                                                     (rebuild_abs
@@ -977,17 +977,17 @@ let rec (rebuild_abs :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (151))
-                                                                    (Prims.of_int (14))
                                                                     (Prims.of_int (152))
+                                                                    (Prims.of_int (14))
+                                                                    (Prims.of_int (153))
                                                                     (Prims.of_int (44)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (150))
+                                                                    (Prims.of_int (151))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (152))
+                                                                    (Prims.of_int (153))
                                                                     (Prims.of_int (44)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -995,9 +995,9 @@ let rec (rebuild_abs :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (152))
+                                                                    (Prims.of_int (153))
                                                                     (Prims.of_int (18))
-                                                                    (Prims.of_int (152))
+                                                                    (Prims.of_int (153))
                                                                     (Prims.of_int (43)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -1041,17 +1041,17 @@ let rec (rebuild_abs :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (154))
+                                                                    (Prims.of_int (155))
                                                                     (Prims.of_int (18))
-                                                                    (Prims.of_int (154))
+                                                                    (Prims.of_int (155))
                                                                     (Prims.of_int (34)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (153))
+                                                                    (Prims.of_int (154))
                                                                     (Prims.of_int (31))
-                                                                    (Prims.of_int (164))
+                                                                    (Prims.of_int (165))
                                                                     (Prims.of_int (11)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_NamedView.inspect
@@ -1073,17 +1073,17 @@ let rec (rebuild_abs :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (157))
+                                                                    (Prims.of_int (158))
                                                                     (Prims.of_int (25))
-                                                                    (Prims.of_int (157))
+                                                                    (Prims.of_int (158))
                                                                     (Prims.of_int (91)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (156))
-                                                                    (Prims.of_int (14))
                                                                     (Prims.of_int (157))
+                                                                    (Prims.of_int (14))
+                                                                    (Prims.of_int (158))
                                                                     (Prims.of_int (91)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1091,9 +1091,9 @@ let rec (rebuild_abs :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (157))
+                                                                    (Prims.of_int (158))
                                                                     (Prims.of_int (68))
-                                                                    (Prims.of_int (157))
+                                                                    (Prims.of_int (158))
                                                                     (Prims.of_int (90)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -1134,17 +1134,17 @@ let rec (rebuild_abs :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (161))
+                                                                    (Prims.of_int (162))
                                                                     (Prims.of_int (20))
-                                                                    (Prims.of_int (163))
+                                                                    (Prims.of_int (164))
                                                                     (Prims.of_int (52)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (160))
+                                                                    (Prims.of_int (161))
                                                                     (Prims.of_int (16))
-                                                                    (Prims.of_int (163))
+                                                                    (Prims.of_int (164))
                                                                     (Prims.of_int (52)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1152,9 +1152,9 @@ let rec (rebuild_abs :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (163))
+                                                                    (Prims.of_int (164))
                                                                     (Prims.of_int (22))
-                                                                    (Prims.of_int (163))
+                                                                    (Prims.of_int (164))
                                                                     (Prims.of_int (51)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -1241,17 +1241,17 @@ let rec (rebuild_abs :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (174))
-                                                                    (Prims.of_int (12))
                                                                     (Prims.of_int (175))
+                                                                    (Prims.of_int (12))
+                                                                    (Prims.of_int (176))
                                                                     (Prims.of_int (41)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (173))
+                                                                    (Prims.of_int (174))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (175))
+                                                                    (Prims.of_int (176))
                                                                     (Prims.of_int (41)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1259,9 +1259,9 @@ let rec (rebuild_abs :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (175))
+                                                                    (Prims.of_int (176))
                                                                     (Prims.of_int (16))
-                                                                    (Prims.of_int (175))
+                                                                    (Prims.of_int (176))
                                                                     (Prims.of_int (40)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -1303,22 +1303,22 @@ let rec (rebuild_abs :
                          (FStar_Sealed.seal
                             (Obj.magic
                                (FStar_Range.mk_range "Pulse.Checker.Abs.fst"
-                                  (Prims.of_int (180)) (Prims.of_int (16))
-                                  (Prims.of_int (181)) (Prims.of_int (47)))))
+                                  (Prims.of_int (181)) (Prims.of_int (16))
+                                  (Prims.of_int (182)) (Prims.of_int (47)))))
                          (FStar_Sealed.seal
                             (Obj.magic
                                (FStar_Range.mk_range "Pulse.Checker.Abs.fst"
-                                  (Prims.of_int (179)) (Prims.of_int (6))
-                                  (Prims.of_int (181)) (Prims.of_int (47)))))
+                                  (Prims.of_int (180)) (Prims.of_int (6))
+                                  (Prims.of_int (182)) (Prims.of_int (47)))))
                          (Obj.magic
                             (FStar_Tactics_Effect.tac_bind
                                (FStar_Sealed.seal
                                   (Obj.magic
                                      (FStar_Range.mk_range
                                         "Pulse.Checker.Abs.fst"
-                                        (Prims.of_int (181))
+                                        (Prims.of_int (182))
                                         (Prims.of_int (22))
-                                        (Prims.of_int (181))
+                                        (Prims.of_int (182))
                                         (Prims.of_int (46)))))
                                (FStar_Sealed.seal
                                   (Obj.magic
@@ -1354,12 +1354,12 @@ let (preprocess_abs :
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.Abs.fst"
-                 (Prims.of_int (187)) (Prims.of_int (19))
-                 (Prims.of_int (187)) (Prims.of_int (35)))))
+                 (Prims.of_int (188)) (Prims.of_int (19))
+                 (Prims.of_int (188)) (Prims.of_int (35)))))
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.Abs.fst"
-                 (Prims.of_int (187)) (Prims.of_int (3)) (Prims.of_int (198))
+                 (Prims.of_int (188)) (Prims.of_int (3)) (Prims.of_int (199))
                  (Prims.of_int (51))))) (Obj.magic (arrow_of_abs g t))
         (fun uu___ ->
            (fun uu___ ->
@@ -1370,13 +1370,13 @@ let (preprocess_abs :
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Checker.Abs.fst"
-                                (Prims.of_int (188)) (Prims.of_int (4))
-                                (Prims.of_int (188)) (Prims.of_int (88)))))
+                                (Prims.of_int (189)) (Prims.of_int (4))
+                                (Prims.of_int (189)) (Prims.of_int (88)))))
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Checker.Abs.fst"
-                                (Prims.of_int (188)) (Prims.of_int (89))
-                                (Prims.of_int (198)) (Prims.of_int (51)))))
+                                (Prims.of_int (189)) (Prims.of_int (89))
+                                (Prims.of_int (199)) (Prims.of_int (51)))))
                        (Obj.magic
                           (debug_abs g
                              (fun uu___1 ->
@@ -1385,9 +1385,9 @@ let (preprocess_abs :
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "Pulse.Checker.Abs.fst"
-                                           (Prims.of_int (188))
+                                           (Prims.of_int (189))
                                            (Prims.of_int (63))
-                                           (Prims.of_int (188))
+                                           (Prims.of_int (189))
                                            (Prims.of_int (87)))))
                                   (FStar_Sealed.seal
                                      (Obj.magic
@@ -1412,17 +1412,17 @@ let (preprocess_abs :
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "Pulse.Checker.Abs.fst"
-                                           (Prims.of_int (189))
+                                           (Prims.of_int (190))
                                            (Prims.of_int (19))
-                                           (Prims.of_int (189))
+                                           (Prims.of_int (190))
                                            (Prims.of_int (72)))))
                                   (FStar_Sealed.seal
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "Pulse.Checker.Abs.fst"
-                                           (Prims.of_int (188))
+                                           (Prims.of_int (189))
                                            (Prims.of_int (89))
-                                           (Prims.of_int (198))
+                                           (Prims.of_int (199))
                                            (Prims.of_int (51)))))
                                   (Obj.magic
                                      (Pulse_Checker_Pure.instantiate_term_implicits
@@ -1441,17 +1441,17 @@ let (preprocess_abs :
                                                          (Obj.magic
                                                             (FStar_Range.mk_range
                                                                "Pulse.Checker.Abs.fst"
-                                                               (Prims.of_int (192))
+                                                               (Prims.of_int (193))
                                                                (Prims.of_int (16))
-                                                               (Prims.of_int (192))
+                                                               (Prims.of_int (193))
                                                                (Prims.of_int (37)))))
                                                       (FStar_Sealed.seal
                                                          (Obj.magic
                                                             (FStar_Range.mk_range
                                                                "Pulse.Checker.Abs.fst"
-                                                               (Prims.of_int (193))
-                                                               (Prims.of_int (6))
                                                                (Prims.of_int (194))
+                                                               (Prims.of_int (6))
+                                                               (Prims.of_int (195))
                                                                (Prims.of_int (9)))))
                                                       (Obj.magic
                                                          (rebuild_abs g t1
@@ -1465,18 +1465,18 @@ let (preprocess_abs :
                                                                     Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (193))
+                                                                    (Prims.of_int (194))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (193))
+                                                                    (Prims.of_int (194))
                                                                     (Prims.of_int (90)))))
                                                                  (FStar_Sealed.seal
                                                                     (
                                                                     Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (192))
+                                                                    (Prims.of_int (193))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (192))
+                                                                    (Prims.of_int (193))
                                                                     (Prims.of_int (13)))))
                                                                  (Obj.magic
                                                                     (
@@ -1489,9 +1489,9 @@ let (preprocess_abs :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (193))
+                                                                    (Prims.of_int (194))
                                                                     (Prims.of_int (64))
-                                                                    (Prims.of_int (193))
+                                                                    (Prims.of_int (194))
                                                                     (Prims.of_int (89)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -1528,17 +1528,17 @@ let (preprocess_abs :
                                                          (Obj.magic
                                                             (FStar_Range.mk_range
                                                                "Pulse.Checker.Abs.fst"
-                                                               (Prims.of_int (197))
-                                                               (Prims.of_int (17))
                                                                (Prims.of_int (198))
+                                                               (Prims.of_int (17))
+                                                               (Prims.of_int (199))
                                                                (Prims.of_int (51)))))
                                                       (FStar_Sealed.seal
                                                          (Obj.magic
                                                             (FStar_Range.mk_range
                                                                "Pulse.Checker.Abs.fst"
-                                                               (Prims.of_int (196))
+                                                               (Prims.of_int (197))
                                                                (Prims.of_int (6))
-                                                               (Prims.of_int (198))
+                                                               (Prims.of_int (199))
                                                                (Prims.of_int (51)))))
                                                       (Obj.magic
                                                          (FStar_Tactics_Effect.tac_bind
@@ -1546,9 +1546,9 @@ let (preprocess_abs :
                                                                (Obj.magic
                                                                   (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (198))
+                                                                    (Prims.of_int (199))
                                                                     (Prims.of_int (26))
-                                                                    (Prims.of_int (198))
+                                                                    (Prims.of_int (199))
                                                                     (Prims.of_int (50)))))
                                                             (FStar_Sealed.seal
                                                                (Obj.magic
@@ -1580,6 +1580,67 @@ let (preprocess_abs :
                                                                  uu___5))
                                                            uu___5)))) uu___2)))
                             uu___1))) uu___)
+let sub_effect_comp :
+  'uuuuu .
+    Pulse_Typing_Env.env ->
+      'uuuuu ->
+        Pulse_Syntax_Base.comp_ascription ->
+          Pulse_Syntax_Base.comp ->
+            ((Pulse_Syntax_Base.comp,
+               (unit, unit, unit) Pulse_Typing.lift_comp) Prims.dtuple2
+               FStar_Pervasives_Native.option,
+              unit) FStar_Tactics_Effect.tac_repr
+  =
+  fun uu___3 ->
+    fun uu___2 ->
+      fun uu___1 ->
+        fun uu___ ->
+          (fun g ->
+             fun r ->
+               fun asc ->
+                 fun c_computed ->
+                   Obj.magic
+                     (FStar_Tactics_Effect.lift_div_tac
+                        (fun uu___ ->
+                           match asc.Pulse_Syntax_Base.elaborated with
+                           | FStar_Pervasives_Native.None ->
+                               FStar_Pervasives_Native.None
+                           | FStar_Pervasives_Native.Some c ->
+                               (match (c_computed, c) with
+                                | (Pulse_Syntax_Base.C_Tot t1,
+                                   Pulse_Syntax_Base.C_Tot t2) ->
+                                    FStar_Pervasives_Native.None
+                                | (Pulse_Syntax_Base.C_ST uu___1,
+                                   Pulse_Syntax_Base.C_ST uu___2) ->
+                                    FStar_Pervasives_Native.None
+                                | (Pulse_Syntax_Base.C_STAtomic
+                                   (i, Pulse_Syntax_Base.Observable, c1),
+                                   Pulse_Syntax_Base.C_STAtomic
+                                   (j, Pulse_Syntax_Base.Observable, c2)) ->
+                                    FStar_Pervasives_Native.None
+                                | (Pulse_Syntax_Base.C_STAtomic
+                                   (i, Pulse_Syntax_Base.Unobservable, c1),
+                                   Pulse_Syntax_Base.C_STAtomic
+                                   (j, Pulse_Syntax_Base.Unobservable, c2))
+                                    -> FStar_Pervasives_Native.None
+                                | (Pulse_Syntax_Base.C_STGhost (i, c1),
+                                   Pulse_Syntax_Base.C_STGhost (j, c2)) ->
+                                    FStar_Pervasives_Native.None
+                                | (Pulse_Syntax_Base.C_STAtomic
+                                   (i, Pulse_Syntax_Base.Unobservable, c1),
+                                   Pulse_Syntax_Base.C_STAtomic
+                                   (uu___1, Pulse_Syntax_Base.Observable,
+                                    uu___2)) ->
+                                    FStar_Pervasives_Native.Some
+                                      (Prims.Mkdtuple2
+                                         ((Pulse_Syntax_Base.C_STAtomic
+                                             (i,
+                                               Pulse_Syntax_Base.Observable,
+                                               c1)),
+                                           (Pulse_Typing.Lift_STUnobservable_STAtomic
+                                              (g, c_computed))))
+                                | uu___1 -> FStar_Pervasives_Native.None))))
+            uu___3 uu___2 uu___1 uu___
 let (check_effect_annotation :
   Pulse_Typing_Env.env ->
     Pulse_Syntax_Base.range ->
@@ -1597,13 +1658,13 @@ let (check_effect_annotation :
             (FStar_Sealed.seal
                (Obj.magic
                   (FStar_Range.mk_range "Pulse.Checker.Abs.fst"
-                     (Prims.of_int (201)) (Prims.of_int (12))
-                     (Prims.of_int (201)) (Prims.of_int (42)))))
+                     (Prims.of_int (221)) (Prims.of_int (12))
+                     (Prims.of_int (221)) (Prims.of_int (42)))))
             (FStar_Sealed.seal
                (Obj.magic
                   (FStar_Range.mk_range "Pulse.Checker.Abs.fst"
-                     (Prims.of_int (202)) (Prims.of_int (2))
-                     (Prims.of_int (252)) (Prims.of_int (7)))))
+                     (Prims.of_int (222)) (Prims.of_int (2))
+                     (Prims.of_int (273)) (Prims.of_int (7)))))
             (FStar_Tactics_Effect.lift_div_tac
                (fun uu___ ->
                   Prims.Mkdtuple2
@@ -1647,17 +1708,17 @@ let (check_effect_annotation :
                                              (Obj.magic
                                                 (FStar_Range.mk_range
                                                    "Pulse.Checker.Abs.fst"
-                                                   (Prims.of_int (221))
+                                                   (Prims.of_int (242))
                                                    (Prims.of_int (14))
-                                                   (Prims.of_int (221))
+                                                   (Prims.of_int (242))
                                                    (Prims.of_int (50)))))
                                           (FStar_Sealed.seal
                                              (Obj.magic
                                                 (FStar_Range.mk_range
                                                    "Pulse.Checker.Abs.fst"
-                                                   (Prims.of_int (221))
+                                                   (Prims.of_int (242))
                                                    (Prims.of_int (53))
-                                                   (Prims.of_int (243))
+                                                   (Prims.of_int (264))
                                                    (Prims.of_int (20)))))
                                           (FStar_Tactics_Effect.lift_div_tac
                                              (fun uu___1 ->
@@ -1672,17 +1733,17 @@ let (check_effect_annotation :
                                                         (Obj.magic
                                                            (FStar_Range.mk_range
                                                               "Pulse.Checker.Abs.fst"
-                                                              (Prims.of_int (222))
+                                                              (Prims.of_int (243))
                                                               (Prims.of_int (16))
-                                                              (Prims.of_int (222))
+                                                              (Prims.of_int (243))
                                                               (Prims.of_int (36)))))
                                                      (FStar_Sealed.seal
                                                         (Obj.magic
                                                            (FStar_Range.mk_range
                                                               "Pulse.Checker.Abs.fst"
-                                                              (Prims.of_int (222))
-                                                              (Prims.of_int (39))
                                                               (Prims.of_int (243))
+                                                              (Prims.of_int (39))
+                                                              (Prims.of_int (264))
                                                               (Prims.of_int (20)))))
                                                      (FStar_Tactics_Effect.lift_div_tac
                                                         (fun uu___1 ->
@@ -1696,17 +1757,17 @@ let (check_effect_annotation :
                                                                    (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (223))
+                                                                    (Prims.of_int (244))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (223))
+                                                                    (Prims.of_int (244))
                                                                     (Prims.of_int (48)))))
                                                                 (FStar_Sealed.seal
                                                                    (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (223))
+                                                                    (Prims.of_int (244))
                                                                     (Prims.of_int (51))
-                                                                    (Prims.of_int (243))
+                                                                    (Prims.of_int (264))
                                                                     (Prims.of_int (20)))))
                                                                 (FStar_Tactics_Effect.lift_div_tac
                                                                    (fun
@@ -1722,17 +1783,17 @@ let (check_effect_annotation :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (226))
+                                                                    (Prims.of_int (247))
                                                                     (Prims.of_int (16))
-                                                                    (Prims.of_int (226))
+                                                                    (Prims.of_int (247))
                                                                     (Prims.of_int (88)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (227))
+                                                                    (Prims.of_int (248))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (243))
+                                                                    (Prims.of_int (264))
                                                                     (Prims.of_int (20)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_V2_Derived.with_policy
@@ -1751,17 +1812,17 @@ let (check_effect_annotation :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (227))
+                                                                    (Prims.of_int (248))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (234))
+                                                                    (Prims.of_int (255))
                                                                     (Prims.of_int (7)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (234))
+                                                                    (Prims.of_int (255))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (243))
+                                                                    (Prims.of_int (264))
                                                                     (Prims.of_int (20)))))
                                                                     (if
                                                                     FStar_Pervasives_Native.uu___is_None
@@ -1774,17 +1835,17 @@ let (check_effect_annotation :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (229))
+                                                                    (Prims.of_int (250))
                                                                     (Prims.of_int (34))
-                                                                    (Prims.of_int (233))
+                                                                    (Prims.of_int (254))
                                                                     (Prims.of_int (9)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (229))
+                                                                    (Prims.of_int (250))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (233))
+                                                                    (Prims.of_int (254))
                                                                     (Prims.of_int (9)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1792,17 +1853,17 @@ let (check_effect_annotation :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (230))
+                                                                    (Prims.of_int (251))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (232))
+                                                                    (Prims.of_int (253))
                                                                     (Prims.of_int (27)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (229))
+                                                                    (Prims.of_int (250))
                                                                     (Prims.of_int (34))
-                                                                    (Prims.of_int (233))
+                                                                    (Prims.of_int (254))
                                                                     (Prims.of_int (9)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1810,17 +1871,17 @@ let (check_effect_annotation :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (230))
+                                                                    (Prims.of_int (251))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (230))
+                                                                    (Prims.of_int (251))
                                                                     (Prims.of_int (80)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (230))
+                                                                    (Prims.of_int (251))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (232))
+                                                                    (Prims.of_int (253))
                                                                     (Prims.of_int (27)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1828,17 +1889,17 @@ let (check_effect_annotation :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (230))
+                                                                    (Prims.of_int (251))
                                                                     (Prims.of_int (74))
-                                                                    (Prims.of_int (230))
+                                                                    (Prims.of_int (251))
                                                                     (Prims.of_int (80)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (230))
+                                                                    (Prims.of_int (251))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (230))
+                                                                    (Prims.of_int (251))
                                                                     (Prims.of_int (80)))))
                                                                     (Obj.magic
                                                                     (Pulse_PP.pp
@@ -1865,17 +1926,17 @@ let (check_effect_annotation :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (231))
+                                                                    (Prims.of_int (252))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (232))
+                                                                    (Prims.of_int (253))
                                                                     (Prims.of_int (27)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (230))
+                                                                    (Prims.of_int (251))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (232))
+                                                                    (Prims.of_int (253))
                                                                     (Prims.of_int (27)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1883,17 +1944,17 @@ let (check_effect_annotation :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (231))
+                                                                    (Prims.of_int (252))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (231))
+                                                                    (Prims.of_int (252))
                                                                     (Prims.of_int (93)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (231))
+                                                                    (Prims.of_int (252))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (232))
+                                                                    (Prims.of_int (253))
                                                                     (Prims.of_int (27)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1901,17 +1962,17 @@ let (check_effect_annotation :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (231))
+                                                                    (Prims.of_int (252))
                                                                     (Prims.of_int (87))
-                                                                    (Prims.of_int (231))
+                                                                    (Prims.of_int (252))
                                                                     (Prims.of_int (93)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (231))
+                                                                    (Prims.of_int (252))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (231))
+                                                                    (Prims.of_int (252))
                                                                     (Prims.of_int (93)))))
                                                                     (Obj.magic
                                                                     (Pulse_PP.pp
@@ -1999,8 +2060,381 @@ let (check_effect_annotation :
                                                                     Pulse_Typing.STS_AtomicInvs
                                                                     (g, c2,
                                                                     j, i,
-                                                                    Pulse_Syntax_Base.Observable,
-                                                                    Pulse_Syntax_Base.Observable,
+                                                                    obs, obs,
+                                                                    ()))))))))
+                                                                    uu___1)))
+                                                                    uu___1)))
+                                                          uu___1))) uu___1)))
+                            | (Pulse_Syntax_Base.C_STAtomic
+                               (i, Pulse_Syntax_Base.Unobservable, c1),
+                               Pulse_Syntax_Base.C_STAtomic
+                               (j, Pulse_Syntax_Base.Unobservable, c2)) ->
+                                Obj.repr
+                                  (if Pulse_Syntax_Base.eq_tm i j
+                                   then
+                                     Obj.repr
+                                       (FStar_Tactics_Effect.lift_div_tac
+                                          (fun uu___ -> nop))
+                                   else
+                                     Obj.repr
+                                       (FStar_Tactics_Effect.tac_bind
+                                          (FStar_Sealed.seal
+                                             (Obj.magic
+                                                (FStar_Range.mk_range
+                                                   "Pulse.Checker.Abs.fst"
+                                                   (Prims.of_int (242))
+                                                   (Prims.of_int (14))
+                                                   (Prims.of_int (242))
+                                                   (Prims.of_int (50)))))
+                                          (FStar_Sealed.seal
+                                             (Obj.magic
+                                                (FStar_Range.mk_range
+                                                   "Pulse.Checker.Abs.fst"
+                                                   (Prims.of_int (242))
+                                                   (Prims.of_int (53))
+                                                   (Prims.of_int (264))
+                                                   (Prims.of_int (20)))))
+                                          (FStar_Tactics_Effect.lift_div_tac
+                                             (fun uu___1 ->
+                                                Pulse_Syntax_Base.mk_binder
+                                                  "res" FStar_Range.range_0
+                                                  c2.Pulse_Syntax_Base.res))
+                                          (fun uu___1 ->
+                                             (fun b ->
+                                                Obj.magic
+                                                  (FStar_Tactics_Effect.tac_bind
+                                                     (FStar_Sealed.seal
+                                                        (Obj.magic
+                                                           (FStar_Range.mk_range
+                                                              "Pulse.Checker.Abs.fst"
+                                                              (Prims.of_int (243))
+                                                              (Prims.of_int (16))
+                                                              (Prims.of_int (243))
+                                                              (Prims.of_int (36)))))
+                                                     (FStar_Sealed.seal
+                                                        (Obj.magic
+                                                           (FStar_Range.mk_range
+                                                              "Pulse.Checker.Abs.fst"
+                                                              (Prims.of_int (243))
+                                                              (Prims.of_int (39))
+                                                              (Prims.of_int (264))
+                                                              (Prims.of_int (20)))))
+                                                     (FStar_Tactics_Effect.lift_div_tac
+                                                        (fun uu___1 ->
+                                                           Pulse_Typing.tm_inames_subset
+                                                             j i))
+                                                     (fun uu___1 ->
+                                                        (fun phi ->
+                                                           Obj.magic
+                                                             (FStar_Tactics_Effect.tac_bind
+                                                                (FStar_Sealed.seal
+                                                                   (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Abs.fst"
+                                                                    (Prims.of_int (244))
+                                                                    (Prims.of_int (19))
+                                                                    (Prims.of_int (244))
+                                                                    (Prims.of_int (48)))))
+                                                                (FStar_Sealed.seal
+                                                                   (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Abs.fst"
+                                                                    (Prims.of_int (244))
+                                                                    (Prims.of_int (51))
+                                                                    (Prims.of_int (264))
+                                                                    (Prims.of_int (20)))))
+                                                                (FStar_Tactics_Effect.lift_div_tac
+                                                                   (fun
+                                                                    uu___1 ->
+                                                                    ()))
+                                                                (fun uu___1
+                                                                   ->
+                                                                   (fun
+                                                                    typing ->
+                                                                    Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Abs.fst"
+                                                                    (Prims.of_int (247))
+                                                                    (Prims.of_int (16))
+                                                                    (Prims.of_int (247))
+                                                                    (Prims.of_int (88)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Abs.fst"
+                                                                    (Prims.of_int (248))
+                                                                    (Prims.of_int (6))
+                                                                    (Prims.of_int (264))
+                                                                    (Prims.of_int (20)))))
+                                                                    (Obj.magic
+                                                                    (FStar_Tactics_V2_Derived.with_policy
+                                                                    FStar_Tactics_Types.SMTSync
+                                                                    (fun
+                                                                    uu___1 ->
+                                                                    Pulse_Checker_Pure.try_check_prop_validity
+                                                                    g phi ())))
+                                                                    (fun
+                                                                    uu___1 ->
+                                                                    (fun tok
+                                                                    ->
+                                                                    Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Abs.fst"
+                                                                    (Prims.of_int (248))
+                                                                    (Prims.of_int (6))
+                                                                    (Prims.of_int (255))
+                                                                    (Prims.of_int (7)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Abs.fst"
+                                                                    (Prims.of_int (255))
+                                                                    (Prims.of_int (8))
+                                                                    (Prims.of_int (264))
+                                                                    (Prims.of_int (20)))))
+                                                                    (if
+                                                                    FStar_Pervasives_Native.uu___is_None
+                                                                    tok
+                                                                    then
+                                                                    Obj.magic
+                                                                    (Obj.repr
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Abs.fst"
+                                                                    (Prims.of_int (250))
+                                                                    (Prims.of_int (34))
+                                                                    (Prims.of_int (254))
+                                                                    (Prims.of_int (9)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Abs.fst"
+                                                                    (Prims.of_int (250))
+                                                                    (Prims.of_int (8))
+                                                                    (Prims.of_int (254))
+                                                                    (Prims.of_int (9)))))
+                                                                    (Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Abs.fst"
+                                                                    (Prims.of_int (251))
+                                                                    (Prims.of_int (10))
+                                                                    (Prims.of_int (253))
+                                                                    (Prims.of_int (27)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Abs.fst"
+                                                                    (Prims.of_int (250))
+                                                                    (Prims.of_int (34))
+                                                                    (Prims.of_int (254))
+                                                                    (Prims.of_int (9)))))
+                                                                    (Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Abs.fst"
+                                                                    (Prims.of_int (251))
+                                                                    (Prims.of_int (10))
+                                                                    (Prims.of_int (251))
+                                                                    (Prims.of_int (80)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Abs.fst"
+                                                                    (Prims.of_int (251))
+                                                                    (Prims.of_int (10))
+                                                                    (Prims.of_int (253))
+                                                                    (Prims.of_int (27)))))
+                                                                    (Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Abs.fst"
+                                                                    (Prims.of_int (251))
+                                                                    (Prims.of_int (74))
+                                                                    (Prims.of_int (251))
+                                                                    (Prims.of_int (80)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Abs.fst"
+                                                                    (Prims.of_int (251))
+                                                                    (Prims.of_int (10))
+                                                                    (Prims.of_int (251))
+                                                                    (Prims.of_int (80)))))
+                                                                    (Obj.magic
+                                                                    (Pulse_PP.pp
+                                                                    Pulse_PP.uu___44
+                                                                    i))
+                                                                    (fun
+                                                                    uu___1 ->
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___2 ->
+                                                                    FStar_Pprint.prefix
+                                                                    (Prims.of_int (4))
+                                                                    Prims.int_one
+                                                                    (Pulse_PP.text
+                                                                    "Annotated effect expects only invariants in")
+                                                                    uu___1))))
+                                                                    (fun
+                                                                    uu___1 ->
+                                                                    (fun
+                                                                    uu___1 ->
+                                                                    Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Abs.fst"
+                                                                    (Prims.of_int (252))
+                                                                    (Prims.of_int (10))
+                                                                    (Prims.of_int (253))
+                                                                    (Prims.of_int (27)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Abs.fst"
+                                                                    (Prims.of_int (251))
+                                                                    (Prims.of_int (10))
+                                                                    (Prims.of_int (253))
+                                                                    (Prims.of_int (27)))))
+                                                                    (Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Abs.fst"
+                                                                    (Prims.of_int (252))
+                                                                    (Prims.of_int (10))
+                                                                    (Prims.of_int (252))
+                                                                    (Prims.of_int (93)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Abs.fst"
+                                                                    (Prims.of_int (252))
+                                                                    (Prims.of_int (10))
+                                                                    (Prims.of_int (253))
+                                                                    (Prims.of_int (27)))))
+                                                                    (Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Abs.fst"
+                                                                    (Prims.of_int (252))
+                                                                    (Prims.of_int (87))
+                                                                    (Prims.of_int (252))
+                                                                    (Prims.of_int (93)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Abs.fst"
+                                                                    (Prims.of_int (252))
+                                                                    (Prims.of_int (10))
+                                                                    (Prims.of_int (252))
+                                                                    (Prims.of_int (93)))))
+                                                                    (Obj.magic
+                                                                    (Pulse_PP.pp
+                                                                    Pulse_PP.uu___44
+                                                                    j))
+                                                                    (fun
+                                                                    uu___2 ->
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___3 ->
+                                                                    FStar_Pprint.prefix
+                                                                    (Prims.of_int (4))
+                                                                    Prims.int_one
+                                                                    (Pulse_PP.text
+                                                                    "to be opened; but computed effect claims that invariants")
+                                                                    uu___2))))
+                                                                    (fun
+                                                                    uu___2 ->
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___3 ->
+                                                                    FStar_Pprint.op_Hat_Slash_Hat
+                                                                    uu___2
+                                                                    (Pulse_PP.text
+                                                                    "are opened")))))
+                                                                    (fun
+                                                                    uu___2 ->
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___3 ->
+                                                                    FStar_Pprint.op_Hat_Slash_Hat
+                                                                    uu___1
+                                                                    uu___2))))
+                                                                    uu___1)))
+                                                                    (fun
+                                                                    uu___1 ->
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___2 ->
+                                                                    [uu___1]))))
+                                                                    (fun
+                                                                    uu___1 ->
+                                                                    (fun
+                                                                    uu___1 ->
+                                                                    Obj.magic
+                                                                    (Pulse_Typing_Env.fail_doc
+                                                                    g
+                                                                    (FStar_Pervasives_Native.Some
+                                                                    (i.Pulse_Syntax_Base.range1))
+                                                                    uu___1))
+                                                                    uu___1)))
+                                                                    else
+                                                                    Obj.magic
+                                                                    (Obj.repr
+                                                                    (FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___2 ->
+                                                                    ()))))
+                                                                    (fun
+                                                                    uu___1 ->
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___2 ->
+                                                                    match tok
+                                                                    with
+                                                                    | 
+                                                                    FStar_Pervasives_Native.Some
+                                                                    tok1 ->
+                                                                    Prims.Mkdtuple2
+                                                                    (c,
+                                                                    ((match c_computed
+                                                                    with
+                                                                    | Pulse_Syntax_Base.C_STGhost
+                                                                    (uu___3,
+                                                                    uu___4)
+                                                                    ->
+                                                                    Pulse_Typing.STS_GhostInvs
+                                                                    (g, c2,
+                                                                    j, i, ())
+                                                                    | Pulse_Syntax_Base.C_STAtomic
+                                                                    (uu___3,
+                                                                    obs,
+                                                                    uu___4)
+                                                                    ->
+                                                                    Pulse_Typing.STS_AtomicInvs
+                                                                    (g, c2,
+                                                                    j, i,
+                                                                    obs, obs,
                                                                     ()))))))))
                                                                     uu___1)))
                                                                     uu___1)))
@@ -2020,17 +2454,17 @@ let (check_effect_annotation :
                                              (Obj.magic
                                                 (FStar_Range.mk_range
                                                    "Pulse.Checker.Abs.fst"
-                                                   (Prims.of_int (221))
+                                                   (Prims.of_int (242))
                                                    (Prims.of_int (14))
-                                                   (Prims.of_int (221))
+                                                   (Prims.of_int (242))
                                                    (Prims.of_int (50)))))
                                           (FStar_Sealed.seal
                                              (Obj.magic
                                                 (FStar_Range.mk_range
                                                    "Pulse.Checker.Abs.fst"
-                                                   (Prims.of_int (221))
+                                                   (Prims.of_int (242))
                                                    (Prims.of_int (53))
-                                                   (Prims.of_int (243))
+                                                   (Prims.of_int (264))
                                                    (Prims.of_int (20)))))
                                           (FStar_Tactics_Effect.lift_div_tac
                                              (fun uu___1 ->
@@ -2045,17 +2479,17 @@ let (check_effect_annotation :
                                                         (Obj.magic
                                                            (FStar_Range.mk_range
                                                               "Pulse.Checker.Abs.fst"
-                                                              (Prims.of_int (222))
+                                                              (Prims.of_int (243))
                                                               (Prims.of_int (16))
-                                                              (Prims.of_int (222))
+                                                              (Prims.of_int (243))
                                                               (Prims.of_int (36)))))
                                                      (FStar_Sealed.seal
                                                         (Obj.magic
                                                            (FStar_Range.mk_range
                                                               "Pulse.Checker.Abs.fst"
-                                                              (Prims.of_int (222))
-                                                              (Prims.of_int (39))
                                                               (Prims.of_int (243))
+                                                              (Prims.of_int (39))
+                                                              (Prims.of_int (264))
                                                               (Prims.of_int (20)))))
                                                      (FStar_Tactics_Effect.lift_div_tac
                                                         (fun uu___1 ->
@@ -2069,17 +2503,17 @@ let (check_effect_annotation :
                                                                    (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (223))
+                                                                    (Prims.of_int (244))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (223))
+                                                                    (Prims.of_int (244))
                                                                     (Prims.of_int (48)))))
                                                                 (FStar_Sealed.seal
                                                                    (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (223))
+                                                                    (Prims.of_int (244))
                                                                     (Prims.of_int (51))
-                                                                    (Prims.of_int (243))
+                                                                    (Prims.of_int (264))
                                                                     (Prims.of_int (20)))))
                                                                 (FStar_Tactics_Effect.lift_div_tac
                                                                    (fun
@@ -2095,17 +2529,17 @@ let (check_effect_annotation :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (226))
+                                                                    (Prims.of_int (247))
                                                                     (Prims.of_int (16))
-                                                                    (Prims.of_int (226))
+                                                                    (Prims.of_int (247))
                                                                     (Prims.of_int (88)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (227))
+                                                                    (Prims.of_int (248))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (243))
+                                                                    (Prims.of_int (264))
                                                                     (Prims.of_int (20)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_V2_Derived.with_policy
@@ -2124,17 +2558,17 @@ let (check_effect_annotation :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (227))
+                                                                    (Prims.of_int (248))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (234))
+                                                                    (Prims.of_int (255))
                                                                     (Prims.of_int (7)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (234))
+                                                                    (Prims.of_int (255))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (243))
+                                                                    (Prims.of_int (264))
                                                                     (Prims.of_int (20)))))
                                                                     (if
                                                                     FStar_Pervasives_Native.uu___is_None
@@ -2147,17 +2581,17 @@ let (check_effect_annotation :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (229))
+                                                                    (Prims.of_int (250))
                                                                     (Prims.of_int (34))
-                                                                    (Prims.of_int (233))
+                                                                    (Prims.of_int (254))
                                                                     (Prims.of_int (9)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (229))
+                                                                    (Prims.of_int (250))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (233))
+                                                                    (Prims.of_int (254))
                                                                     (Prims.of_int (9)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -2165,17 +2599,17 @@ let (check_effect_annotation :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (230))
+                                                                    (Prims.of_int (251))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (232))
+                                                                    (Prims.of_int (253))
                                                                     (Prims.of_int (27)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (229))
+                                                                    (Prims.of_int (250))
                                                                     (Prims.of_int (34))
-                                                                    (Prims.of_int (233))
+                                                                    (Prims.of_int (254))
                                                                     (Prims.of_int (9)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -2183,17 +2617,17 @@ let (check_effect_annotation :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (230))
+                                                                    (Prims.of_int (251))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (230))
+                                                                    (Prims.of_int (251))
                                                                     (Prims.of_int (80)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (230))
+                                                                    (Prims.of_int (251))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (232))
+                                                                    (Prims.of_int (253))
                                                                     (Prims.of_int (27)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -2201,17 +2635,17 @@ let (check_effect_annotation :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (230))
+                                                                    (Prims.of_int (251))
                                                                     (Prims.of_int (74))
-                                                                    (Prims.of_int (230))
+                                                                    (Prims.of_int (251))
                                                                     (Prims.of_int (80)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (230))
+                                                                    (Prims.of_int (251))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (230))
+                                                                    (Prims.of_int (251))
                                                                     (Prims.of_int (80)))))
                                                                     (Obj.magic
                                                                     (Pulse_PP.pp
@@ -2238,17 +2672,17 @@ let (check_effect_annotation :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (231))
+                                                                    (Prims.of_int (252))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (232))
+                                                                    (Prims.of_int (253))
                                                                     (Prims.of_int (27)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (230))
+                                                                    (Prims.of_int (251))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (232))
+                                                                    (Prims.of_int (253))
                                                                     (Prims.of_int (27)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -2256,17 +2690,17 @@ let (check_effect_annotation :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (231))
+                                                                    (Prims.of_int (252))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (231))
+                                                                    (Prims.of_int (252))
                                                                     (Prims.of_int (93)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (231))
+                                                                    (Prims.of_int (252))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (232))
+                                                                    (Prims.of_int (253))
                                                                     (Prims.of_int (27)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -2274,17 +2708,17 @@ let (check_effect_annotation :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (231))
+                                                                    (Prims.of_int (252))
                                                                     (Prims.of_int (87))
-                                                                    (Prims.of_int (231))
+                                                                    (Prims.of_int (252))
                                                                     (Prims.of_int (93)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (231))
+                                                                    (Prims.of_int (252))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (231))
+                                                                    (Prims.of_int (252))
                                                                     (Prims.of_int (93)))))
                                                                     (Obj.magic
                                                                     (Pulse_PP.pp
@@ -2372,8 +2806,7 @@ let (check_effect_annotation :
                                                                     Pulse_Typing.STS_AtomicInvs
                                                                     (g, c2,
                                                                     j, i,
-                                                                    Pulse_Syntax_Base.Observable,
-                                                                    Pulse_Syntax_Base.Observable,
+                                                                    obs, obs,
                                                                     ()))))))))
                                                                     uu___1)))
                                                                     uu___1)))
@@ -2385,17 +2818,17 @@ let (check_effect_annotation :
                                         (Obj.magic
                                            (FStar_Range.mk_range
                                               "Pulse.Checker.Abs.fst"
-                                              (Prims.of_int (247))
+                                              (Prims.of_int (268))
                                               (Prims.of_int (26))
-                                              (Prims.of_int (252))
+                                              (Prims.of_int (273))
                                               (Prims.of_int (7)))))
                                      (FStar_Sealed.seal
                                         (Obj.magic
                                            (FStar_Range.mk_range
                                               "Pulse.Checker.Abs.fst"
-                                              (Prims.of_int (247))
+                                              (Prims.of_int (268))
                                               (Prims.of_int (6))
-                                              (Prims.of_int (252))
+                                              (Prims.of_int (273))
                                               (Prims.of_int (7)))))
                                      (Obj.magic
                                         (FStar_Tactics_Effect.tac_bind
@@ -2403,17 +2836,17 @@ let (check_effect_annotation :
                                               (Obj.magic
                                                  (FStar_Range.mk_range
                                                     "Pulse.Checker.Abs.fst"
-                                                    (Prims.of_int (248))
+                                                    (Prims.of_int (269))
                                                     (Prims.of_int (8))
-                                                    (Prims.of_int (251))
+                                                    (Prims.of_int (272))
                                                     (Prims.of_int (67)))))
                                            (FStar_Sealed.seal
                                               (Obj.magic
                                                  (FStar_Range.mk_range
                                                     "Pulse.Checker.Abs.fst"
-                                                    (Prims.of_int (247))
+                                                    (Prims.of_int (268))
                                                     (Prims.of_int (26))
-                                                    (Prims.of_int (252))
+                                                    (Prims.of_int (273))
                                                     (Prims.of_int (7)))))
                                            (Obj.magic
                                               (FStar_Tactics_Effect.tac_bind
@@ -2421,17 +2854,17 @@ let (check_effect_annotation :
                                                     (Obj.magic
                                                        (FStar_Range.mk_range
                                                           "Pulse.Checker.Abs.fst"
-                                                          (Prims.of_int (248))
+                                                          (Prims.of_int (269))
                                                           (Prims.of_int (8))
-                                                          (Prims.of_int (249))
+                                                          (Prims.of_int (270))
                                                           (Prims.of_int (58)))))
                                                  (FStar_Sealed.seal
                                                     (Obj.magic
                                                        (FStar_Range.mk_range
                                                           "Pulse.Checker.Abs.fst"
-                                                          (Prims.of_int (248))
+                                                          (Prims.of_int (269))
                                                           (Prims.of_int (8))
-                                                          (Prims.of_int (251))
+                                                          (Prims.of_int (272))
                                                           (Prims.of_int (67)))))
                                                  (Obj.magic
                                                     (FStar_Tactics_Effect.tac_bind
@@ -2439,17 +2872,17 @@ let (check_effect_annotation :
                                                           (Obj.magic
                                                              (FStar_Range.mk_range
                                                                 "Pulse.Checker.Abs.fst"
-                                                                (Prims.of_int (249))
+                                                                (Prims.of_int (270))
                                                                 (Prims.of_int (22))
-                                                                (Prims.of_int (249))
+                                                                (Prims.of_int (270))
                                                                 (Prims.of_int (58)))))
                                                        (FStar_Sealed.seal
                                                           (Obj.magic
                                                              (FStar_Range.mk_range
                                                                 "Pulse.Checker.Abs.fst"
-                                                                (Prims.of_int (248))
+                                                                (Prims.of_int (269))
                                                                 (Prims.of_int (8))
-                                                                (Prims.of_int (249))
+                                                                (Prims.of_int (270))
                                                                 (Prims.of_int (58)))))
                                                        (Obj.magic
                                                           (FStar_Tactics_Effect.tac_bind
@@ -2457,17 +2890,17 @@ let (check_effect_annotation :
                                                                 (Obj.magic
                                                                    (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (249))
+                                                                    (Prims.of_int (270))
                                                                     (Prims.of_int (40))
-                                                                    (Prims.of_int (249))
+                                                                    (Prims.of_int (270))
                                                                     (Prims.of_int (57)))))
                                                              (FStar_Sealed.seal
                                                                 (Obj.magic
                                                                    (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (249))
+                                                                    (Prims.of_int (270))
                                                                     (Prims.of_int (22))
-                                                                    (Prims.of_int (249))
+                                                                    (Prims.of_int (270))
                                                                     (Prims.of_int (58)))))
                                                              (Obj.magic
                                                                 (Pulse_Syntax_Printer.tag_of_comp
@@ -2495,17 +2928,17 @@ let (check_effect_annotation :
                                                                (Obj.magic
                                                                   (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (250))
+                                                                    (Prims.of_int (271))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (251))
+                                                                    (Prims.of_int (272))
                                                                     (Prims.of_int (67)))))
                                                             (FStar_Sealed.seal
                                                                (Obj.magic
                                                                   (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (248))
+                                                                    (Prims.of_int (269))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (251))
+                                                                    (Prims.of_int (272))
                                                                     (Prims.of_int (67)))))
                                                             (Obj.magic
                                                                (FStar_Tactics_Effect.tac_bind
@@ -2513,17 +2946,17 @@ let (check_effect_annotation :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (251))
+                                                                    (Prims.of_int (272))
                                                                     (Prims.of_int (22))
-                                                                    (Prims.of_int (251))
+                                                                    (Prims.of_int (272))
                                                                     (Prims.of_int (67)))))
                                                                   (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (250))
+                                                                    (Prims.of_int (271))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (251))
+                                                                    (Prims.of_int (272))
                                                                     (Prims.of_int (67)))))
                                                                   (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -2531,17 +2964,17 @@ let (check_effect_annotation :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (251))
+                                                                    (Prims.of_int (272))
                                                                     (Prims.of_int (40))
-                                                                    (Prims.of_int (251))
+                                                                    (Prims.of_int (272))
                                                                     (Prims.of_int (66)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (251))
+                                                                    (Prims.of_int (272))
                                                                     (Prims.of_int (22))
-                                                                    (Prims.of_int (251))
+                                                                    (Prims.of_int (272))
                                                                     (Prims.of_int (67)))))
                                                                     (Obj.magic
                                                                     (Pulse_Syntax_Printer.tag_of_comp
@@ -2619,17 +3052,17 @@ let (maybe_rewrite_body_typing :
                                           (Obj.magic
                                              (FStar_Range.mk_range
                                                 "Pulse.Checker.Abs.fst"
-                                                (Prims.of_int (266))
+                                                (Prims.of_int (287))
                                                 (Prims.of_int (19))
-                                                (Prims.of_int (266))
+                                                (Prims.of_int (287))
                                                 (Prims.of_int (68)))))
                                        (FStar_Sealed.seal
                                           (Obj.magic
                                              (FStar_Range.mk_range
                                                 "Pulse.Checker.Abs.fst"
-                                                (Prims.of_int (265))
+                                                (Prims.of_int (286))
                                                 (Prims.of_int (20))
-                                                (Prims.of_int (279))
+                                                (Prims.of_int (300))
                                                 (Prims.of_int (7)))))
                                        (Obj.magic
                                           (Pulse_Checker_Pure.instantiate_term_implicits
@@ -2644,17 +3077,17 @@ let (maybe_rewrite_body_typing :
                                                          (Obj.magic
                                                             (FStar_Range.mk_range
                                                                "Pulse.Checker.Abs.fst"
-                                                               (Prims.of_int (267))
+                                                               (Prims.of_int (288))
                                                                (Prims.of_int (32))
-                                                               (Prims.of_int (267))
+                                                               (Prims.of_int (288))
                                                                (Prims.of_int (69)))))
                                                       (FStar_Sealed.seal
                                                          (Obj.magic
                                                             (FStar_Range.mk_range
                                                                "Pulse.Checker.Abs.fst"
-                                                               (Prims.of_int (266))
+                                                               (Prims.of_int (287))
                                                                (Prims.of_int (71))
-                                                               (Prims.of_int (278))
+                                                               (Prims.of_int (299))
                                                                (Prims.of_int (26)))))
                                                       (Obj.magic
                                                          (Pulse_Checker_Pure.check_universe
@@ -2671,17 +3104,17 @@ let (maybe_rewrite_body_typing :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (268))
+                                                                    (Prims.of_int (289))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (269))
+                                                                    (Prims.of_int (290))
                                                                     (Prims.of_int (56)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (268))
+                                                                    (Prims.of_int (289))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (278))
+                                                                    (Prims.of_int (299))
                                                                     (Prims.of_int (26)))))
                                                                     (Obj.magic
                                                                     (Pulse_Checker_Base.norm_st_typing_inverse
@@ -2714,17 +3147,17 @@ let (maybe_rewrite_body_typing :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (274))
+                                                                    (Prims.of_int (295))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (277))
+                                                                    (Prims.of_int (298))
                                                                     (Prims.of_int (43)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (278))
+                                                                    (Prims.of_int (299))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (278))
+                                                                    (Prims.of_int (299))
                                                                     (Prims.of_int (26)))))
                                                                     (Obj.magic
                                                                     (debug_abs
@@ -2736,17 +3169,17 @@ let (maybe_rewrite_body_typing :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (277))
+                                                                    (Prims.of_int (298))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (277))
+                                                                    (Prims.of_int (298))
                                                                     (Prims.of_int (42)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (275))
+                                                                    (Prims.of_int (296))
                                                                     (Prims.of_int (22))
-                                                                    (Prims.of_int (277))
+                                                                    (Prims.of_int (298))
                                                                     (Prims.of_int (42)))))
                                                                     (Obj.magic
                                                                     (Pulse_Syntax_Printer.comp_to_string
@@ -2762,17 +3195,17 @@ let (maybe_rewrite_body_typing :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (275))
+                                                                    (Prims.of_int (296))
                                                                     (Prims.of_int (22))
-                                                                    (Prims.of_int (277))
+                                                                    (Prims.of_int (298))
                                                                     (Prims.of_int (42)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (275))
+                                                                    (Prims.of_int (296))
                                                                     (Prims.of_int (22))
-                                                                    (Prims.of_int (277))
+                                                                    (Prims.of_int (298))
                                                                     (Prims.of_int (42)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -2780,9 +3213,9 @@ let (maybe_rewrite_body_typing :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (276))
+                                                                    (Prims.of_int (297))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (276))
+                                                                    (Prims.of_int (297))
                                                                     (Prims.of_int (34)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -2840,17 +3273,17 @@ let (maybe_rewrite_body_typing :
                                       (Obj.magic
                                          (FStar_Range.mk_range
                                             "Pulse.Checker.Abs.fst"
-                                            (Prims.of_int (284))
+                                            (Prims.of_int (305))
                                             (Prims.of_int (15))
-                                            (Prims.of_int (284))
+                                            (Prims.of_int (305))
                                             (Prims.of_int (32)))))
                                    (FStar_Sealed.seal
                                       (Obj.magic
                                          (FStar_Range.mk_range
                                             "Pulse.Checker.Abs.fst"
-                                            (Prims.of_int (285))
+                                            (Prims.of_int (306))
                                             (Prims.of_int (6))
-                                            (Prims.of_int (285))
+                                            (Prims.of_int (306))
                                             (Prims.of_int (79)))))
                                    (FStar_Tactics_Effect.lift_div_tac
                                       (fun uu___ ->
@@ -2880,13 +3313,13 @@ let rec (check_abs_core :
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Checker.Abs.fst"
-                   (Prims.of_int (293)) (Prims.of_int (14))
-                   (Prims.of_int (293)) (Prims.of_int (21)))))
+                   (Prims.of_int (314)) (Prims.of_int (14))
+                   (Prims.of_int (314)) (Prims.of_int (21)))))
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Checker.Abs.fst"
-                   (Prims.of_int (294)) (Prims.of_int (2))
-                   (Prims.of_int (384)) (Prims.of_int (29)))))
+                   (Prims.of_int (315)) (Prims.of_int (2))
+                   (Prims.of_int (424)) (Prims.of_int (29)))))
           (FStar_Tactics_Effect.lift_div_tac
              (fun uu___ -> t.Pulse_Syntax_Base.range2))
           (fun uu___ ->
@@ -2906,13 +3339,13 @@ let rec (check_abs_core :
                          (FStar_Sealed.seal
                             (Obj.magic
                                (FStar_Range.mk_range "Pulse.Checker.Abs.fst"
-                                  (Prims.of_int (298)) (Prims.of_int (24))
-                                  (Prims.of_int (298)) (Prims.of_int (49)))))
+                                  (Prims.of_int (319)) (Prims.of_int (24))
+                                  (Prims.of_int (319)) (Prims.of_int (49)))))
                          (FStar_Sealed.seal
                             (Obj.magic
                                (FStar_Range.mk_range "Pulse.Checker.Abs.fst"
-                                  (Prims.of_int (295)) (Prims.of_int (86))
-                                  (Prims.of_int (384)) (Prims.of_int (29)))))
+                                  (Prims.of_int (316)) (Prims.of_int (86))
+                                  (Prims.of_int (424)) (Prims.of_int (29)))))
                          (Obj.magic
                             (Pulse_Checker_Pure.compute_tot_term_type g t1))
                          (fun uu___ ->
@@ -2926,17 +3359,17 @@ let rec (check_abs_core :
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.Checker.Abs.fst"
-                                                 (Prims.of_int (299))
+                                                 (Prims.of_int (320))
                                                  (Prims.of_int (28))
-                                                 (Prims.of_int (299))
+                                                 (Prims.of_int (320))
                                                  (Prims.of_int (46)))))
                                         (FStar_Sealed.seal
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.Checker.Abs.fst"
-                                                 (Prims.of_int (298))
+                                                 (Prims.of_int (319))
                                                  (Prims.of_int (52))
-                                                 (Prims.of_int (384))
+                                                 (Prims.of_int (424))
                                                  (Prims.of_int (29)))))
                                         (Obj.magic
                                            (Pulse_Checker_Pure.check_universe
@@ -2952,17 +3385,17 @@ let rec (check_abs_core :
                                                           (Obj.magic
                                                              (FStar_Range.mk_range
                                                                 "Pulse.Checker.Abs.fst"
-                                                                (Prims.of_int (300))
+                                                                (Prims.of_int (321))
                                                                 (Prims.of_int (12))
-                                                                (Prims.of_int (300))
+                                                                (Prims.of_int (321))
                                                                 (Prims.of_int (19)))))
                                                        (FStar_Sealed.seal
                                                           (Obj.magic
                                                              (FStar_Range.mk_range
                                                                 "Pulse.Checker.Abs.fst"
-                                                                (Prims.of_int (300))
+                                                                (Prims.of_int (321))
                                                                 (Prims.of_int (22))
-                                                                (Prims.of_int (384))
+                                                                (Prims.of_int (424))
                                                                 (Prims.of_int (29)))))
                                                        (FStar_Tactics_Effect.lift_div_tac
                                                           (fun uu___4 ->
@@ -2976,17 +3409,17 @@ let rec (check_abs_core :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (301))
+                                                                    (Prims.of_int (322))
                                                                     (Prims.of_int (13))
-                                                                    (Prims.of_int (301))
+                                                                    (Prims.of_int (322))
                                                                     (Prims.of_int (22)))))
                                                                   (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (301))
+                                                                    (Prims.of_int (322))
                                                                     (Prims.of_int (25))
-                                                                    (Prims.of_int (384))
+                                                                    (Prims.of_int (424))
                                                                     (Prims.of_int (29)))))
                                                                   (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -3003,17 +3436,17 @@ let rec (check_abs_core :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (302))
+                                                                    (Prims.of_int (323))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (302))
+                                                                    (Prims.of_int (323))
                                                                     (Prims.of_int (50)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (302))
+                                                                    (Prims.of_int (323))
                                                                     (Prims.of_int (53))
-                                                                    (Prims.of_int (384))
+                                                                    (Prims.of_int (424))
                                                                     (Prims.of_int (29)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -3035,17 +3468,17 @@ let rec (check_abs_core :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (303))
+                                                                    (Prims.of_int (324))
                                                                     (Prims.of_int (13))
-                                                                    (Prims.of_int (303))
+                                                                    (Prims.of_int (324))
                                                                     (Prims.of_int (38)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (303))
+                                                                    (Prims.of_int (324))
                                                                     (Prims.of_int (41))
-                                                                    (Prims.of_int (384))
+                                                                    (Prims.of_int (424))
                                                                     (Prims.of_int (29)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -3063,17 +3496,17 @@ let rec (check_abs_core :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (304))
+                                                                    (Prims.of_int (325))
                                                                     (Prims.of_int (22))
-                                                                    (Prims.of_int (304))
+                                                                    (Prims.of_int (325))
                                                                     (Prims.of_int (45)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (305))
+                                                                    (Prims.of_int (326))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (384))
+                                                                    (Prims.of_int (424))
                                                                     (Prims.of_int (29)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -3097,17 +3530,17 @@ let rec (check_abs_core :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (308))
+                                                                    (Prims.of_int (329))
                                                                     (Prims.of_int (44))
-                                                                    (Prims.of_int (308))
+                                                                    (Prims.of_int (329))
                                                                     (Prims.of_int (79)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (306))
+                                                                    (Prims.of_int (327))
                                                                     (Prims.of_int (17))
-                                                                    (Prims.of_int (325))
+                                                                    (Prims.of_int (355))
                                                                     (Prims.of_int (29)))))
                                                                     (Obj.magic
                                                                     (check_abs_core
@@ -3132,24 +3565,69 @@ let rec (check_abs_core :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (312))
-                                                                    (Prims.of_int (32))
-                                                                    (Prims.of_int (312))
-                                                                    (Prims.of_int (80)))))
+                                                                    (Prims.of_int (333))
+                                                                    (Prims.of_int (8))
+                                                                    (Prims.of_int (337))
+                                                                    (Prims.of_int (35)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (308))
+                                                                    (Prims.of_int (329))
                                                                     (Prims.of_int (82))
-                                                                    (Prims.of_int (325))
+                                                                    (Prims.of_int (355))
                                                                     (Prims.of_int (29)))))
                                                                     (Obj.magic
-                                                                    (check_effect_annotation
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Abs.fst"
+                                                                    (Prims.of_int (333))
+                                                                    (Prims.of_int (14))
+                                                                    (Prims.of_int (333))
+                                                                    (Prims.of_int (54)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Abs.fst"
+                                                                    (Prims.of_int (333))
+                                                                    (Prims.of_int (8))
+                                                                    (Prims.of_int (337))
+                                                                    (Prims.of_int (35)))))
+                                                                    (Obj.magic
+                                                                    (sub_effect_comp
                                                                     g'
                                                                     body1.Pulse_Syntax_Base.range2
                                                                     asc
                                                                     c_body))
+                                                                    (fun
+                                                                    uu___6 ->
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___7 ->
+                                                                    match uu___6
+                                                                    with
+                                                                    | 
+                                                                    FStar_Pervasives_Native.None
+                                                                    ->
+                                                                    Prims.Mkdtuple2
+                                                                    (c_body,
+                                                                    body_typing)
+                                                                    | 
+                                                                    FStar_Pervasives_Native.Some
+                                                                    (Prims.Mkdtuple2
+                                                                    (c_body1,
+                                                                    lift)) ->
+                                                                    Prims.Mkdtuple2
+                                                                    (c_body1,
+                                                                    (Pulse_Typing.T_Lift
+                                                                    (g',
+                                                                    body1,
+                                                                    c_body,
+                                                                    c_body1,
+                                                                    body_typing,
+                                                                    lift)))))))
                                                                     (fun
                                                                     uu___6 ->
                                                                     (fun
@@ -3159,39 +3637,7 @@ let rec (check_abs_core :
                                                                     | 
                                                                     Prims.Mkdtuple2
                                                                     (c_body1,
-                                                                    d_sub) ->
-                                                                    Obj.magic
-                                                                    (FStar_Tactics_Effect.tac_bind
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (313))
-                                                                    (Prims.of_int (24))
-                                                                    (Prims.of_int (313))
-                                                                    (Prims.of_int (55)))))
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (313))
-                                                                    (Prims.of_int (58))
-                                                                    (Prims.of_int (325))
-                                                                    (Prims.of_int (29)))))
-                                                                    (FStar_Tactics_Effect.lift_div_tac
-                                                                    (fun
-                                                                    uu___7 ->
-                                                                    Pulse_Typing.T_Sub
-                                                                    (g',
-                                                                    body1,
-                                                                    c_body,
-                                                                    c_body1,
-                                                                    body_typing,
-                                                                    d_sub)))
-                                                                    (fun
-                                                                    uu___7 ->
-                                                                    (fun
-                                                                    body_typing1
+                                                                    body_typing1)
                                                                     ->
                                                                     Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -3199,35 +3645,129 @@ let rec (check_abs_core :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (317))
+                                                                    (Prims.of_int (338))
+                                                                    (Prims.of_int (8))
+                                                                    (Prims.of_int (355))
+                                                                    (Prims.of_int (29)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Abs.fst"
+                                                                    (Prims.of_int (338))
+                                                                    (Prims.of_int (8))
+                                                                    (Prims.of_int (355))
+                                                                    (Prims.of_int (29)))))
+                                                                    (FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___7 ->
+                                                                    uu___6))
+                                                                    (fun
+                                                                    uu___7 ->
+                                                                    (fun
+                                                                    uu___7 ->
+                                                                    Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Abs.fst"
+                                                                    (Prims.of_int (342))
+                                                                    (Prims.of_int (32))
+                                                                    (Prims.of_int (342))
+                                                                    (Prims.of_int (80)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Abs.fst"
+                                                                    (Prims.of_int (338))
+                                                                    (Prims.of_int (8))
+                                                                    (Prims.of_int (355))
+                                                                    (Prims.of_int (29)))))
+                                                                    (Obj.magic
+                                                                    (check_effect_annotation
+                                                                    g'
+                                                                    body1.Pulse_Syntax_Base.range2
+                                                                    asc
+                                                                    c_body1))
+                                                                    (fun
+                                                                    uu___8 ->
+                                                                    (fun
+                                                                    uu___8 ->
+                                                                    match uu___8
+                                                                    with
+                                                                    | 
+                                                                    Prims.Mkdtuple2
+                                                                    (c_body2,
+                                                                    d_sub) ->
+                                                                    Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Abs.fst"
+                                                                    (Prims.of_int (343))
+                                                                    (Prims.of_int (24))
+                                                                    (Prims.of_int (343))
+                                                                    (Prims.of_int (55)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Abs.fst"
+                                                                    (Prims.of_int (343))
+                                                                    (Prims.of_int (58))
+                                                                    (Prims.of_int (355))
+                                                                    (Prims.of_int (29)))))
+                                                                    (FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___9 ->
+                                                                    Pulse_Typing.T_Sub
+                                                                    (g',
+                                                                    body1,
+                                                                    c_body1,
+                                                                    c_body2,
+                                                                    body_typing1,
+                                                                    d_sub)))
+                                                                    (fun
+                                                                    uu___9 ->
+                                                                    (fun
+                                                                    body_typing2
+                                                                    ->
+                                                                    Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Abs.fst"
+                                                                    (Prims.of_int (347))
                                                                     (Prims.of_int (38))
-                                                                    (Prims.of_int (317))
+                                                                    (Prims.of_int (347))
                                                                     (Prims.of_int (79)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (313))
+                                                                    (Prims.of_int (343))
                                                                     (Prims.of_int (58))
-                                                                    (Prims.of_int (325))
+                                                                    (Prims.of_int (355))
                                                                     (Prims.of_int (29)))))
                                                                     (Obj.magic
                                                                     (maybe_rewrite_body_typing
                                                                     g' body1
-                                                                    c_body1
-                                                                    body_typing1
+                                                                    c_body2
+                                                                    body_typing2
                                                                     asc))
                                                                     (fun
-                                                                    uu___7 ->
+                                                                    uu___9 ->
                                                                     FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
-                                                                    uu___8 ->
-                                                                    match uu___7
+                                                                    uu___10
+                                                                    ->
+                                                                    match uu___9
                                                                     with
                                                                     | 
                                                                     Prims.Mkdtuple2
-                                                                    (c_body2,
-                                                                    body_typing2)
+                                                                    (c_body3,
+                                                                    body_typing3)
                                                                     ->
                                                                     FStar_Pervasives.Mkdtuple3
                                                                     ((Pulse_Typing.wtag
@@ -3261,7 +3801,7 @@ let rec (check_abs_core :
                                                                     = ppname
                                                                     } qual
                                                                     (Pulse_Syntax_Naming.close_comp
-                                                                    c_body2 x))),
+                                                                    c_body3 x))),
                                                                     (Pulse_Typing.T_Abs
                                                                     (g, x,
                                                                     qual,
@@ -3273,9 +3813,11 @@ let rec (check_abs_core :
                                                                     }, u,
                                                                     (Pulse_Syntax_Naming.close_st_term
                                                                     body1 x),
-                                                                    c_body2,
+                                                                    c_body3,
                                                                     (),
-                                                                    body_typing2)))))))
+                                                                    body_typing3)))))))
+                                                                    uu___9)))
+                                                                    uu___8)))
                                                                     uu___7)))
                                                                     uu___6)))
                                                                     uu___5))
@@ -3287,17 +3829,17 @@ let rec (check_abs_core :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (328))
+                                                                    (Prims.of_int (358))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (345))
+                                                                    (Prims.of_int (375))
                                                                     (Prims.of_int (47)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (326))
+                                                                    (Prims.of_int (356))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (384))
+                                                                    (Prims.of_int (424))
                                                                     (Prims.of_int (29)))))
                                                                     (match 
                                                                     asc.Pulse_Syntax_Base.elaborated
@@ -3323,17 +3865,17 @@ let rec (check_abs_core :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (335))
+                                                                    (Prims.of_int (365))
                                                                     (Prims.of_int (21))
-                                                                    (Prims.of_int (337))
+                                                                    (Prims.of_int (367))
                                                                     (Prims.of_int (53)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (333))
+                                                                    (Prims.of_int (363))
                                                                     (Prims.of_int (28))
-                                                                    (Prims.of_int (338))
+                                                                    (Prims.of_int (368))
                                                                     (Prims.of_int (9)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -3341,9 +3883,9 @@ let rec (check_abs_core :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (337))
+                                                                    (Prims.of_int (367))
                                                                     (Prims.of_int (24))
-                                                                    (Prims.of_int (337))
+                                                                    (Prims.of_int (367))
                                                                     (Prims.of_int (52)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -3426,17 +3968,17 @@ let rec (check_abs_core :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (347))
+                                                                    (Prims.of_int (377))
                                                                     (Prims.of_int (41))
-                                                                    (Prims.of_int (347))
+                                                                    (Prims.of_int (377))
                                                                     (Prims.of_int (66)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (346))
+                                                                    (Prims.of_int (376))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (384))
+                                                                    (Prims.of_int (424))
                                                                     (Prims.of_int (29)))))
                                                                     (Obj.magic
                                                                     (Pulse_Checker_Pure.check_vprop
@@ -3459,17 +4001,17 @@ let rec (check_abs_core :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (348))
+                                                                    (Prims.of_int (378))
                                                                     (Prims.of_int (16))
-                                                                    (Prims.of_int (348))
+                                                                    (Prims.of_int (378))
                                                                     (Prims.of_int (39)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (348))
+                                                                    (Prims.of_int (378))
                                                                     (Prims.of_int (42))
-                                                                    (Prims.of_int (384))
+                                                                    (Prims.of_int (424))
                                                                     (Prims.of_int (29)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -3487,17 +4029,17 @@ let rec (check_abs_core :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (350))
+                                                                    (Prims.of_int (380))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (363))
+                                                                    (Prims.of_int (393))
                                                                     (Prims.of_int (31)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (364))
+                                                                    (Prims.of_int (394))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (384))
+                                                                    (Prims.of_int (424))
                                                                     (Prims.of_int (29)))))
                                                                     (match post_hint_body
                                                                     with
@@ -3521,17 +4063,17 @@ let rec (check_abs_core :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (357))
+                                                                    (Prims.of_int (387))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (361))
+                                                                    (Prims.of_int (391))
                                                                     (Prims.of_int (22)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (363))
+                                                                    (Prims.of_int (393))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (363))
+                                                                    (Prims.of_int (393))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (Pulse_Checker_Base.intro_post_hint
@@ -3561,17 +4103,17 @@ let rec (check_abs_core :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (366))
+                                                                    (Prims.of_int (396))
                                                                     (Prims.of_int (23))
-                                                                    (Prims.of_int (366))
+                                                                    (Prims.of_int (396))
                                                                     (Prims.of_int (49)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (366))
+                                                                    (Prims.of_int (396))
                                                                     (Prims.of_int (52))
-                                                                    (Prims.of_int (384))
+                                                                    (Prims.of_int (424))
                                                                     (Prims.of_int (29)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -3589,17 +4131,17 @@ let rec (check_abs_core :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (367))
+                                                                    (Prims.of_int (397))
                                                                     (Prims.of_int (15))
-                                                                    (Prims.of_int (367))
+                                                                    (Prims.of_int (397))
                                                                     (Prims.of_int (73)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (367))
+                                                                    (Prims.of_int (397))
                                                                     (Prims.of_int (77))
-                                                                    (Prims.of_int (384))
+                                                                    (Prims.of_int (424))
                                                                     (Prims.of_int (29)))))
                                                                     (Obj.magic
                                                                     (check g'
@@ -3616,17 +4158,17 @@ let rec (check_abs_core :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (369))
+                                                                    (Prims.of_int (399))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (369))
+                                                                    (Prims.of_int (399))
                                                                     (Prims.of_int (65)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (367))
+                                                                    (Prims.of_int (397))
                                                                     (Prims.of_int (77))
-                                                                    (Prims.of_int (384))
+                                                                    (Prims.of_int (424))
                                                                     (Prims.of_int (29)))))
                                                                     (Obj.magic
                                                                     (Pulse_Checker_Base.apply_checker_result_k
@@ -3653,17 +4195,17 @@ let rec (check_abs_core :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (369))
+                                                                    (Prims.of_int (399))
                                                                     (Prims.of_int (68))
-                                                                    (Prims.of_int (384))
+                                                                    (Prims.of_int (424))
                                                                     (Prims.of_int (29)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (369))
+                                                                    (Prims.of_int (399))
                                                                     (Prims.of_int (68))
-                                                                    (Prims.of_int (384))
+                                                                    (Prims.of_int (424))
                                                                     (Prims.of_int (29)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -3679,17 +4221,17 @@ let rec (check_abs_core :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (371))
+                                                                    (Prims.of_int (401))
                                                                     (Prims.of_int (41))
-                                                                    (Prims.of_int (371))
+                                                                    (Prims.of_int (401))
                                                                     (Prims.of_int (101)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (371))
+                                                                    (Prims.of_int (401))
                                                                     (Prims.of_int (106))
-                                                                    (Prims.of_int (384))
+                                                                    (Prims.of_int (424))
                                                                     (Prims.of_int (29)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -3715,24 +4257,70 @@ let rec (check_abs_core :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (372))
-                                                                    (Prims.of_int (32))
-                                                                    (Prims.of_int (372))
-                                                                    (Prims.of_int (85)))))
+                                                                    (Prims.of_int (405))
+                                                                    (Prims.of_int (8))
+                                                                    (Prims.of_int (409))
+                                                                    (Prims.of_int (35)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (371))
+                                                                    (Prims.of_int (401))
                                                                     (Prims.of_int (106))
-                                                                    (Prims.of_int (384))
+                                                                    (Prims.of_int (424))
                                                                     (Prims.of_int (29)))))
                                                                     (Obj.magic
-                                                                    (check_effect_annotation
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Abs.fst"
+                                                                    (Prims.of_int (405))
+                                                                    (Prims.of_int (14))
+                                                                    (Prims.of_int (405))
+                                                                    (Prims.of_int (59)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Abs.fst"
+                                                                    (Prims.of_int (405))
+                                                                    (Prims.of_int (8))
+                                                                    (Prims.of_int (409))
+                                                                    (Prims.of_int (35)))))
+                                                                    (Obj.magic
+                                                                    (sub_effect_comp
                                                                     g'
                                                                     body1.Pulse_Syntax_Base.range2
                                                                     c_opened
                                                                     c_body))
+                                                                    (fun
+                                                                    uu___9 ->
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___10
+                                                                    ->
+                                                                    match uu___9
+                                                                    with
+                                                                    | 
+                                                                    FStar_Pervasives_Native.None
+                                                                    ->
+                                                                    Prims.Mkdtuple2
+                                                                    (c_body,
+                                                                    body_typing)
+                                                                    | 
+                                                                    FStar_Pervasives_Native.Some
+                                                                    (Prims.Mkdtuple2
+                                                                    (c_body1,
+                                                                    lift)) ->
+                                                                    Prims.Mkdtuple2
+                                                                    (c_body1,
+                                                                    (Pulse_Typing.T_Lift
+                                                                    (g',
+                                                                    body1,
+                                                                    c_body,
+                                                                    c_body1,
+                                                                    body_typing,
+                                                                    lift)))))))
                                                                     (fun
                                                                     uu___9 ->
                                                                     (fun
@@ -3742,6 +4330,71 @@ let rec (check_abs_core :
                                                                     | 
                                                                     Prims.Mkdtuple2
                                                                     (c_body1,
+                                                                    body_typing1)
+                                                                    ->
+                                                                    Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Abs.fst"
+                                                                    (Prims.of_int (410))
+                                                                    (Prims.of_int (8))
+                                                                    (Prims.of_int (424))
+                                                                    (Prims.of_int (29)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Abs.fst"
+                                                                    (Prims.of_int (410))
+                                                                    (Prims.of_int (8))
+                                                                    (Prims.of_int (424))
+                                                                    (Prims.of_int (29)))))
+                                                                    (FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___10
+                                                                    -> uu___9))
+                                                                    (fun
+                                                                    uu___10
+                                                                    ->
+                                                                    (fun
+                                                                    uu___10
+                                                                    ->
+                                                                    Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Abs.fst"
+                                                                    (Prims.of_int (412))
+                                                                    (Prims.of_int (32))
+                                                                    (Prims.of_int (412))
+                                                                    (Prims.of_int (85)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Abs.fst"
+                                                                    (Prims.of_int (410))
+                                                                    (Prims.of_int (8))
+                                                                    (Prims.of_int (424))
+                                                                    (Prims.of_int (29)))))
+                                                                    (Obj.magic
+                                                                    (check_effect_annotation
+                                                                    g'
+                                                                    body1.Pulse_Syntax_Base.range2
+                                                                    c_opened
+                                                                    c_body1))
+                                                                    (fun
+                                                                    uu___11
+                                                                    ->
+                                                                    (fun
+                                                                    uu___11
+                                                                    ->
+                                                                    match uu___11
+                                                                    with
+                                                                    | 
+                                                                    Prims.Mkdtuple2
+                                                                    (c_body2,
                                                                     d_sub) ->
                                                                     Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -3749,34 +4402,34 @@ let rec (check_abs_core :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (373))
+                                                                    (Prims.of_int (413))
                                                                     (Prims.of_int (24))
-                                                                    (Prims.of_int (373))
+                                                                    (Prims.of_int (413))
                                                                     (Prims.of_int (55)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (373))
+                                                                    (Prims.of_int (413))
                                                                     (Prims.of_int (58))
-                                                                    (Prims.of_int (384))
+                                                                    (Prims.of_int (424))
                                                                     (Prims.of_int (29)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
-                                                                    uu___10
+                                                                    uu___12
                                                                     ->
                                                                     Pulse_Typing.T_Sub
                                                                     (g',
                                                                     body1,
-                                                                    c_body,
                                                                     c_body1,
-                                                                    body_typing,
+                                                                    c_body2,
+                                                                    body_typing1,
                                                                     d_sub)))
                                                                     (fun
-                                                                    uu___10
+                                                                    uu___12
                                                                     ->
                                                                     (fun
-                                                                    body_typing1
+                                                                    body_typing2
                                                                     ->
                                                                     Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -3784,37 +4437,37 @@ let rec (check_abs_core :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (375))
+                                                                    (Prims.of_int (415))
                                                                     (Prims.of_int (38))
-                                                                    (Prims.of_int (375))
+                                                                    (Prims.of_int (415))
                                                                     (Prims.of_int (79)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (373))
+                                                                    (Prims.of_int (413))
                                                                     (Prims.of_int (58))
-                                                                    (Prims.of_int (384))
+                                                                    (Prims.of_int (424))
                                                                     (Prims.of_int (29)))))
                                                                     (Obj.magic
                                                                     (maybe_rewrite_body_typing
                                                                     g' body1
-                                                                    c_body1
-                                                                    body_typing1
+                                                                    c_body2
+                                                                    body_typing2
                                                                     asc))
                                                                     (fun
-                                                                    uu___10
+                                                                    uu___12
                                                                     ->
                                                                     FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
-                                                                    uu___11
+                                                                    uu___13
                                                                     ->
-                                                                    match uu___10
+                                                                    match uu___12
                                                                     with
                                                                     | 
                                                                     Prims.Mkdtuple2
-                                                                    (c_body2,
-                                                                    body_typing2)
+                                                                    (c_body3,
+                                                                    body_typing3)
                                                                     ->
                                                                     FStar_Pervasives.Mkdtuple3
                                                                     ((Pulse_Typing.wtag
@@ -3848,7 +4501,7 @@ let rec (check_abs_core :
                                                                     = ppname
                                                                     } qual
                                                                     (Pulse_Syntax_Naming.close_comp
-                                                                    c_body2 x))),
+                                                                    c_body3 x))),
                                                                     (Pulse_Typing.T_Abs
                                                                     (g, x,
                                                                     qual,
@@ -3860,9 +4513,11 @@ let rec (check_abs_core :
                                                                     }, u,
                                                                     (Pulse_Syntax_Naming.close_st_term
                                                                     body1 x),
-                                                                    c_body2,
+                                                                    c_body3,
                                                                     (),
-                                                                    body_typing2)))))))
+                                                                    body_typing3)))))))
+                                                                    uu___12)))
+                                                                    uu___11)))
                                                                     uu___10)))
                                                                     uu___9)))
                                                                     uu___9)))
@@ -3896,13 +4551,13 @@ let (check_abs :
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Checker.Abs.fst"
-                   (Prims.of_int (388)) (Prims.of_int (10))
-                   (Prims.of_int (388)) (Prims.of_int (28)))))
+                   (Prims.of_int (428)) (Prims.of_int (10))
+                   (Prims.of_int (428)) (Prims.of_int (28)))))
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Checker.Abs.fst"
-                   (Prims.of_int (389)) (Prims.of_int (2))
-                   (Prims.of_int (389)) (Prims.of_int (26)))))
+                   (Prims.of_int (429)) (Prims.of_int (2))
+                   (Prims.of_int (429)) (Prims.of_int (26)))))
           (Obj.magic (preprocess_abs g t))
           (fun uu___ ->
              (fun t1 -> Obj.magic (check_abs_core g t1 check)) uu___)

--- a/src/ocaml/plugin/generated/Pulse_Checker_If.ml
+++ b/src/ocaml/plugin/generated/Pulse_Checker_If.ml
@@ -81,7 +81,7 @@ let (lift_ghost_to_atomic :
                                                (inames,
                                                  Pulse_Syntax_Base.Unobservable,
                                                  c_st)), d,
-                                            (Pulse_Typing.Lift_STGhost_STAtomic
+                                            (Pulse_Typing.Lift_STGhost_STUnobservable
                                                (g, c, w))))))))) uu___)
 let (lift_if_branches :
   Pulse_Typing_Env.env ->

--- a/src/ocaml/plugin/generated/Pulse_Checker_WithInv.ml
+++ b/src/ocaml/plugin/generated/Pulse_Checker_WithInv.ml
@@ -1403,10 +1403,10 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (172))
-                                                                    (Prims.of_int (6))
-                                                                    (Prims.of_int (172))
-                                                                    (Prims.of_int (21)))))
+                                                                    (Prims.of_int (171))
+                                                                    (Prims.of_int (4))
+                                                                    (Prims.of_int (174))
+                                                                    (Prims.of_int (20)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
@@ -1418,8 +1418,19 @@ let (check :
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
                                                                     uu___3 ->
+                                                                    if
+                                                                    (FStar_Pervasives_Native.uu___is_None
+                                                                    post.Pulse_Typing.ctag_hint)
+                                                                    ||
+                                                                    (post.Pulse_Typing.ctag_hint
+                                                                    =
+                                                                    (FStar_Pervasives_Native.Some
+                                                                    Pulse_Syntax_Base.STT))
+                                                                    then
                                                                     FStar_Pervasives_Native.Some
-                                                                    Pulse_Syntax_Base.STT_Atomic))
+                                                                    Pulse_Syntax_Base.STT_Atomic
+                                                                    else
+                                                                    post.Pulse_Typing.ctag_hint))
                                                                     (fun
                                                                     uu___3 ->
                                                                     (fun
@@ -1601,7 +1612,7 @@ let (check :
                                                                     (Prims.of_int (202))
                                                                     (Prims.of_int (4))
                                                                     (Prims.of_int (211))
-                                                                    (Prims.of_int (64)))))
+                                                                    (Prims.of_int (57)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
@@ -1904,9 +1915,9 @@ let (check :
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
                                                                     (Prims.of_int (211))
-                                                                    (Prims.of_int (35))
+                                                                    (Prims.of_int (28))
                                                                     (Prims.of_int (211))
-                                                                    (Prims.of_int (64)))))
+                                                                    (Prims.of_int (57)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
@@ -1914,7 +1925,7 @@ let (check :
                                                                     (Prims.of_int (211))
                                                                     (Prims.of_int (6))
                                                                     (Prims.of_int (211))
-                                                                    (Prims.of_int (64)))))
+                                                                    (Prims.of_int (57)))))
                                                                     (Obj.magic
                                                                     (st_comp_remove_inv
                                                                     inv_p st))
@@ -1925,7 +1936,7 @@ let (check :
                                                                     uu___5 ->
                                                                     Pulse_Syntax_Base.C_STAtomic
                                                                     (inames,
-                                                                    Pulse_Syntax_Base.Observable,
+                                                                    obs,
                                                                     uu___4)))))
                                                                     (fun
                                                                     uu___4 ->
@@ -1940,7 +1951,7 @@ let (check :
                                                                     (Prims.of_int (217))
                                                                     (Prims.of_int (6))
                                                                     (Prims.of_int (219))
-                                                                    (Prims.of_int (48)))))
+                                                                    (Prims.of_int (41)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
@@ -1971,8 +1982,7 @@ let (check :
                                                                     Pulse_Syntax_Base.effect_tag
                                                                     =
                                                                     (FStar_Sealed.seal
-                                                                    (FStar_Pervasives_Native.Some
-                                                                    Pulse_Syntax_Base.STT_Atomic))
+                                                                    ctag_hint')
                                                                     }))
                                                                     (fun
                                                                     uu___4 ->

--- a/src/ocaml/plugin/generated/Pulse_Elaborate_Core.ml
+++ b/src/ocaml/plugin/generated/Pulse_Elaborate_Core.ml
@@ -192,13 +192,13 @@ let (elab_lift :
                      FStar_Reflection_V2_Data.Q_Explicit
                      (Pulse_Elaborate_Pure.elab_term
                         (Pulse_Syntax_Base.comp_post c1))) e
-            | Pulse_Typing.Lift_STGhost_STAtomic
+            | Pulse_Typing.Lift_STGhost_STUnobservable
                 (uu___, uu___1, Prims.Mkdtuple2 (reveal_a, reveal_a_typing))
                 ->
                 let t =
                   Pulse_Elaborate_Pure.elab_term
                     (Pulse_Syntax_Base.comp_res c1) in
-                Pulse_Reflection_Util.mk_lift_ghost_atomic
+                Pulse_Reflection_Util.mk_lift_ghost_unobservable
                   (Pulse_Syntax_Base.comp_u c1) t
                   (Pulse_Elaborate_Pure.elab_term
                      (Pulse_Syntax_Base.comp_inames c1))
@@ -209,6 +209,20 @@ let (elab_lift :
                      (Pulse_Elaborate_Pure.elab_term
                         (Pulse_Syntax_Base.comp_post c1))) e
                   (Pulse_Elaborate_Pure.elab_term reveal_a)
+            | Pulse_Typing.Lift_STUnobservable_STAtomic (uu___, uu___1) ->
+                let t =
+                  Pulse_Elaborate_Pure.elab_term
+                    (Pulse_Syntax_Base.comp_res c1) in
+                Pulse_Reflection_Util.mk_lift_unobservable_atomic
+                  (Pulse_Syntax_Base.comp_u c1) t
+                  (Pulse_Elaborate_Pure.elab_term
+                     (Pulse_Syntax_Base.comp_inames c1))
+                  (Pulse_Elaborate_Pure.elab_term
+                     (Pulse_Syntax_Base.comp_pre c1))
+                  (Pulse_Reflection_Util.mk_abs t
+                     FStar_Reflection_V2_Data.Q_Explicit
+                     (Pulse_Elaborate_Pure.elab_term
+                        (Pulse_Syntax_Base.comp_post c1))) e
 let (intro_pure_tm : Pulse_Syntax_Base.term -> Pulse_Syntax_Base.st_term) =
   fun p ->
     Pulse_Typing.wtag

--- a/src/ocaml/plugin/generated/Pulse_Reflection_Util.ml
+++ b/src/ocaml/plugin/generated/Pulse_Reflection_Util.ml
@@ -1027,7 +1027,7 @@ let (mk_lift_atomic_stt :
             FStar_Reflection_V2_Builtins.pack_ln
               (FStar_Reflection_V2_Data.Tv_App
                  (t3, (e, FStar_Reflection_V2_Data.Q_Explicit)))
-let (mk_lift_ghost_atomic :
+let (mk_lift_ghost_unobservable :
   FStar_Reflection_Types.universe ->
     FStar_Reflection_Types.term ->
       FStar_Reflection_Types.term ->
@@ -1043,7 +1043,7 @@ let (mk_lift_ghost_atomic :
           fun post ->
             fun e ->
               fun reveal_a ->
-                let lid = mk_pulse_lib_core_lid "lift_stt_ghost" in
+                let lid = mk_pulse_lib_core_lid "lift_ghost_unobservable" in
                 let t =
                   FStar_Reflection_V2_Builtins.pack_ln
                     (FStar_Reflection_V2_Data.Tv_UInst
@@ -1071,6 +1071,44 @@ let (mk_lift_ghost_atomic :
                 FStar_Reflection_V2_Builtins.pack_ln
                   (FStar_Reflection_V2_Data.Tv_App
                      (t5, (reveal_a, FStar_Reflection_V2_Data.Q_Explicit)))
+let (mk_lift_unobservable_atomic :
+  FStar_Reflection_Types.universe ->
+    FStar_Reflection_Types.term ->
+      FStar_Reflection_Types.term ->
+        FStar_Reflection_Types.term ->
+          FStar_Reflection_Types.term ->
+            FStar_Reflection_Types.term -> FStar_Reflection_Types.term)
+  =
+  fun u ->
+    fun a ->
+      fun opened ->
+        fun pre ->
+          fun post ->
+            fun e ->
+              let lid = mk_pulse_lib_core_lid "lift_unobservable_atomic" in
+              let t =
+                FStar_Reflection_V2_Builtins.pack_ln
+                  (FStar_Reflection_V2_Data.Tv_UInst
+                     ((FStar_Reflection_V2_Builtins.pack_fv lid), [u])) in
+              let t1 =
+                FStar_Reflection_V2_Builtins.pack_ln
+                  (FStar_Reflection_V2_Data.Tv_App
+                     (t, (a, FStar_Reflection_V2_Data.Q_Implicit))) in
+              let t2 =
+                FStar_Reflection_V2_Builtins.pack_ln
+                  (FStar_Reflection_V2_Data.Tv_App
+                     (t1, (opened, FStar_Reflection_V2_Data.Q_Implicit))) in
+              let t3 =
+                FStar_Reflection_V2_Builtins.pack_ln
+                  (FStar_Reflection_V2_Data.Tv_App
+                     (t2, (pre, FStar_Reflection_V2_Data.Q_Implicit))) in
+              let t4 =
+                FStar_Reflection_V2_Builtins.pack_ln
+                  (FStar_Reflection_V2_Data.Tv_App
+                     (t3, (post, FStar_Reflection_V2_Data.Q_Implicit))) in
+              FStar_Reflection_V2_Builtins.pack_ln
+                (FStar_Reflection_V2_Data.Tv_App
+                   (t4, (e, FStar_Reflection_V2_Data.Q_Explicit)))
 let (mk_bind_stt :
   FStar_Reflection_Types.universe ->
     FStar_Reflection_Types.universe ->
@@ -2118,39 +2156,39 @@ let (mk_opaque_let :
             (FStar_Sealed.seal
                (Obj.magic
                   (FStar_Range.mk_range "Pulse.Reflection.Util.fst"
-                     (Prims.of_int (734)) (Prims.of_int (11))
-                     (Prims.of_int (734)) (Prims.of_int (45)))))
+                     (Prims.of_int (745)) (Prims.of_int (11))
+                     (Prims.of_int (745)) (Prims.of_int (45)))))
             (FStar_Sealed.seal
                (Obj.magic
                   (FStar_Range.mk_range "Pulse.Reflection.Util.fst"
-                     (Prims.of_int (734)) (Prims.of_int (48))
-                     (Prims.of_int (740)) (Prims.of_int (18)))))
+                     (Prims.of_int (745)) (Prims.of_int (48))
+                     (Prims.of_int (751)) (Prims.of_int (18)))))
             (Obj.magic
                (FStar_Tactics_Effect.tac_bind
                   (FStar_Sealed.seal
                      (Obj.magic
                         (FStar_Range.mk_range "Pulse.Reflection.Util.fst"
-                           (Prims.of_int (734)) (Prims.of_int (21))
-                           (Prims.of_int (734)) (Prims.of_int (45)))))
+                           (Prims.of_int (745)) (Prims.of_int (21))
+                           (Prims.of_int (745)) (Prims.of_int (45)))))
                   (FStar_Sealed.seal
                      (Obj.magic
                         (FStar_Range.mk_range "Pulse.Reflection.Util.fst"
-                           (Prims.of_int (734)) (Prims.of_int (11))
-                           (Prims.of_int (734)) (Prims.of_int (45)))))
+                           (Prims.of_int (745)) (Prims.of_int (11))
+                           (Prims.of_int (745)) (Prims.of_int (45)))))
                   (Obj.magic
                      (FStar_Tactics_Effect.tac_bind
                         (FStar_Sealed.seal
                            (Obj.magic
                               (FStar_Range.mk_range
                                  "Pulse.Reflection.Util.fst"
-                                 (Prims.of_int (734)) (Prims.of_int (22))
-                                 (Prims.of_int (734)) (Prims.of_int (37)))))
+                                 (Prims.of_int (745)) (Prims.of_int (22))
+                                 (Prims.of_int (745)) (Prims.of_int (37)))))
                         (FStar_Sealed.seal
                            (Obj.magic
                               (FStar_Range.mk_range
                                  "Pulse.Reflection.Util.fst"
-                                 (Prims.of_int (734)) (Prims.of_int (21))
-                                 (Prims.of_int (734)) (Prims.of_int (45)))))
+                                 (Prims.of_int (745)) (Prims.of_int (21))
+                                 (Prims.of_int (745)) (Prims.of_int (45)))))
                         (Obj.magic (FStar_Tactics_V2_Derived.cur_module ()))
                         (fun uu___ ->
                            FStar_Tactics_Effect.lift_div_tac

--- a/src/ocaml/plugin/generated/Pulse_Typing.ml
+++ b/src/ocaml/plugin/generated/Pulse_Typing.ml
@@ -972,12 +972,16 @@ let uu___is_STS_AtomicInvs uu___2 uu___1 uu___ uu___3 =
   match uu___3 with | STS_AtomicInvs _ -> true | _ -> false
 type ('dummyV0, 'dummyV1, 'dummyV2) lift_comp =
   | Lift_STAtomic_ST of Pulse_Typing_Env.env * Pulse_Syntax_Base.comp_st 
-  | Lift_STGhost_STAtomic of Pulse_Typing_Env.env * Pulse_Syntax_Base.comp_st
-  * (unit, unit) non_informative_c 
+  | Lift_STUnobservable_STAtomic of Pulse_Typing_Env.env *
+  Pulse_Syntax_Base.comp_st 
+  | Lift_STGhost_STUnobservable of Pulse_Typing_Env.env *
+  Pulse_Syntax_Base.comp_st * (unit, unit) non_informative_c 
 let uu___is_Lift_STAtomic_ST uu___2 uu___1 uu___ uu___3 =
   match uu___3 with | Lift_STAtomic_ST _ -> true | _ -> false
-let uu___is_Lift_STGhost_STAtomic uu___2 uu___1 uu___ uu___3 =
-  match uu___3 with | Lift_STGhost_STAtomic _ -> true | _ -> false
+let uu___is_Lift_STUnobservable_STAtomic uu___2 uu___1 uu___ uu___3 =
+  match uu___3 with | Lift_STUnobservable_STAtomic _ -> true | _ -> false
+let uu___is_Lift_STGhost_STUnobservable uu___2 uu___1 uu___ uu___3 =
+  match uu___3 with | Lift_STGhost_STUnobservable _ -> true | _ -> false
 let (wr :
   Pulse_Syntax_Base.comp_st ->
     Pulse_Syntax_Base.st_term' -> Pulse_Syntax_Base.st_term)

--- a/src/ocaml/plugin/generated/Pulse_Typing_Combinators.ml
+++ b/src/ocaml/plugin/generated/Pulse_Typing_Combinators.ml
@@ -1745,7 +1745,7 @@ let rec (mk_bind :
                                   (FStar_Range.mk_range
                                      "Pulse.Typing.Combinators.fst"
                                      (Prims.of_int (317)) (Prims.of_int (38))
-                                     (Prims.of_int (368)) (Prims.of_int (82)))))
+                                     (Prims.of_int (372)) (Prims.of_int (82)))))
                             (FStar_Tactics_Effect.lift_div_tac
                                (fun uu___ -> px))
                             (fun uu___ ->
@@ -1768,7 +1768,7 @@ let rec (mk_bind :
                                                     "Pulse.Typing.Combinators.fst"
                                                     (Prims.of_int (320))
                                                     (Prims.of_int (2))
-                                                    (Prims.of_int (368))
+                                                    (Prims.of_int (372))
                                                     (Prims.of_int (82)))))
                                            (FStar_Tactics_Effect.lift_div_tac
                                               (fun uu___2 ->
@@ -1818,17 +1818,17 @@ let rec (mk_bind :
                                                                   (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Typing.Combinators.fst"
-                                                                    (Prims.of_int (331))
+                                                                    (Prims.of_int (330))
                                                                     (Prims.of_int (21))
-                                                                    (Prims.of_int (331))
+                                                                    (Prims.of_int (330))
                                                                     (Prims.of_int (46)))))
                                                                (FStar_Sealed.seal
                                                                   (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Typing.Combinators.fst"
-                                                                    (Prims.of_int (331))
+                                                                    (Prims.of_int (330))
                                                                     (Prims.of_int (49))
-                                                                    (Prims.of_int (334))
+                                                                    (Prims.of_int (333))
                                                                     (Prims.of_int (81)))))
                                                                (FStar_Tactics_Effect.lift_div_tac
                                                                   (fun uu___3
@@ -1846,17 +1846,17 @@ let rec (mk_bind :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Typing.Combinators.fst"
-                                                                    (Prims.of_int (333))
+                                                                    (Prims.of_int (332))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (333))
+                                                                    (Prims.of_int (332))
                                                                     (Prims.of_int (58)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Typing.Combinators.fst"
-                                                                    (Prims.of_int (334))
+                                                                    (Prims.of_int (333))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (334))
+                                                                    (Prims.of_int (333))
                                                                     (Prims.of_int (81)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -1894,17 +1894,17 @@ let rec (mk_bind :
                                                                 (Obj.magic
                                                                    (FStar_Range.mk_range
                                                                     "Pulse.Typing.Combinators.fst"
-                                                                    (Prims.of_int (337))
+                                                                    (Prims.of_int (336))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (337))
+                                                                    (Prims.of_int (336))
                                                                     (Prims.of_int (44)))))
                                                              (FStar_Sealed.seal
                                                                 (Obj.magic
                                                                    (FStar_Range.mk_range
                                                                     "Pulse.Typing.Combinators.fst"
-                                                                    (Prims.of_int (337))
+                                                                    (Prims.of_int (336))
                                                                     (Prims.of_int (47))
-                                                                    (Prims.of_int (340))
+                                                                    (Prims.of_int (339))
                                                                     (Prims.of_int (79)))))
                                                              (FStar_Tactics_Effect.lift_div_tac
                                                                 (fun uu___5
@@ -1921,17 +1921,17 @@ let rec (mk_bind :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Typing.Combinators.fst"
-                                                                    (Prims.of_int (339))
+                                                                    (Prims.of_int (338))
                                                                     (Prims.of_int (5))
-                                                                    (Prims.of_int (339))
+                                                                    (Prims.of_int (338))
                                                                     (Prims.of_int (55)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Typing.Combinators.fst"
-                                                                    (Prims.of_int (340))
+                                                                    (Prims.of_int (339))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (340))
+                                                                    (Prims.of_int (339))
                                                                     (Prims.of_int (79)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -1966,6 +1966,16 @@ let rec (mk_bind :
                                                      Obj.magic
                                                        (Obj.repr
                                                           (mk_bind_ghost_atomic
+                                                             g pre e1 e2 c1
+                                                             c2 px d_e1 ()
+                                                             d_e2 () ()))
+                                                 | (Pulse_Syntax_Base.C_STAtomic
+                                                    (inames1, uu___2, uu___3),
+                                                    Pulse_Syntax_Base.C_STGhost
+                                                    (inames2, uu___4)) ->
+                                                     Obj.magic
+                                                       (Obj.repr
+                                                          (mk_bind_atomic_ghost
                                                              g pre e1 e2 c1
                                                              c2 px d_e1 ()
                                                              d_e2 () ()))
@@ -2071,17 +2081,17 @@ let rec (mk_bind :
                                                                 (Obj.magic
                                                                    (FStar_Range.mk_range
                                                                     "Pulse.Typing.Combinators.fst"
-                                                                    (Prims.of_int (354))
+                                                                    (Prims.of_int (358))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (354))
+                                                                    (Prims.of_int (358))
                                                                     (Prims.of_int (69)))))
                                                              (FStar_Sealed.seal
                                                                 (Obj.magic
                                                                    (FStar_Range.mk_range
                                                                     "Pulse.Typing.Combinators.fst"
-                                                                    (Prims.of_int (354))
-                                                                    (Prims.of_int (72))
                                                                     (Prims.of_int (358))
+                                                                    (Prims.of_int (72))
+                                                                    (Prims.of_int (362))
                                                                     (Prims.of_int (81)))))
                                                              (Obj.magic
                                                                 (Pulse_Checker_Pure.get_non_informative_witness
@@ -2098,17 +2108,17 @@ let rec (mk_bind :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Typing.Combinators.fst"
-                                                                    (Prims.of_int (355))
+                                                                    (Prims.of_int (359))
                                                                     (Prims.of_int (21))
-                                                                    (Prims.of_int (355))
+                                                                    (Prims.of_int (359))
                                                                     (Prims.of_int (72)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Typing.Combinators.fst"
-                                                                    (Prims.of_int (355))
+                                                                    (Prims.of_int (359))
                                                                     (Prims.of_int (75))
-                                                                    (Prims.of_int (358))
+                                                                    (Prims.of_int (362))
                                                                     (Prims.of_int (81)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -2129,17 +2139,17 @@ let rec (mk_bind :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Typing.Combinators.fst"
-                                                                    (Prims.of_int (357))
+                                                                    (Prims.of_int (361))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (357))
-                                                                    (Prims.of_int (65)))))
+                                                                    (Prims.of_int (361))
+                                                                    (Prims.of_int (71)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Typing.Combinators.fst"
-                                                                    (Prims.of_int (358))
+                                                                    (Prims.of_int (362))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (358))
+                                                                    (Prims.of_int (362))
                                                                     (Prims.of_int (81)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -2149,7 +2159,7 @@ let rec (mk_bind :
                                                                     c1,
                                                                     c1lifted,
                                                                     d_e1,
-                                                                    (Pulse_Typing.Lift_STGhost_STAtomic
+                                                                    (Pulse_Typing.Lift_STGhost_STUnobservable
                                                                     (g, c1,
                                                                     w)))))
                                                                     (fun
@@ -2179,17 +2189,17 @@ let rec (mk_bind :
                                                                 (Obj.magic
                                                                    (FStar_Range.mk_range
                                                                     "Pulse.Typing.Combinators.fst"
-                                                                    (Prims.of_int (361))
+                                                                    (Prims.of_int (365))
                                                                     (Prims.of_int (13))
-                                                                    (Prims.of_int (361))
+                                                                    (Prims.of_int (365))
                                                                     (Prims.of_int (52)))))
                                                              (FStar_Sealed.seal
                                                                 (Obj.magic
                                                                    (FStar_Range.mk_range
                                                                     "Pulse.Typing.Combinators.fst"
-                                                                    (Prims.of_int (361))
+                                                                    (Prims.of_int (365))
                                                                     (Prims.of_int (55))
-                                                                    (Prims.of_int (367))
+                                                                    (Prims.of_int (371))
                                                                     (Prims.of_int (17)))))
                                                              (FStar_Tactics_Effect.lift_div_tac
                                                                 (fun uu___4
@@ -2208,17 +2218,17 @@ let rec (mk_bind :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Typing.Combinators.fst"
-                                                                    (Prims.of_int (362))
+                                                                    (Prims.of_int (366))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (362))
+                                                                    (Prims.of_int (366))
                                                                     (Prims.of_int (68)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Typing.Combinators.fst"
-                                                                    (Prims.of_int (362))
+                                                                    (Prims.of_int (366))
                                                                     (Prims.of_int (71))
-                                                                    (Prims.of_int (367))
+                                                                    (Prims.of_int (371))
                                                                     (Prims.of_int (17)))))
                                                                     (Obj.magic
                                                                     (Pulse_Checker_Pure.get_non_informative_witness
@@ -2236,17 +2246,17 @@ let rec (mk_bind :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Typing.Combinators.fst"
-                                                                    (Prims.of_int (363))
+                                                                    (Prims.of_int (367))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (363))
+                                                                    (Prims.of_int (367))
                                                                     (Prims.of_int (70)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Typing.Combinators.fst"
-                                                                    (Prims.of_int (363))
-                                                                    (Prims.of_int (73))
                                                                     (Prims.of_int (367))
+                                                                    (Prims.of_int (73))
+                                                                    (Prims.of_int (371))
                                                                     (Prims.of_int (17)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -2267,17 +2277,17 @@ let rec (mk_bind :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Typing.Combinators.fst"
-                                                                    (Prims.of_int (365))
+                                                                    (Prims.of_int (369))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (365))
-                                                                    (Prims.of_int (64)))))
+                                                                    (Prims.of_int (369))
+                                                                    (Prims.of_int (70)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Typing.Combinators.fst"
-                                                                    (Prims.of_int (365))
-                                                                    (Prims.of_int (67))
-                                                                    (Prims.of_int (367))
+                                                                    (Prims.of_int (369))
+                                                                    (Prims.of_int (73))
+                                                                    (Prims.of_int (371))
                                                                     (Prims.of_int (17)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -2296,7 +2306,7 @@ let rec (mk_bind :
                                                                     c2,
                                                                     c2lifted,
                                                                     d_e2,
-                                                                    (Pulse_Typing.Lift_STGhost_STAtomic
+                                                                    (Pulse_Typing.Lift_STGhost_STUnobservable
                                                                     (g', c2,
                                                                     w)))))
                                                                     (fun
@@ -2309,17 +2319,17 @@ let rec (mk_bind :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Typing.Combinators.fst"
-                                                                    (Prims.of_int (366))
+                                                                    (Prims.of_int (370))
                                                                     (Prims.of_int (24))
-                                                                    (Prims.of_int (366))
+                                                                    (Prims.of_int (370))
                                                                     (Prims.of_int (99)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Typing.Combinators.fst"
-                                                                    (Prims.of_int (365))
-                                                                    (Prims.of_int (67))
-                                                                    (Prims.of_int (367))
+                                                                    (Prims.of_int (369))
+                                                                    (Prims.of_int (73))
+                                                                    (Prims.of_int (371))
                                                                     (Prims.of_int (17)))))
                                                                     (Obj.magic
                                                                     (mk_bind
@@ -2378,17 +2388,17 @@ let (bind_res_and_post_typing :
                                   (Obj.magic
                                      (FStar_Range.mk_range
                                         "Pulse.Typing.Combinators.fst"
-                                        (Prims.of_int (380))
+                                        (Prims.of_int (384))
                                         (Prims.of_int (32))
-                                        (Prims.of_int (380))
+                                        (Prims.of_int (384))
                                         (Prims.of_int (55)))))
                                (FStar_Sealed.seal
                                   (Obj.magic
                                      (FStar_Range.mk_range
                                         "Pulse.Typing.Combinators.fst"
-                                        (Prims.of_int (377))
+                                        (Prims.of_int (381))
                                         (Prims.of_int (13))
-                                        (Prims.of_int (391))
+                                        (Prims.of_int (395))
                                         (Prims.of_int (7)))))
                                (Obj.magic
                                   (Pulse_Checker_Pure.check_universe g
@@ -2418,17 +2428,17 @@ let (bind_res_and_post_typing :
                                                      (Obj.magic
                                                         (FStar_Range.mk_range
                                                            "Pulse.Typing.Combinators.fst"
-                                                           (Prims.of_int (384))
+                                                           (Prims.of_int (388))
                                                            (Prims.of_int (23))
-                                                           (Prims.of_int (384))
+                                                           (Prims.of_int (388))
                                                            (Prims.of_int (122)))))
                                                   (FStar_Sealed.seal
                                                      (Obj.magic
                                                         (FStar_Range.mk_range
                                                            "Pulse.Typing.Combinators.fst"
-                                                           (Prims.of_int (384))
+                                                           (Prims.of_int (388))
                                                            (Prims.of_int (11))
-                                                           (Prims.of_int (384))
+                                                           (Prims.of_int (388))
                                                            (Prims.of_int (122)))))
                                                   (Obj.magic
                                                      (FStar_Tactics_Effect.tac_bind
@@ -2436,9 +2446,9 @@ let (bind_res_and_post_typing :
                                                            (Obj.magic
                                                               (FStar_Range.mk_range
                                                                  "Pulse.Typing.Combinators.fst"
-                                                                 (Prims.of_int (384))
+                                                                 (Prims.of_int (388))
                                                                  (Prims.of_int (95))
-                                                                 (Prims.of_int (384))
+                                                                 (Prims.of_int (388))
                                                                  (Prims.of_int (121)))))
                                                         (FStar_Sealed.seal
                                                            (Obj.magic
@@ -2477,17 +2487,17 @@ let (bind_res_and_post_typing :
                                                      (Obj.magic
                                                         (FStar_Range.mk_range
                                                            "Pulse.Typing.Combinators.fst"
-                                                           (Prims.of_int (386))
+                                                           (Prims.of_int (390))
                                                            (Prims.of_int (16))
-                                                           (Prims.of_int (386))
+                                                           (Prims.of_int (390))
                                                            (Prims.of_int (17)))))
                                                   (FStar_Sealed.seal
                                                      (Obj.magic
                                                         (FStar_Range.mk_range
                                                            "Pulse.Typing.Combinators.fst"
-                                                           (Prims.of_int (386))
-                                                           (Prims.of_int (20))
                                                            (Prims.of_int (390))
+                                                           (Prims.of_int (20))
+                                                           (Prims.of_int (394))
                                                            (Prims.of_int (31)))))
                                                   (FStar_Tactics_Effect.lift_div_tac
                                                      (fun uu___3 -> x))
@@ -2499,17 +2509,17 @@ let (bind_res_and_post_typing :
                                                                 (Obj.magic
                                                                    (FStar_Range.mk_range
                                                                     "Pulse.Typing.Combinators.fst"
-                                                                    (Prims.of_int (387))
+                                                                    (Prims.of_int (391))
                                                                     (Prims.of_int (29))
-                                                                    (Prims.of_int (387))
+                                                                    (Prims.of_int (391))
                                                                     (Prims.of_int (61)))))
                                                              (FStar_Sealed.seal
                                                                 (Obj.magic
                                                                    (FStar_Range.mk_range
                                                                     "Pulse.Typing.Combinators.fst"
-                                                                    (Prims.of_int (387))
+                                                                    (Prims.of_int (391))
                                                                     (Prims.of_int (64))
-                                                                    (Prims.of_int (390))
+                                                                    (Prims.of_int (394))
                                                                     (Prims.of_int (31)))))
                                                              (FStar_Tactics_Effect.lift_div_tac
                                                                 (fun uu___3
@@ -2528,17 +2538,17 @@ let (bind_res_and_post_typing :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Typing.Combinators.fst"
-                                                                    (Prims.of_int (389))
+                                                                    (Prims.of_int (393))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (389))
+                                                                    (Prims.of_int (393))
                                                                     (Prims.of_int (87)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Typing.Combinators.fst"
-                                                                    (Prims.of_int (390))
+                                                                    (Prims.of_int (394))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (390))
+                                                                    (Prims.of_int (394))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (Pulse_Checker_Pure.check_vprop_with_core

--- a/src/ocaml/plugin/generated/Pulse_Typing_Metatheory_Base.ml
+++ b/src/ocaml/plugin/generated/Pulse_Typing_Metatheory_Base.ml
@@ -205,13 +205,17 @@ let (lift_comp_weakening :
                   Pulse_Typing.Lift_STAtomic_ST
                     ((Pulse_Typing_Env.push_env
                         (Pulse_Typing_Env.push_env g g1) g'), c)
-              | Pulse_Typing.Lift_STGhost_STAtomic
+              | Pulse_Typing.Lift_STGhost_STUnobservable
                   (uu___, c, non_informative_c) ->
-                  Pulse_Typing.Lift_STGhost_STAtomic
+                  Pulse_Typing.Lift_STGhost_STUnobservable
                     ((Pulse_Typing_Env.push_env
                         (Pulse_Typing_Env.push_env g g1) g'), c,
                       (non_informative_c_weakening g g' g1 c
                          non_informative_c))
+              | Pulse_Typing.Lift_STUnobservable_STAtomic (uu___, c) ->
+                  Pulse_Typing.Lift_STUnobservable_STAtomic
+                    ((Pulse_Typing_Env.push_env
+                        (Pulse_Typing_Env.push_env g g1) g'), c)
 let (st_equiv_weakening :
   Pulse_Typing_Env.env ->
     Pulse_Typing_Env.env ->
@@ -713,14 +717,19 @@ let (lift_comp_subst :
                           ((Pulse_Typing_Env.push_env g
                               (Pulse_Typing_Env.subst_env g' (nt x e))),
                             (Pulse_Syntax_Naming.subst_comp c ss))
-                    | Pulse_Typing.Lift_STGhost_STAtomic
+                    | Pulse_Typing.Lift_STGhost_STUnobservable
                         (uu___, c, d_non_informative) ->
-                        Pulse_Typing.Lift_STGhost_STAtomic
+                        Pulse_Typing.Lift_STGhost_STUnobservable
                           ((Pulse_Typing_Env.push_env g
                               (Pulse_Typing_Env.subst_env g' (nt x e))),
                             (Pulse_Syntax_Naming.subst_comp c ss),
                             (non_informative_c_subst g x t g' e () c
                                d_non_informative))
+                    | Pulse_Typing.Lift_STUnobservable_STAtomic (uu___, c) ->
+                        Pulse_Typing.Lift_STUnobservable_STAtomic
+                          ((Pulse_Typing_Env.push_env g
+                              (Pulse_Typing_Env.subst_env g' (nt x e))),
+                            (Pulse_Syntax_Naming.subst_comp c ss))
 let (bind_comp_subst :
   Pulse_Typing_Env.env ->
     Pulse_Syntax_Base.var ->

--- a/src/ocaml/plugin/pulseparser.mly
+++ b/src/ocaml/plugin/pulseparser.mly
@@ -66,7 +66,8 @@ let mk_fn_decl q id is_rec bs body range =
 %}
 
 /* pulse specific tokens; rest are inherited from F* */
-%token MUT FN INVARIANT WHILE REF PARALLEL REWRITE FOLD GHOST ATOMIC EACH
+%token MUT FN INVARIANT WHILE REF PARALLEL REWRITE FOLD EACH
+%token GHOST ATOMIC UNOBSERVABLE
 %token WITH_INVS OPENS  SHOW_PROOF_STATE
 
 %start pulseDecl
@@ -89,6 +90,7 @@ peekFnId:
 qual:
   | GHOST { PulseSyntaxExtension_Sugar.STGhost }
   | ATOMIC { PulseSyntaxExtension_Sugar.STAtomic }
+  | UNOBSERVABLE { PulseSyntaxExtension_Sugar.STUnobservable }
 
 /* This is the main entry point for the pulse parser */
 pulseDecl:

--- a/src/syntax_extension/PulseSyntaxExtension.Desugar.fst
+++ b/src/syntax_extension/PulseSyntaxExtension.Desugar.fst
@@ -76,6 +76,12 @@ let comp_to_ast_term (c:Sugar.computation_type) : err A.term =
       let h = mk_term (Var stt_atomic_lid) r Expr in
       let h = mk_term (App (h, return_ty, Nothing)) r Expr in
       mk_term (App (h, is, Nothing)) r Expr
+    | Sugar.STUnobservable ->
+      (* hack for now *)
+      let is = mk_term (Var (Ident.lid_of_str "Pulse.Lib.Core.emp_inames")) r Expr in
+      let h = mk_term (Var stt_unobservable_lid) r Expr in
+      let h = mk_term (App (h, return_ty, Nothing)) r Expr in
+      mk_term (App (h, is, Nothing)) r Expr
     | Sugar.STGhost ->
       (* hack for now *)
       let is = mk_term (Var (Ident.lid_of_str "Pulse.Lib.Core.emp_inames")) r Expr in
@@ -298,6 +304,8 @@ let desugar_computation_type (env:env_t) (c:Sugar.computation_type)
       return SW.(mk_comp pre (mk_binder c.return_name ret) post)
     | Sugar.STAtomic ->
       return SW.(atomic_comp opens pre (mk_binder c.return_name ret) post)
+    | Sugar.STUnobservable ->
+      return SW.(unobservable_comp opens pre (mk_binder c.return_name ret) post)
     | Sugar.STGhost ->
       return SW.(ghost_comp opens pre (mk_binder c.return_name ret) post)
 

--- a/src/syntax_extension/PulseSyntaxExtension.Env.fst
+++ b/src/syntax_extension/PulseSyntaxExtension.Env.fst
@@ -52,6 +52,7 @@ let pure_lid = pulse_lib_core_lid "pure"
 let stt_lid = pulse_lib_core_lid "stt"
 let assign_lid = pulse_lib_ref_lid "op_Colon_Equals"
 let stt_ghost_lid = pulse_lib_core_lid "stt_ghost"
+let stt_unobservable_lid = pulse_lib_core_lid "stt_unobservable"
 let stt_atomic_lid = pulse_lib_core_lid "stt_atomic"
 let op_colon_equals_lid r = Ident.lid_of_path ["op_Colon_Equals"] r
 let op_array_assignment_lid r = Ident.lid_of_path ["op_Array_Assignment"] r

--- a/src/syntax_extension/PulseSyntaxExtension.Sugar.fst
+++ b/src/syntax_extension/PulseSyntaxExtension.Sugar.fst
@@ -37,6 +37,7 @@ let as_vprop (v:vprop') (r:rng) = { v; vrange=r}
 type st_comp_tag = 
   | ST
   | STAtomic
+  | STUnobservable
   | STGhost
 
 type computation_type = {

--- a/src/syntax_extension/PulseSyntaxExtension.SyntaxWrapper.fsti
+++ b/src/syntax_extension/PulseSyntaxExtension.SyntaxWrapper.fsti
@@ -61,6 +61,7 @@ val tm_add_inv : i:term -> is:term -> range -> term
 val mk_tot (t:term) : comp
 val mk_comp (pre:term) (ret:binder) (post:term) : comp
 val ghost_comp (opens:term) (pre:term) (ret:binder) (post:term) : comp
+val unobservable_comp (opens:term) (pre:term) (ret:binder) (post:term) : comp
 val atomic_comp (opens:term) (pre:term) (ret:binder) (post:term) : comp
 
 val is_tm_exists (x:term) : bool


### PR DESCRIPTION
This PR allows to annotate functions as unobservable, like for atomic and ghost already, and makes the checker lift from unobservable to atomic when needed.