### PR TITLE
Implementing Trades as ghost steps, which preserve a given set of (already opened) invariants

### DIFF
--- a/Steel.fst.config.json
+++ b/Steel.fst.config.json
@@ -12,6 +12,7 @@
     "share/steel/examples/pulse/bug-reports",
     "share/steel/examples/pulse/by-example",
     "share/steel/examples/pulse/lib",
+    "share/steel/examples/pulse/class",
     "share/steel/examples/pulse/parallel",
     "share/steel/examples/pulse/parix",
     "share/steel/examples/pulse/dice",

--- a/share/steel/examples/pulse/Makefile
+++ b/share/steel/examples/pulse/Makefile
@@ -3,7 +3,7 @@ STEEL_SHARE = ../../
 # the root (../../../..) since the OPAM package will detach the share
 # directory from the rest of the repo.
 
-INCLUDE_DIRS=bug-reports by-example lib lib/pledge dice/cbor dice/common dice/dpe dice/engine dice/l0 parallel parix .
+INCLUDE_DIRS=bug-reports by-example lib class lib/pledge dice/cbor dice/common dice/dpe dice/engine dice/l0 parallel parix .
 CACHE_DIR=.cache
 SRC_DIRS=$(addprefix $(STEEL_SHARE)/examples/pulse/, $(INCLUDE_DIRS))
 FSTAR_FILES=$(wildcard $(addsuffix /*.fst, $(SRC_DIRS))) $(wildcard $(addsuffix /*.fsti, $(SRC_DIRS)))

--- a/share/steel/examples/pulse/Makefile.pulse.common
+++ b/share/steel/examples/pulse/Makefile.pulse.common
@@ -31,7 +31,7 @@ WARN_ERROR=
 
 SMT_OPTIONS?=
 OTHERFLAGS+=$(WARN_ERROR) $(SMT_OPTIONS)
-ALREADY_CACHED_LIST ?= Prims,FStar,Steel,Pulse,-Pulse.Lib
+ALREADY_CACHED_LIST ?= Prims,FStar,Steel,Pulse,-Pulse.Lib,-Pulse.Class
 ALREADY_CACHED = --already_cached $(ALREADY_CACHED_LIST)
 
 # A place to put all build artifacts

--- a/share/steel/examples/pulse/Pulse.fst.config.json
+++ b/share/steel/examples/pulse/Pulse.fst.config.json
@@ -16,6 +16,7 @@
     "bug-reports",
     "by-example",
     "lib",
+    "class",
     "lib/pledge",
     "parallel",
     "parix",

--- a/share/steel/examples/pulse/class/Pulse.Class.PtsTo.fsti
+++ b/share/steel/examples/pulse/class/Pulse.Class.PtsTo.fsti
@@ -1,0 +1,28 @@
+module Pulse.Class.PtsTo
+
+open Pulse.Lib.Pervasives
+open FStar.Tactics.V2
+
+(* NOTE: this class is not very useful unless we either inline these methods
+early in the typechecking process, or we make the pulse checker normalize
+(and unfold) the contexts. *)
+
+let full_default () : Tac unit = exact (`full_perm)
+
+class pointer (r v : Type) = {
+  pts_to : r -> (#[full_default()] f : perm) -> v -> vprop;
+}
+
+instance pts_to_r (a:Type) : pointer (ref a) a = {
+  pts_to = (fun r v -> Pulse.Lib.Reference.pts_to r v);
+}
+
+instance pts_to_gr (a:Type) : pointer (Pulse.Lib.GhostReference.ref a) a = {
+  pts_to = (fun r v -> Pulse.Lib.GhostReference.pts_to r v);
+}
+
+instance pts_to_hr (a:Type) : pointer (Pulse.Lib.HigherReference.ref a) a = {
+  pts_to = (fun r v -> Pulse.Lib.HigherReference.pts_to r v);
+}
+
+let ( |-> ) #r #v {| pointer r v |} = pts_to #r #v

--- a/share/steel/examples/pulse/lib/pledge/Pulse.Lib.InvList.fst
+++ b/share/steel/examples/pulse/lib/pledge/Pulse.Lib.InvList.fst
@@ -78,3 +78,5 @@ fn __with_invlist_ghost (#pre : vprop) (#post : vprop)
 }
 ```
 let with_invlist_ghost = __with_invlist_ghost
+
+let invlist_reveal = admit()

--- a/share/steel/examples/pulse/lib/pledge/Pulse.Lib.InvList.fst
+++ b/share/steel/examples/pulse/lib/pledge/Pulse.Lib.InvList.fst
@@ -1,0 +1,69 @@
+module Pulse.Lib.InvList
+
+open Pulse.Lib.Pervasives
+
+let add_one (p:vprop) (i : inv p) (is : invlist{not (mem_inv (invlist_names is) i)}) : invlist =
+  (| p, i |) :: is
+
+```pulse
+unobservable
+fn __shift_invlist_one
+  (#a:Type0)
+  (p : vprop)
+  (i : inv p)
+  (is : invlist{not (mem_inv (invlist_names is) i)})
+  (#pre:vprop)
+  (#post : a -> vprop)
+  (f : unit -> stt_unobservable a emp_inames (invlist_v (add_one p i is) ** pre) (fun v -> invlist_v (add_one p i is) ** post v))
+  (_:unit)
+  requires invlist_v is ** (p ** pre)
+  returns v:a
+  ensures invlist_v is ** (p ** post v)
+{
+  rewrite
+    (p ** invlist_v is)
+  as
+    (invlist_v (add_one p i is));
+  let v = f ();
+  rewrite
+    (invlist_v (add_one p i is))
+  as
+    (p ** invlist_v is);
+  v
+}
+```
+let shift_invlist_one = __shift_invlist_one
+
+```pulse
+unobservable
+fn rec __with_invlist (#a:Type0) (#pre : vprop) (#post : a -> vprop)
+  (is : invlist)
+  (f : unit -> stt_unobservable a emp_inames (invlist_v is ** pre) (fun v -> invlist_v is ** post v))
+  requires pre
+  returns v:a
+  ensures post v
+  opens (invlist_names is)
+  decreases is
+{
+  match is {
+    Nil -> {
+      rewrite emp as invlist_v is;
+      let r = f ();
+      rewrite invlist_v is as emp;
+      r
+    }
+    Cons h t -> {
+      let p = dfst h;
+      let i : inv p = dsnd h;
+      with_invariants (i <: inv p) {
+        assert (p ** pre);
+        let fw : (unit -> stt_unobservable a emp_inames (invlist_v t ** (p ** pre)) (fun v -> invlist_v t ** (p ** post v))) = shift_invlist_one #a p i t #pre #post f;
+        let v = __with_invlist #a #(p ** pre) #(fun v -> p ** post v) t fw;
+        assert (p ** post v);
+        v
+      }
+    }
+  }
+}
+```
+let with_invlist = __with_invlist

--- a/share/steel/examples/pulse/lib/pledge/Pulse.Lib.InvList.fst
+++ b/share/steel/examples/pulse/lib/pledge/Pulse.Lib.InvList.fst
@@ -2,9 +2,6 @@ module Pulse.Lib.InvList
 
 open Pulse.Lib.Pervasives
 
-let add_one (p:vprop) (i : inv p) (is : invlist{not (mem_inv (invlist_names is) i)}) : invlist =
-  (| p, i |) :: is
-
 ```pulse
 unobservable
 fn __shift_invlist_one
@@ -14,7 +11,7 @@ fn __shift_invlist_one
   (is : invlist{not (mem_inv (invlist_names is) i)})
   (#pre:vprop)
   (#post : a -> vprop)
-  (f : unit -> stt_unobservable a emp_inames (invlist_v (add_one p i is) ** pre) (fun v -> invlist_v (add_one p i is) ** post v))
+  (f : unit -> stt_unobservable a emp_inames (invlist_v (add_one (| p, i |) is) ** pre) (fun v -> invlist_v (add_one (| p, i |) is) ** post v))
   (_:unit)
   requires invlist_v is ** (p ** pre)
   returns v:a
@@ -23,10 +20,10 @@ fn __shift_invlist_one
   rewrite
     (p ** invlist_v is)
   as
-    (invlist_v (add_one p i is));
+    (invlist_v (add_one (|p, i|) is));
   let v = f ();
   rewrite
-    (invlist_v (add_one p i is))
+    (invlist_v (add_one (|p, i|) is))
   as
     (p ** invlist_v is);
   v
@@ -67,3 +64,17 @@ fn rec __with_invlist (#a:Type0) (#pre : vprop) (#post : a -> vprop)
 }
 ```
 let with_invlist = __with_invlist
+
+```pulse
+unobservable
+fn __with_invlist_ghost (#pre : vprop) (#post : vprop)
+  (is : invlist)
+  (f : unit -> stt_ghost unit emp_inames (invlist_v is ** pre) (fun _ -> invlist_v is ** post))
+  requires pre
+  ensures post
+  opens (invlist_names is)
+{
+  with_invlist is (fun () -> lift_ghost_unobservable (f ()) (fun _ -> ()))
+}
+```
+let with_invlist_ghost = __with_invlist_ghost

--- a/share/steel/examples/pulse/lib/pledge/Pulse.Lib.InvList.fsti
+++ b/share/steel/examples/pulse/lib/pledge/Pulse.Lib.InvList.fsti
@@ -2,7 +2,8 @@ module Pulse.Lib.InvList
 
 open Pulse.Lib.Pervasives
 
-let invlist0 = list (p:vprop & inv p)
+let invlist_elem = p:vprop & inv p
+let invlist0 = list invlist_elem
 
 let rec invlist_names (is : invlist0) : inames =
   match is with
@@ -16,6 +17,9 @@ let rec invlist_nodups (is : invlist0) : prop =
 
 let invlist =
   i:invlist0{invlist_nodups i}
+
+let add_one (h : invlist_elem) (t : invlist{not (mem_inv (invlist_names t) (dsnd h))}) : invlist =
+  h :: t
 
 let rec invlist_v (is : invlist) : vprop =
   match is with
@@ -36,3 +40,12 @@ val with_invlist (#a:Type0) (#pre : vprop) (#post : a -> vprop)
   (is : invlist)
   (f : unit -> stt_unobservable a emp_inames (invlist_v is ** pre) (fun v -> invlist_v is ** post v))
   : stt_unobservable a (invlist_names is) pre (fun v -> post v)
+
+(* A helper for a ghost-unit function. *)
+val with_invlist_ghost (#pre : vprop) (#post : vprop)
+  (is : invlist)
+  (f : unit -> stt_ghost unit emp_inames (invlist_v is ** pre) (fun _ -> invlist_v is ** post))
+  : stt_unobservable unit (invlist_names is) pre (fun _ -> post)
+
+let invlist_sub (is1 is2 : invlist) : prop =
+  inames_subset (invlist_names is1) (invlist_names is2)

--- a/share/steel/examples/pulse/lib/pledge/Pulse.Lib.InvList.fsti
+++ b/share/steel/examples/pulse/lib/pledge/Pulse.Lib.InvList.fsti
@@ -49,3 +49,6 @@ val with_invlist_ghost (#pre : vprop) (#post : vprop)
 
 let invlist_sub (is1 is2 : invlist) : prop =
   inames_subset (invlist_names is1) (invlist_names is2)
+
+(* FIXME: invlist should be made erasable *)
+val invlist_reveal (is : erased invlist) : (is':invlist{reveal is == is'})

--- a/share/steel/examples/pulse/lib/pledge/Pulse.Lib.InvList.fsti
+++ b/share/steel/examples/pulse/lib/pledge/Pulse.Lib.InvList.fsti
@@ -1,0 +1,38 @@
+module Pulse.Lib.InvList
+
+open Pulse.Lib.Pervasives
+
+let invlist0 = list (p:vprop & inv p)
+
+let rec invlist_names (is : invlist0) : inames =
+  match is with
+  | [] -> emp_inames
+  | i :: is -> add_iname (invlist_names is) (name_of_inv <| dsnd i)
+
+let rec invlist_nodups (is : invlist0) : prop =
+  match is with
+  | [] -> True
+  | i :: is -> not (mem_inv (invlist_names is) (dsnd i)) /\ invlist_nodups is
+
+let invlist =
+  i:invlist0{invlist_nodups i}
+
+let rec invlist_v (is : invlist) : vprop =
+  match is with
+  | [] -> emp
+  | i :: is -> dfst i ** invlist_v is
+
+val shift_invlist_one
+  (#a:Type0)
+  (p : vprop)
+  (i : inv p)
+  (is : invlist{not (mem_inv (invlist_names is) i)})
+  (#pre:vprop)
+  (#post : a -> vprop)
+  (f : unit -> stt_unobservable a emp_inames (invlist_v ((| p, i |) :: is) ** pre) (fun v -> invlist_v ((| p, i |) :: is) ** post v)) :
+       unit -> stt_unobservable a emp_inames (invlist_v is ** (p ** pre)) (fun v -> invlist_v is ** (p ** post v))
+
+val with_invlist (#a:Type0) (#pre : vprop) (#post : a -> vprop)
+  (is : invlist)
+  (f : unit -> stt_unobservable a emp_inames (invlist_v is ** pre) (fun v -> invlist_v is ** post v))
+  : stt_unobservable a (invlist_names is) pre (fun v -> post v)

--- a/share/steel/examples/pulse/lib/pledge/Pulse.Lib.Par.Pledge.Simple.fsti
+++ b/share/steel/examples/pulse/lib/pledge/Pulse.Lib.Par.Pledge.Simple.fsti
@@ -17,6 +17,7 @@
 module Pulse.Lib.Par.Pledge.Simple
 
 open Pulse.Lib.Pervasives
+open Pulse.Lib.InvList
 
 (* In this this version of the pledge library, pledges
 are not indexed by invariants. The actual invariants are existentially
@@ -26,16 +27,16 @@ effectful operations to manipulate them. *)
 val pledge (f:vprop) (v:vprop) : vprop
 
 (* An unobservable step to rewrite the context. *)
-let ustep (opens:inames) (p q : vprop)
-  = unit -> stt_unobservable unit opens p (fun _ -> q)
+let ustep (is:invlist) (p q : vprop)
+  = unit -> stt_ghost unit emp_inames (invlist_v is ** p) (fun _ -> invlist_v is ** q)
 
 (* Anything that holds now holds in the future too. *)
 val return_pledge (f:vprop) (v:vprop)
   : stt_ghost unit emp_inames v (fun _ -> pledge f v)
 
 (* The function proving a pledge can use any invariants. *)
-val make_pledge (#opens:inames) (f:vprop) (v:vprop) (extra:vprop)
-  ($k : ustep opens (f ** extra) (f ** v))
+val make_pledge (#is:invlist) (f:vprop) (v:vprop) (extra:vprop)
+  ($k : ustep is (f ** extra) (f ** v))
   : stt_ghost unit emp_inames extra (fun _ -> pledge f v)
 
 (* Redeem is stateful in this simple variant, which is what
@@ -44,17 +45,17 @@ val redeem_pledge (f:vprop) (v:vprop)
   : stt unit (f ** pledge f v) (fun () -> f ** v)
 
 // Unclear how useful/convenient this is
-val bind_pledge (#os:inames) (#f:vprop) (#v1:vprop) (#v2:vprop)
+val bind_pledge (#is:invlist) (#f:vprop) (#v1:vprop) (#v2:vprop)
         (extra : vprop)
-        (k : ustep os (f ** extra ** v1) (f ** pledge f v2))
+        (k : ustep is (f ** extra ** v1) (f ** pledge f v2))
   : stt_ghost unit emp_inames (pledge f v1 ** extra) (fun () -> pledge f v2)
 
 (* Weaker variant, the proof does not use f. It's implemented
 by framing k with f and then using the above combinator. Exposing
 only in case it's useful for inference. *)
-val bind_pledge' (#os:inames) (#f:vprop) (#v1:vprop) (#v2:vprop)
+val bind_pledge' (#is:invlist) (#f:vprop) (#v1:vprop) (#v2:vprop)
         (extra : vprop)
-        (k : ustep os (extra ** v1) (pledge f v2))
+        (k : ustep is (extra ** v1) (pledge f v2))
   : stt_ghost unit emp_inames (pledge f v1 ** extra) (fun () -> pledge f v2)
 
 val join_pledge (#f:vprop) (v1:vprop) (v2:vprop)
@@ -69,8 +70,8 @@ val split_pledge (#f:vprop) (v1:vprop) (v2:vprop)
               (pledge f (v1 ** v2))
               (fun () -> pledge f v1 ** pledge f v2)
 
-val rewrite_pledge (#opens:inames) (#f:vprop) (v1 : vprop) (v2 : vprop)
-  (k : ustep opens v1 v2)
+val rewrite_pledge (#is:invlist) (#f:vprop) (v1 : vprop) (v2 : vprop)
+  (k : ustep is v1 v2)
   : stt_ghost unit
               emp_inames
               (pledge f v1)

--- a/share/steel/examples/pulse/lib/pledge/Pulse.Lib.Par.Pledge.fst
+++ b/share/steel/examples/pulse/lib/pledge/Pulse.Lib.Par.Pledge.fst
@@ -18,6 +18,9 @@ module Pulse.Lib.Par.Pledge
 
 open Pulse.Lib.Pervasives
 open Pulse.Lib.Trade
+module GR = Pulse.Lib.GhostReference
+open Pulse.Class.PtsTo
+
 
 assume
 val unobservable_reveal_bool
@@ -189,8 +192,6 @@ fn __join_pledge (#os:inames) (#f v1 v2 : vprop)
 let join_pledge = __join_pledge
 
 (* A big chunk follows for split_pledge *)
-
-module GR = Pulse.Lib.GhostReference
 
 let inv_p' (os0 : inames) (f v1 v2 : vprop) (r1 r2 : GR.ref bool) (b1 b2 : bool) =
      GR.pts_to r1 #one_half b1

--- a/share/steel/examples/pulse/lib/pledge/Pulse.Lib.Par.Pledge.fsti
+++ b/share/steel/examples/pulse/lib/pledge/Pulse.Lib.Par.Pledge.fsti
@@ -17,66 +17,70 @@
 module Pulse.Lib.Par.Pledge
 
 open Pulse.Lib.Pervasives
+open Pulse.Lib.InvList
 
-val pledge (opens:inames) (f:vprop) (v:vprop) : vprop
+val pledge (is:invlist) (f:vprop) (v:vprop) : vprop
 
 let pledge_any (f:vprop) (v:vprop) : vprop =
   exists* is. pledge is f v
 
-(* An unobservable step to rewrite the context. *)
-let ustep (opens:inames) (p q : vprop)
-  = unit -> stt_unobservable unit opens p (fun _ -> q)
+(* A ghost step to rewrite the context, running under invlist is. *)
+let ustep (is:invlist) (p q : vprop)
+  = unit -> stt_ghost unit emp_inames (invlist_v is ** p) (fun _ -> invlist_v is ** q)
 
 unfold
 let pledge0 (f:vprop) (v:vprop) : vprop =
-  pledge emp_inames f v
+  pledge [] f v
 
-val pledge_sub_inv (os1:inames) (os2:inames{inames_subset os1 os2}) (f:vprop) (v:vprop)
+val pledge_sub_inv (os1:invlist) (os2:invlist{invlist_sub os1 os2}) (f:vprop) (v:vprop)
   : stt_ghost unit emp_inames (pledge os1 f v) (fun _ -> pledge os2 f v)
 
 (* Anything that holds now holds in the future too. *)
-val return_pledge (os:inames) (f:vprop) (v:vprop)
-  : stt_ghost unit emp_inames v (fun _ -> pledge os f v)
+val return_pledge (is:invlist) (f:vprop) (v:vprop)
+  : stt_ghost unit emp_inames v (fun _ -> pledge is f v)
 
-val make_pledge (opens:inames) (f:vprop) (v:vprop) (extra:vprop)
-  ($k : ustep opens (f ** extra) (f ** v))
-  : stt_ghost unit emp_inames extra (fun _ -> pledge opens f v)
+val make_pledge (is:invlist) (f:vprop) (v:vprop) (extra:vprop)
+  ($k : ustep is (f ** extra) (f ** v))
+  : stt_ghost unit emp_inames extra (fun _ -> pledge is f v)
 
-val redeem_pledge (opens:inames) (f:vprop) (v:vprop)
-  : stt_unobservable unit opens (f ** pledge opens f v) (fun () -> f ** v)
+val redeem_pledge_ghost (is:invlist) (f:vprop) (v:vprop)
+  : stt_ghost unit emp_inames (invlist_v is ** f ** pledge is f v) (fun () -> invlist_v is ** f ** v)
+  
+val redeem_pledge (is:invlist) (f:vprop) (v:vprop)
+  : stt_unobservable unit (invlist_names is) (f ** pledge is f v) (fun () -> f ** v)
 
 // Unclear how useful/convenient this is
-val bind_pledge (#os:inames) (#f:vprop) (#v1:vprop) (#v2:vprop)
+val bind_pledge (#is:invlist) (#f:vprop) (#v1:vprop) (#v2:vprop)
         (extra : vprop)
-        (k : ustep os (f ** extra ** v1) (f ** pledge os f v2))
-  : stt_ghost unit emp_inames (pledge os f v1 ** extra) (fun () -> pledge os f v2)
+        (k : ustep is (f ** extra ** v1) (f ** pledge is f v2))
+  : stt_ghost unit emp_inames (pledge is f v1 ** extra) (fun () -> pledge is f v2)
 
 (* Weaker variant, the proof does not use f. It's implemented
 by framing k with f and then using the above combinator. Exposing
 only in case it's useful for inference. *)
-val bind_pledge' (#os:inames) (#f:vprop) (#v1:vprop) (#v2:vprop)
+val bind_pledge' (#is:invlist) (#f:vprop) (#v1:vprop) (#v2:vprop)
         (extra : vprop)
-        (k : ustep os (extra ** v1) (pledge os f v2))
-  : stt_ghost unit emp_inames (pledge os f v1 ** extra) (fun () -> pledge os f v2)
+        (k : ustep is (extra ** v1) (pledge is f v2))
+  : stt_ghost unit emp_inames (pledge is f v1 ** extra) (fun () -> pledge is f v2)
 
-val join_pledge (#opens:inames) (#f:vprop) (v1:vprop) (v2:vprop)
+val join_pledge (#is:invlist) (#f:vprop) (v1:vprop) (v2:vprop)
   : stt_ghost unit
               emp_inames
-              (pledge opens f v1 ** pledge opens f v2)
-              (fun () -> pledge opens f (v1 ** v2))
+              (pledge is f v1 ** pledge is f v2)
+              (fun () -> pledge is f (v1 ** v2))
 
 // NB: This must be an unobservable step, and not ghost,
 // as it allocates an invariant.
-val split_pledge (#os:inames) (#f:vprop) (v1:vprop) (v2:vprop)
-  : stt_unobservable (erased iname)
+val split_pledge (#is:invlist) (#f:vprop) (v1:vprop) (v2:vprop)
+  : stt_unobservable (pi:(p:vprop & inv p){not (mem_inv (invlist_names is) (dsnd pi))})
               emp_inames
-              (pledge os f (v1 ** v2))
-              (fun i -> pledge (add_iname os i) f v1 ** pledge (add_iname os i) f v2)
+              (pledge is f (v1 ** v2))
+              (fun pi -> pledge (pi :: is) f v1 ** pledge (pi :: is) f v2)
 
 // TODO: write a variant that assumes f too
-val rewrite_pledge (#opens:inames) (#f:vprop) (v1 : vprop) (v2 : vprop)
-  (k : ustep opens v1 v2)
+val rewrite_pledge (#is:invlist) (#f:vprop) (v1 : vprop) (v2 : vprop)
+  (k : ustep is v1 v2)
   : stt_ghost unit
               emp_inames
-              (pledge opens f v1)
-              (fun _ -> pledge opens f v2)
+              (pledge is f v1)
+              (fun _ -> pledge is f v2)

--- a/share/steel/examples/pulse/lib/pledge/Pulse.Lib.Par.Pledge.fsti
+++ b/share/steel/examples/pulse/lib/pledge/Pulse.Lib.Par.Pledge.fsti
@@ -21,9 +21,6 @@ open Pulse.Lib.InvList
 
 val pledge (is:invlist) (f:vprop) (v:vprop) : vprop
 
-let pledge_any (f:vprop) (v:vprop) : vprop =
-  exists* is. pledge is f v
-
 (* A ghost step to rewrite the context, running under invlist is. *)
 let ustep (is:invlist) (p q : vprop)
   = unit -> stt_ghost unit emp_inames (invlist_v is ** p) (fun _ -> invlist_v is ** q)

--- a/share/steel/examples/pulse/lib/pledge/Pulse.Lib.Trade.fst
+++ b/share/steel/examples/pulse/lib/pledge/Pulse.Lib.Trade.fst
@@ -121,7 +121,7 @@ let elim_trade #is = __elim_trade #is
 ghost
 fn __trade_sub_inv
   (#os1 : invlist)
-  (#os2 : invlist{inames_subset (invlist_names os1) (invlist_names os2)})
+  (#os2 : invlist{invlist_sub os1 os2})
   (hyp concl: vprop)
   requires trade #os1 hyp concl
   ensures trade #os2 hyp concl

--- a/share/steel/examples/pulse/lib/pledge/Pulse.Lib.Trade.fst
+++ b/share/steel/examples/pulse/lib/pledge/Pulse.Lib.Trade.fst
@@ -1,0 +1,132 @@
+(*
+   Copyright 2023 Microsoft Research
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*)
+
+module Pulse.Lib.Trade
+
+open Pulse.Lib.Core
+open Pulse.Lib.Pervasives
+open Pulse.Lib.InvList
+module T = FStar.Tactics
+
+let trade_elim_t is hyp extra concl : Type u#2 =
+  unit -> stt_ghost unit emp_inames (invlist_v is ** extra ** hyp) (fun _ -> invlist_v is ** concl)
+
+let trade_elim_exists (is:invlist) (hyp extra concl : vprop) : vprop =
+  pure (squash (trade_elim_t is hyp extra concl))
+
+let trade (#is : invlist) (hyp : vprop) (concl : vprop) =
+  exists* extra. extra ** trade_elim_exists is hyp extra concl
+
+```pulse
+ghost
+fn __intro_trade
+  (#is : invlist)
+  (hyp concl : vprop)
+  (extra : vprop)
+  (f_elim: unit -> (
+    stt_ghost unit emp_inames
+    (invlist_v is ** extra ** hyp)
+    (fun _ -> invlist_v is ** concl)
+  ))
+  requires extra
+  ensures trade #is hyp concl
+{
+  fold (trade_elim_exists is hyp extra concl);
+  assert (extra ** trade_elim_exists is hyp extra concl); // FIXME: why is this needed? somehow guiding the prover?
+  fold (trade #is hyp concl);
+}
+```
+let intro_trade #is = __intro_trade #is
+
+let sqeq (p : Type) (_ : squash p) : erased p =
+  FStar.IndefiniteDescription.elim_squash #p ()
+
+```pulse
+ghost
+fn __elim_trade_ghost
+  (#is : invlist)
+  (hyp concl : vprop)
+  requires invlist_v is ** trade #is hyp concl ** hyp
+  ensures invlist_v is ** concl
+{
+  unfold (trade #is hyp concl);
+
+  with extra. assert (extra ** trade_elim_exists is hyp extra concl);
+  
+  unfold (trade_elim_exists is hyp extra concl);
+  
+  // assert pure (squash (trade_elim_t is hyp (reveal extra) concl));
+  
+  // assert (pure (squash (trade_elim_t is hyp (reveal extra) concl)));
+
+  // let f = elim_ghost (trade_elim_t is hyp (reveal extra) concl);
+  
+  // f();
+  
+  admit();
+}
+```
+let elim_trade_ghost #is = __elim_trade_ghost #is
+
+```pulse
+unobservable
+fn elim_trade_helper
+  (#is : invlist)
+  (hyp concl : vprop)
+  (_ : unit)
+  requires invlist_v is ** (trade #is hyp concl ** hyp)
+  ensures invlist_v is ** concl
+{
+  elim_trade_ghost #is hyp concl;
+}
+```
+
+// val elim_trade
+//   (#[T.exact (`[])] is : invlist)
+//   (hyp concl: vprop)
+// : stt_unobservable unit (invlist_names is)
+//     ((trade #is hyp concl) ** hyp)
+//     (fun _ -> concl)
+
+#set-options "--log_failing_queries"
+
+```pulse
+unobservable
+fn __elim_trade
+  (#is : invlist)
+  (hyp concl : vprop)
+  requires trade #is hyp concl ** hyp
+  ensures concl
+  opens (invlist_names is)
+{
+  with_invlist is (elim_trade_helper #is hyp concl);
+}
+```
+let elim_trade #is = __elim_trade #is
+
+```pulse
+ghost
+fn __trade_sub_inv
+  (#os1 : invlist)
+  (#os2 : invlist{inames_subset (invlist_names os1) (invlist_names os2)})
+  (hyp concl: vprop)
+  requires trade #os1 hyp concl
+  ensures trade #os2 hyp concl
+{
+  admit()
+}
+```
+let trade_sub_inv = __trade_sub_inv

--- a/share/steel/examples/pulse/lib/pledge/Pulse.Lib.Trade.fsti
+++ b/share/steel/examples/pulse/lib/pledge/Pulse.Lib.Trade.fsti
@@ -63,7 +63,7 @@ val elim_trade
 
 val trade_sub_inv
   (#os1 : invlist)
-  (#os2 : invlist{inames_subset (invlist_names os1) (invlist_names os2)})
+  (#os2 : invlist{invlist_sub os1 os2})
   (hyp concl: vprop)
 : stt_ghost unit emp_inames
     (trade #os1 hyp concl)

--- a/share/steel/examples/pulse/lib/pledge/Pulse.Lib.Trade.fsti
+++ b/share/steel/examples/pulse/lib/pledge/Pulse.Lib.Trade.fsti
@@ -17,44 +17,53 @@
 module Pulse.Lib.Trade
 
 open Pulse.Lib.Core
+open Pulse.Lib.Pervasives
+open Pulse.Lib.InvList
 module T = FStar.Tactics
 
 val trade :
-  (#[T.exact (`emp_inames)] is:inames) ->
+  (#[T.exact (`[])] is : invlist) ->
   (hyp : vprop) ->
   (concl : vprop) ->
   vprop
 
 let ( ==>* ) :
-  (#[T.exact (`emp_inames)] is:inames) ->
+  (#[T.exact (`[])] is : invlist) ->
   (hyp : vprop) ->
   (concl : vprop) ->
   vprop
   = fun #is -> trade #is
 
 val intro_trade
-  (#[T.exact (`emp_inames)] is : inames)
+  (#[T.exact (`[])] is : invlist)
   (hyp concl: vprop)
-  (v: vprop)
+  (extra: vprop)
   (f_elim: unit -> (
-    stt_unobservable unit is
-    (v ** hyp)
-    (fun _ -> concl)
+    stt_ghost unit emp_inames
+    (invlist_v is ** extra ** hyp)
+    (fun _ -> invlist_v is ** concl)
   ))
 : stt_ghost unit emp_inames
-    v
+    extra
     (fun _ -> trade #is hyp concl)
 
-val elim_trade
-  (#[T.exact (`emp_inames)] is: inames)
+val elim_trade_ghost
+  (#[T.exact (`[])] is : invlist)
   (hyp concl: vprop)
-: stt_unobservable unit is
+: stt_ghost unit emp_inames
+    (invlist_v is ** (trade #is hyp concl) ** hyp)
+    (fun _ -> invlist_v is ** concl)
+
+val elim_trade
+  (#[T.exact (`[])] is : invlist)
+  (hyp concl: vprop)
+: stt_unobservable unit (invlist_names is)
     ((trade #is hyp concl) ** hyp)
     (fun _ -> concl)
 
 val trade_sub_inv
-  (#os1 : inames)
-  (#os2 : inames{inames_subset os1 os2})
+  (#os1 : invlist)
+  (#os2 : invlist{inames_subset (invlist_names os1) (invlist_names os2)})
   (hyp concl: vprop)
 : stt_ghost unit emp_inames
     (trade #os1 hyp concl)

--- a/share/steel/examples/pulse/parix/Async.fst
+++ b/share/steel/examples/pulse/parix/Async.fst
@@ -39,7 +39,7 @@ let asynch (a:Type0) (post : a -> vprop) : Type0 =
   ref (option a) & thread
 
 let async_joinable #a #post h =
-  joinable (snd h) ** pledge emp_inames (done (snd h)) (ref_solves_post (fst h) post)
+  joinable (snd h) ** pledge [] (done (snd h)) (ref_solves_post (fst h) post)
 
 ```pulse
 fn async_fill
@@ -78,8 +78,8 @@ fn __async
   let res = ( r, th );
   
   assert (joinable th);
-  assert (pledge emp_inames (done th) (ref_solves_post r post));
-  rewrite (joinable th ** pledge emp_inames (done th) (ref_solves_post r post))
+  assert (pledge [] (done th) (ref_solves_post r post));
+  rewrite (joinable th ** pledge [] (done th) (ref_solves_post r post))
        as (async_joinable #_ #post res);
   res
 }
@@ -102,7 +102,7 @@ fn __await
   join th; (* join the thread *)
   assert (done th);
   rewrite (done th) as (done (snd h));
-  redeem_pledge emp_inames (done (snd h)) (ref_solves_post r post);
+  redeem_pledge [] (done (snd h)) (ref_solves_post r post);
   assert (ref_solves_post r post);
   unfold ref_solves_post;
   with vv. assert (pts_to r (Some vv));

--- a/share/steel/examples/pulse/parix/ParallelFor.fst
+++ b/share/steel/examples/pulse/parix/ParallelFor.fst
@@ -21,26 +21,27 @@ open Pulse.Lib.Fixpoints
 open TaskPool
 open FStar.Real
 open Pulse.Lib.Par.Pledge
+open Pulse.Lib.InvList
 
 ```pulse
-unobservable
+ghost
 fn aux_squash_pledge (f v : vprop) (_:unit)
-  requires f ** pledge emp_inames f (pledge emp_inames f v)
-  ensures f ** v
+  requires invlist_v [] ** (f ** pledge [] f (pledge [] f v))
+  ensures  invlist_v [] ** (f ** v)
 {
-  redeem_pledge emp_inames f (pledge emp_inames f v);
-  redeem_pledge emp_inames f v
+  redeem_pledge_ghost [] f (pledge [] f v);
+  redeem_pledge_ghost [] f v;
 }
 ```
 
 ```pulse
 ghost
 fn squash_pledge (f v : vprop)
-  requires pledge emp_inames f (pledge emp_inames f v)
-  ensures pledge emp_inames f v
+  requires pledge [] f (pledge [] f v)
+  ensures pledge [] f v
 {
-  make_pledge emp_inames f v
-   (pledge emp_inames f (pledge emp_inames f v))
+  make_pledge [] f v
+   (pledge [] f (pledge [] f v))
    (aux_squash_pledge f v)
 }
 ```
@@ -114,10 +115,10 @@ let p_combine_equiv p1 p2 i j = magic()
 let rewrite_ = Pulse.Lib.Core.rewrite
 
 ```pulse
-unobservable
+ghost
 fn p_join (p : (nat->vprop)) (i j k : nat) (_ : squash (i <= j /\ j <= k))
-  requires range p i j ** range p j k
-  ensures range p i k
+  requires invlist_v [] ** (range p i j ** range p j k)
+  ensures  invlist_v [] ** range p i k
 {
   rewrite_ _ _ (p_join_equiv p i j k ())
 }
@@ -246,7 +247,7 @@ val gspawn_
   (#e : perm)
   (p:pool) (f : unit -> stt unit pre (fun _ -> post))
   : stt unit (pool_alive #e p ** pre)
-             (fun prom -> pool_alive #e p ** pledge emp_inames (pool_done p) post)
+             (fun prom -> pool_alive #e p ** pledge [] (pool_done p) post)
 let gspawn_ p f = TaskPool.spawn_ p f
 
 ```pulse
@@ -258,7 +259,7 @@ fn spawned_f_i
   (f : (i:nat -> stt unit (pre i) (fun () -> post i)))
   (i:nat)
   requires emp ** (pre i ** pool_alive #e p)
-  ensures emp ** (pledge emp_inames (pool_done p) (post i) ** pool_alive #e p)
+  ensures emp ** (pledge [] (pool_done p) (post i) ** pool_alive #e p)
 {
   gspawn_ #(pre i) #(post i) #e p (fun () -> f i)
 }
@@ -271,19 +272,19 @@ fn __redeem_range
   (f : vprop)
   (kk : (
     (n:nat) ->
-    stt unit (f ** range (fun i -> pledge emp_inames f (p i)) 0 n)
+    stt unit (f ** range (fun i -> pledge [] f (p i)) 0 n)
              (fun _ -> f ** range p 0 n)
   ))
   (n : nat)
-  requires f ** range (fun i -> pledge emp_inames f (p i)) 0 n
+  requires f ** range (fun i -> pledge [] f (p i)) 0 n
   ensures f ** range p 0 n
 {
   if (n = 0) {
-    rewrite (range (fun i -> pledge emp_inames f (p i)) 0 n) as emp;
+    rewrite (range (fun i -> pledge [] f (p i)) 0 n) as emp;
     rewrite emp as range p 0 n;
     ()
   } else {
-    p_split_last (fun i -> pledge emp_inames f (p i)) n ();
+    p_split_last (fun i -> pledge [] f (p i)) n ();
     redeem_pledge _ f (p (n-1));
     kk (n-1);
     p_join_last p n ();
@@ -296,7 +297,7 @@ let redeem_range :
   (p : (nat -> vprop)) ->
   (f : vprop) ->
     (n:nat) ->
-    stt unit (f ** range (fun i -> pledge emp_inames f (p i)) 0 n)
+    stt unit (f ** range (fun i -> pledge [] f (p i)) 0 n)
              (fun _ -> f ** range p 0 n)
   =
   fun p f -> fix_stt_1 (__redeem_range p f)
@@ -322,12 +323,12 @@ parallel_for
 
   simple_for
     (fun i -> pre i ** pool_alive #(div_perm full_perm n) p)
-    (fun i -> pledge emp_inames (pool_done p) (post i) ** pool_alive #(div_perm full_perm n) p)
+    (fun i -> pledge [] (pool_done p) (post i) ** pool_alive #(div_perm full_perm n) p)
     emp // Alternative: pass pool_alive p here and forget about the n-way split. See below.
     (spawned_f_i p pre post (div_perm full_perm n) f)
     n;
     
-  p_uncombine (fun i -> pledge emp_inames (pool_done p) (post i)) (fun i -> pool_alive #(div_perm full_perm n) p) 0 n;
+  p_uncombine (fun i -> pledge [] (pool_done p) (post i)) (fun i -> pool_alive #(div_perm full_perm n) p) 0 n;
   unfrac_n n p full_perm;
   teardown_pool p;
   
@@ -348,7 +349,7 @@ fn spawned_f_i_alt
   (f : (i:nat -> stt unit (pre i) (fun () -> post i)))
   (i:nat)
   requires pool_alive p ** pre i
-  ensures pool_alive p ** pledge emp_inames (pool_done p) (post i)
+  ensures pool_alive p ** pledge [] (pool_done p) (post i)
 {
   gspawn_ #(pre i) #(post i) #full_perm p (fun () -> f i)
 }
@@ -370,7 +371,7 @@ parallel_for_alt
 
   simple_for
     pre
-    (fun i -> pledge emp_inames (pool_done p) (post i))
+    (fun i -> pledge [] (pool_done p) (post i))
     (pool_alive p)
     (spawned_f_i_alt p pre post f)
     n;
@@ -520,7 +521,7 @@ fn h_for_task__
   (lo hi : nat)
   (_:unit)
   requires pool_alive #e p ** range pre lo hi
-  ensures pledge emp_inames (pool_done p) (range post lo hi)
+  ensures pledge [] (pool_done p) (range post lo hi)
 {
   admit()
 }
@@ -536,7 +537,7 @@ fn h_for_task
   (lo hi : nat)
   (_:unit)
   requires pool_alive #e p ** range pre lo hi
-  ensures pledge emp_inames (pool_done p) (range post lo hi)
+  ensures pledge [] (pool_done p) (range post lo hi)
 {
   if (hi - lo < 100) {
     (* Too small, just run sequentially *)
@@ -544,7 +545,7 @@ fn h_for_task
     for_loop pre post emp
              (fun i -> frame_stt_left emp (f i)) lo hi;
 
-    return_pledge emp_inames (pool_done p) (range post lo hi)
+    return_pledge [] (pool_done p) (range post lo hi)
   } else {
     let mid = (hi+lo)/2;
     assert (pure (lo <= mid /\ mid <= hi));
@@ -555,31 +556,35 @@ fn h_for_task
     p_split pre lo mid hi ();
 
     gspawn_ #(pool_alive #(half_perm (half_perm e)) p ** range pre lo mid)
-            #(pledge emp_inames (pool_done p) (range post lo mid))
+            #(pledge [] (pool_done p) (range post lo mid))
             #(half_perm e)
             p
             (h_for_task__ p (half_perm (half_perm e)) pre post f lo mid);
 
     gspawn_ #(pool_alive #(half_perm (half_perm e)) p ** range pre mid hi)
-            #(pledge emp_inames (pool_done p) (range post mid hi))
+            #(pledge [] (pool_done p) (range post mid hi))
             #(half_perm e)
             p
             (h_for_task__ p (half_perm (half_perm e)) pre post f mid hi);
 
-    (* We get this complicated pledge emp_inames from the spawns above. We can
+    (* We get this complicated pledge [] from the spawns above. We can
     massage it before even waiting. *)
-    assert (pledge emp_inames (pool_done p) (pledge emp_inames (pool_done p) (range post lo mid)));
-    assert (pledge emp_inames (pool_done p) (pledge emp_inames (pool_done p) (range post mid hi)));
+    assert (pledge [] (pool_done p) (pledge [] (pool_done p) (range post lo mid)));
+    assert (pledge [] (pool_done p) (pledge [] (pool_done p) (range post mid hi)));
 
     squash_pledge (pool_done p) (range post lo mid);
     squash_pledge (pool_done p) (range post mid hi);
 
-    join_pledge #emp_inames #(pool_done p) (range post lo mid) (range post mid hi);
-    rewrite_pledge #emp_inames #(pool_done p) (range post lo mid ** range post mid hi) (range post lo hi)
-        (fun () -> p_join post lo mid hi ());
+    join_pledge #[] #(pool_done p) (range post lo mid) (range post mid hi);
+    rewrite_pledge
+      #[]
+      #(pool_done p)
+      (range post lo mid ** range post mid hi)
+      (range post lo hi)
+      (p_join post lo mid hi);
 
     (* Better *)
-    assert (pledge emp_inames (pool_done p) (range post lo hi));
+    assert (pledge [] (pool_done p) (range post lo hi));
 
     drop_ (pool_alive #(half_perm e) p);
 
@@ -589,7 +594,7 @@ fn h_for_task
 ```
 
 (* Assuming a wait that only needs epsilon permission. We would actually
-need one that takes epsilon permission + a pledge emp_inames for (1-e), or something
+need one that takes epsilon permission + a pledge [] for (1-e), or something
 similar. Otherwise we cannot rule out some other thread holding permission
 to the task pool, and we would not be allowed to free it. *)
 assume
@@ -621,22 +626,22 @@ parallel_for_hier
 
 
     gspawn_ #(pool_alive #one_half p ** range pre 0 n)
-            #(pledge emp_inames (pool_done p) (range post 0 n))
+            #(pledge [] (pool_done p) (range post 0 n))
             #one_half
             p
             (h_for_task p one_half pre post f 0 n);
 
-    (* We get this complicated pledge emp_inames from the spawn above. We can
+    (* We get this complicated pledge [] from the spawn above. We can
     massage it before even waiting. *)
-    assert (pledge emp_inames (pool_done p) (pledge emp_inames (pool_done p) (range post 0 n)));
+    assert (pledge [] (pool_done p) (pledge [] (pool_done p) (range post 0 n)));
 
     squash_pledge (pool_done p) (range post 0 n);
 
-    assert (pledge emp_inames (pool_done p) (range post 0 n));
+    assert (pledge [] (pool_done p) (range post 0 n));
 
     wait_pool p one_half;
 
-    redeem_pledge emp_inames (pool_done p) (range post 0 n);
+    redeem_pledge [] (pool_done p) (range post 0 n);
 
     drop_ (pool_done p);
   } else {
@@ -648,7 +653,7 @@ parallel_for_hier
 
     assert (pool_done p);
 
-    redeem_pledge emp_inames (pool_done p) (range post 0 n);
+    redeem_pledge [] (pool_done p) (range post 0 n);
 
     drop_ (pool_done p);
   }

--- a/share/steel/examples/pulse/parix/Promises.Examples3.fst
+++ b/share/steel/examples/pulse/parix/Promises.Examples3.fst
@@ -18,6 +18,7 @@ module Promises.Examples3
 
 open Pulse.Lib.Pervasives
 open Pulse.Lib.Par.Pledge
+open Pulse.Lib.InvList
 module GR = Pulse.Lib.GhostReference
 
 assume val done : ref bool
@@ -84,17 +85,19 @@ fn proof
 
 let cheat_proof (i:inv inv_p)
   : (_:unit) ->
-      stt_unobservable unit
-        (add_inv emp_inames i)
-        (requires pts_to done #one_half true ** GR.pts_to claimed #one_half false)
-        (ensures fun _ -> pts_to done #one_half true ** goal)
+      stt_ghost unit
+        emp_inames
+        (requires         invlist_v [(| _, i |)] ** (pts_to done #one_half true ** GR.pts_to claimed #one_half false))
+        (ensures fun _ -> invlist_v [(| _, i |)] ** (pts_to done #one_half true ** goal))
   = admit() //proof is atomic, not ghost
-    
+
+#set-options "--debug Promises.Examples3 --debug_level SMTQuery"
+
 ```pulse
 fn setup (_:unit)
    requires pts_to done v_done ** pts_to res v_res ** GR.pts_to claimed v_claimed
    returns i:inv inv_p
-   ensures pts_to done #one_half false ** pledge (add_inv emp_inames i) (pts_to done #one_half true) goal
+   ensures pts_to done #one_half false ** pledge (add_one (|inv_p, i|) []) (pts_to done #one_half true) goal
 {
   done := false;
   res := None;
@@ -112,7 +115,7 @@ fn setup (_:unit)
   let i = new_invariant' inv_p;
   
   make_pledge
-    (add_inv emp_inames i)
+    (add_one (|inv_p, i|) [])
     (pts_to done #one_half true)
     goal
     (GR.pts_to claimed #one_half false)

--- a/share/steel/examples/pulse/parix/TaskPool.Examples.fst
+++ b/share/steel/examples/pulse/parix/TaskPool.Examples.fst
@@ -39,10 +39,10 @@ fn qs (n:nat)
   spawn_ p (fun () -> qsc 3);
   spawn_ p (fun () -> qsc 4);
   teardown_pool p;
-  redeem_pledge emp_inames (pool_done p) (qsv 1);
-  redeem_pledge emp_inames (pool_done p) (qsv 2);
-  redeem_pledge emp_inames (pool_done p) (qsv 3);
-  redeem_pledge emp_inames (pool_done p) (qsv 4);
+  redeem_pledge [] (pool_done p) (qsv 1);
+  redeem_pledge [] (pool_done p) (qsv 2);
+  redeem_pledge [] (pool_done p) (qsv 3);
+  redeem_pledge [] (pool_done p) (qsv 4);
   drop_ (pool_done p);
   ()
 }
@@ -59,11 +59,11 @@ fn qs_joinpromises (n:nat)
   spawn_ p (fun () -> qsc 2);
   spawn_ p (fun () -> qsc 3);
   spawn_ p (fun () -> qsc 4);
-  join_pledge #emp_inames #(pool_done p) (qsv 1) (qsv 2);
-  join_pledge #emp_inames #(pool_done p) (qsv 3) (qsv 4);
+  join_pledge #[] #(pool_done p) (qsv 1) (qsv 2);
+  join_pledge #[] #(pool_done p) (qsv 3) (qsv 4);
   teardown_pool p;
-  redeem_pledge emp_inames (pool_done p) (qsv 1 ** qsv 2);
-  redeem_pledge emp_inames (pool_done p) (qsv 3 ** qsv 4);
+  redeem_pledge [] (pool_done p) (qsv 1 ** qsv 2);
+  redeem_pledge [] (pool_done p) (qsv 3 ** qsv 4);
   drop_ (pool_done p);
   ()
 }
@@ -93,9 +93,9 @@ fn qsh (n:nat)
   spawn_ p (fun () -> qsc 3);
   spawn_ p (fun () -> qsc 4);
   teardown_pool p;
-  redeem_pledge emp_inames (pool_done p) (qsv 1 ** qsv 2);
-  redeem_pledge emp_inames (pool_done p) (qsv 3);
-  redeem_pledge emp_inames (pool_done p) (qsv 4);
+  redeem_pledge [] (pool_done p) (qsv 1 ** qsv 2);
+  redeem_pledge [] (pool_done p) (qsv 3);
+  redeem_pledge [] (pool_done p) (qsv 4);
   drop_ (pool_done p);
   ()
 }
@@ -105,7 +105,7 @@ fn qsh (n:nat)
 fn qs12_par (p:pool)
   requires pool_alive p
   returns _:unit
-  ensures pool_alive p ** pledge emp_inames (pool_done p) (qsv 1) ** pledge emp_inames (pool_done p) (qsv 2)
+  ensures pool_alive p ** pledge [] (pool_done p) (qsv 1) ** pledge [] (pool_done p) (qsv 2)
   {
     spawn_ p (fun () -> qsc 1);
     spawn_ p (fun () -> qsc 2);

--- a/share/steel/examples/pulse/parix/TaskPool.fsti
+++ b/share/steel/examples/pulse/parix/TaskPool.fsti
@@ -50,7 +50,7 @@ val spawn
   ($f : unit -> stt a pre (fun (x:a) -> post x))
   : stt (task_handle p a post)
         (pool_alive #e p ** pre)
-        (fun th -> pool_alive #e p ** joinable th ** pledge emp_inames (joined th) (handle_solved th))
+        (fun th -> pool_alive #e p ** joinable th ** pledge [] (joined th) (handle_solved th))
 
 (* Spawn of a unit-returning task with no intention to join, simpler. *)
 val spawn_
@@ -58,7 +58,7 @@ val spawn_
   (#pre #post : _)
   (p:pool) (f : unit -> stt unit pre (fun _ -> post))
   : stt unit (pool_alive #e p ** pre)
-             (fun prom -> pool_alive #e p ** pledge emp_inames (pool_done p) post)
+             (fun prom -> pool_alive #e p ** pledge [] (pool_done p) post)
 
 (* If the pool is done, all pending joinable threads must be done *)
 val must_be_done

--- a/share/steel/examples/pulse/parix/UnixFork.fsti
+++ b/share/steel/examples/pulse/parix/UnixFork.fsti
@@ -30,7 +30,7 @@ val done     : thread -> vprop (* i.e. reapable/zombie *)
 val fork 
   (#pre #post : vprop)
   (f : unit -> stt unit pre (fun () -> post))
-  : stt thread pre (fun th -> joinable th ** pledge emp_inames (done th) post)
+  : stt thread pre (fun th -> joinable th ** pledge [] (done th) post)
 
 val join
   (th : thread)


### PR DESCRIPTION
This version of trades (and pledges) allows us to not rely on any suspect axioms, such as extracting an unobservable function from a proof of existence, or a reveal for erased with the unobservable effect.

Now, trades and pledges are only ghost steps, but they can still be indexed with a set of invariants (concretely an `invlist`: a heterogeneous lists of invariants and their vprops). The underlying ghost step of a trade/pledge expects all of the invariants to already be opened, and must restore them. Essentially, this is hoisting the opening of invariants _within_ the trade/pledge to their callsite, which makes things easier.

An added limitation of this approach is that trades/pledges will not be able to allocate invariants. I don't think this will be a problem (and it hasn't been required so far).