### PR TITLE
Small PR to add support for admitting specific vprop

### DIFF
--- a/lib/steel/pulse/Pulse.Checker.Admit.fst
+++ b/lib/steel/pulse/Pulse.Checker.Admit.fst
@@ -25,14 +25,7 @@ open Pulse.Checker.Base
 open Pulse.Checker.Prover
 
 module P = Pulse.Syntax.Printer
-
-let post_hint_compatible (p:option post_hint_t) (x:var) (t:term) (u:universe) (post:vprop) =
-  match p with
-  | None -> True
-  | Some p ->
-    p.post== close_term post x /\
-    p.u == u /\
-    p.ret_ty == t
+module RU = Pulse.Reflection.Util
 
 let check_core
   (g:env)
@@ -54,19 +47,18 @@ let check_core
     : (t:term &
        u:universe &
        universe_of g t u &
-       post:vprop { post_hint_compatible post_hint x t u post } &
+       post:vprop &
        tot_typing (push_binding g x (fst px) t) post tm_vprop)
     = match post, post_hint with
       | None, None ->
         fail g None "could not find a post annotation on admit, please add one"
-
-      | Some post1, Some post2 ->
-        fail g None
-          (Printf.sprintf "found two post annotations on admit: %s and %s, please remove one"
-             (P.term_to_string post1)
-             (P.term_to_string post2.post))
       
+        //
+        // If there is a post annoatation on admit, pick that
+        //   plus make the return type as unit
+        //
       | Some post, _ ->
+        let t : term = { t = Tm_FStar RU.unit_tm; range = t.range } in
         let (| u, t_typing |) = check_universe g t in    
         let post_opened = open_term_nv post px in      
         let (| post, post_typing |) = 
@@ -108,7 +100,3 @@ let check
       check_core g pre pre_typing post_hint res_ppname ({ t with term=Tm_Admit {r with ctag=ct}})
     | _ ->
       check_core g pre pre_typing post_hint res_ppname t
-
-
-
- 

--- a/lib/steel/pulse/Pulse.Checker.Admit.fst
+++ b/lib/steel/pulse/Pulse.Checker.Admit.fst
@@ -40,6 +40,7 @@ let check_core
   let g = Pulse.Typing.Env.push_context g "check_admit" t.range in
 
   let Tm_Admit { ctag = c; typ=t; post } = t.term in
+  let has_annotated_post = Some? post in
 
   let x = fresh g in
   let px = v_as_nv x in
@@ -79,10 +80,22 @@ let check_core
   in
   let (| t, u, t_typing, post_opened, post_typing |) = res in
   let post = close_term post_opened x in
-  let s : st_comp = {u;res=t;pre;post} in
-
   assume (open_term (close_term post_opened x) x == post_opened);
-  let d = T_Admit _ _ c (STC _ s x t_typing pre_typing post_typing) in
+
+  let (| _s, ds |) : s:st_comp & st_comp_typing g s =
+    //
+    // if admit has annotated post, set its pre to emp
+    //
+    let (| pre, pre_typing |) : pre:vprop & tot_typing g pre tm_vprop =
+      if has_annotated_post then (| tm_emp, magic () |)
+      else (| pre, pre_typing |) in
+
+    let s : st_comp = {u;res=t;pre;post} in
+    let ds : st_comp_typing g s = STC _ s x t_typing pre_typing post_typing in
+
+    (| s, ds |) in
+
+  let d = T_Admit _ _ c ds in
   prove_post_hint (try_frame_pre pre_typing (match_comp_res_with_post_hint d post_hint) res_ppname) post_hint t.range
 
 let check

--- a/lib/steel/pulse/Pulse.Checker.Bind.fst
+++ b/lib/steel/pulse/Pulse.Checker.Bind.fst
@@ -83,8 +83,17 @@ let check_bind
   then fail g (Some t.range) "check_bind: post hint is not set, please add an annotation";
 
   let Tm_Bind { binder; head=e1; body=e2 } = t.term in
-  if Tm_Admit? e1.term
-  then ( //Discard the continuation if the head is an admit
+  let discard_continuation =
+    match e1.term with
+    | Tm_Admit { post = None } ->
+      //
+      // Discard the continuation if the head is an admit
+      //   with no post specified
+      //
+      true
+    | _ -> false in
+  if discard_continuation
+  then (
     check g ctxt ctxt_typing post_hint res_ppname e1
   )
   else if Tm_Abs? e1.term

--- a/share/steel/examples/pulse/CustomSyntax.fst
+++ b/share/steel/examples/pulse/CustomSyntax.fst
@@ -462,3 +462,12 @@ fn test_admit4 ()
   0
 }
 ```
+
+```pulse
+fn test_admit5 ()
+  requires p1
+  ensures p1 ** q1
+{
+  admit q1
+}
+```

--- a/share/steel/examples/pulse/CustomSyntax.fst
+++ b/share/steel/examples/pulse/CustomSyntax.fst
@@ -408,3 +408,57 @@ fn incr (x:nat)
   ( y <: r:nat { r > x } )
 }
 ```
+
+assume val p1 : vprop
+assume val q1 : vprop
+assume val r1 : prop
+
+```pulse
+fn test_admit1 ()
+  requires emp
+  ensures p1 ** q1
+{
+  admit ()
+}
+```
+
+//
+// The prover fails to prove q1
+//
+[@@ expect_failure]
+```pulse
+fn test_admit2 ()
+  requires emp
+  ensures p1 ** q1
+{
+  admit p1
+}
+```
+
+```pulse
+fn test_admit3 ()
+  requires emp
+  ensures p1 ** q1
+{
+  admit (p1 ** q1)
+}
+```
+
+//
+// p1 is admitted and
+//   pure r1 is proved by the prover as usual
+//
+// note also that the return type of admit
+//   with explicit post is unit
+//
+
+```pulse
+fn test_admit4 ()
+  requires pure r1
+  returns _:int
+  ensures p1 ** pure r1
+{
+  admit p1;
+  0
+}
+```

--- a/src/ocaml/plugin/PulseSyntaxExtension_SyntaxWrapper.ml
+++ b/src/ocaml/plugin/PulseSyntaxExtension_SyntaxWrapper.ml
@@ -178,8 +178,8 @@ let tm_rewrite p1 p2 r : st_term =
 let tm_rename ps r : st_term = failwith ""
 (*  PSB.(with_range (tm_rename ps) r) *)
 
-let tm_admit r : st_term =
-  PSB.(with_range (tm_admit STT u_zero (tm_unknown r) None) r)
+let tm_admit post_opt r : st_term =
+  PSB.(with_range (tm_admit STT u_zero (tm_unknown r) post_opt) r)
 let tm_unreachable r : st_term =
   PSB.(with_range (tm_unreachable) r)
   

--- a/src/ocaml/plugin/generated/PulseSyntaxExtension_Desugar.ml
+++ b/src/ocaml/plugin/generated/PulseSyntaxExtension_Desugar.ml
@@ -235,13 +235,21 @@ let (admit_or_return :
       match uu___ with
       | (head, args) ->
           (match ((head.FStar_Syntax_Syntax.n), args) with
-           | (FStar_Syntax_Syntax.Tm_fvar fv, uu___1::[]) ->
+           | (FStar_Syntax_Syntax.Tm_fvar fv, (e, uu___1)::[]) ->
                let uu___2 =
                  FStar_Syntax_Syntax.fv_eq_lid fv
                    PulseSyntaxExtension_Env.admit_lid in
                if uu___2
                then
-                 let uu___3 = PulseSyntaxExtension_SyntaxWrapper.tm_admit r in
+                 let post =
+                   match e.FStar_Syntax_Syntax.n with
+                   | FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_unit)
+                       -> FStar_Pervasives_Native.None
+                   | uu___3 ->
+                       let uu___4 = as_term e in
+                       FStar_Pervasives_Native.Some uu___4 in
+                 let uu___3 =
+                   PulseSyntaxExtension_SyntaxWrapper.tm_admit post r in
                  STTerm uu___3
                else
                  (let uu___4 =

--- a/src/ocaml/plugin/generated/Pulse_Checker_Admit.ml
+++ b/src/ocaml/plugin/generated/Pulse_Checker_Admit.ml
@@ -25,7 +25,7 @@ let (check_core :
                    (Obj.magic
                       (FStar_Range.mk_range "Pulse.Checker.Admit.fst"
                          (Prims.of_int (40)) (Prims.of_int (66))
-                         (Prims.of_int (86)) (Prims.of_int (117)))))
+                         (Prims.of_int (99)) (Prims.of_int (117)))))
                 (FStar_Tactics_Effect.lift_div_tac
                    (fun uu___ ->
                       Pulse_Typing_Env.push_context g "check_admit"
@@ -45,7 +45,7 @@ let (check_core :
                                  (FStar_Range.mk_range
                                     "Pulse.Checker.Admit.fst"
                                     (Prims.of_int (40)) (Prims.of_int (66))
-                                    (Prims.of_int (86)) (Prims.of_int (117)))))
+                                    (Prims.of_int (99)) (Prims.of_int (117)))))
                            (FStar_Tactics_Effect.lift_div_tac
                               (fun uu___ -> t.Pulse_Syntax_Base.term1))
                            (fun uu___ ->
@@ -63,23 +63,24 @@ let (check_core :
                                              (Obj.magic
                                                 (FStar_Range.mk_range
                                                    "Pulse.Checker.Admit.fst"
-                                                   (Prims.of_int (44))
-                                                   (Prims.of_int (10))
-                                                   (Prims.of_int (44))
-                                                   (Prims.of_int (17)))))
+                                                   (Prims.of_int (43))
+                                                   (Prims.of_int (27))
+                                                   (Prims.of_int (43))
+                                                   (Prims.of_int (37)))))
                                           (FStar_Sealed.seal
                                              (Obj.magic
                                                 (FStar_Range.mk_range
                                                    "Pulse.Checker.Admit.fst"
-                                                   (Prims.of_int (44))
-                                                   (Prims.of_int (20))
-                                                   (Prims.of_int (86))
+                                                   (Prims.of_int (43))
+                                                   (Prims.of_int (40))
+                                                   (Prims.of_int (99))
                                                    (Prims.of_int (117)))))
                                           (FStar_Tactics_Effect.lift_div_tac
                                              (fun uu___2 ->
-                                                Pulse_Typing_Env.fresh g1))
+                                                FStar_Pervasives_Native.uu___is_Some
+                                                  post))
                                           (fun uu___2 ->
-                                             (fun x ->
+                                             (fun has_annotated_post ->
                                                 Obj.magic
                                                   (FStar_Tactics_Effect.tac_bind
                                                      (FStar_Sealed.seal
@@ -87,46 +88,73 @@ let (check_core :
                                                            (FStar_Range.mk_range
                                                               "Pulse.Checker.Admit.fst"
                                                               (Prims.of_int (45))
-                                                              (Prims.of_int (11))
+                                                              (Prims.of_int (10))
                                                               (Prims.of_int (45))
-                                                              (Prims.of_int (20)))))
+                                                              (Prims.of_int (17)))))
                                                      (FStar_Sealed.seal
                                                         (Obj.magic
                                                            (FStar_Range.mk_range
                                                               "Pulse.Checker.Admit.fst"
                                                               (Prims.of_int (45))
-                                                              (Prims.of_int (23))
-                                                              (Prims.of_int (86))
+                                                              (Prims.of_int (20))
+                                                              (Prims.of_int (99))
                                                               (Prims.of_int (117)))))
                                                      (FStar_Tactics_Effect.lift_div_tac
                                                         (fun uu___2 ->
-                                                           Pulse_Syntax_Base.v_as_nv
-                                                             x))
+                                                           Pulse_Typing_Env.fresh
+                                                             g1))
                                                      (fun uu___2 ->
-                                                        (fun px ->
+                                                        (fun x ->
                                                            Obj.magic
                                                              (FStar_Tactics_Effect.tac_bind
                                                                 (FStar_Sealed.seal
                                                                    (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Admit.fst"
-                                                                    (Prims.of_int (52))
-                                                                    (Prims.of_int (6))
-                                                                    (Prims.of_int (78))
-                                                                    (Prims.of_int (9)))))
+                                                                    (Prims.of_int (46))
+                                                                    (Prims.of_int (11))
+                                                                    (Prims.of_int (46))
+                                                                    (Prims.of_int (20)))))
                                                                 (FStar_Sealed.seal
                                                                    (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Admit.fst"
-                                                                    (Prims.of_int (79))
-                                                                    (Prims.of_int (4))
-                                                                    (Prims.of_int (86))
+                                                                    (Prims.of_int (46))
+                                                                    (Prims.of_int (23))
+                                                                    (Prims.of_int (99))
                                                                     (Prims.of_int (117)))))
-                                                                (match 
-                                                                   (post,
+                                                                (FStar_Tactics_Effect.lift_div_tac
+                                                                   (fun
+                                                                    uu___2 ->
+                                                                    Pulse_Syntax_Base.v_as_nv
+                                                                    x))
+                                                                (fun uu___2
+                                                                   ->
+                                                                   (fun px ->
+                                                                    Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Admit.fst"
+                                                                    (Prims.of_int (53))
+                                                                    (Prims.of_int (6))
+                                                                    (Prims.of_int (79))
+                                                                    (Prims.of_int (9)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Admit.fst"
+                                                                    (Prims.of_int (80))
+                                                                    (Prims.of_int (4))
+                                                                    (Prims.of_int (99))
+                                                                    (Prims.of_int (117)))))
+                                                                    (match 
+                                                                    (post,
                                                                     post_hint)
-                                                                 with
-                                                                 | (FStar_Pervasives_Native.None,
+                                                                    with
+                                                                    | 
+                                                                    (FStar_Pervasives_Native.None,
                                                                     FStar_Pervasives_Native.None)
                                                                     ->
                                                                     Obj.magic
@@ -134,7 +162,8 @@ let (check_core :
                                                                     g1
                                                                     FStar_Pervasives_Native.None
                                                                     "could not find a post annotation on admit, please add one")
-                                                                 | (FStar_Pervasives_Native.Some
+                                                                    | 
+                                                                    (FStar_Pervasives_Native.Some
                                                                     post1,
                                                                     uu___2)
                                                                     ->
@@ -144,17 +173,17 @@ let (check_core :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Admit.fst"
-                                                                    (Prims.of_int (61))
+                                                                    (Prims.of_int (62))
                                                                     (Prims.of_int (25))
-                                                                    (Prims.of_int (61))
+                                                                    (Prims.of_int (62))
                                                                     (Prims.of_int (65)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Admit.fst"
-                                                                    (Prims.of_int (61))
+                                                                    (Prims.of_int (62))
                                                                     (Prims.of_int (70))
-                                                                    (Prims.of_int (67))
+                                                                    (Prims.of_int (68))
                                                                     (Prims.of_int (47)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -178,17 +207,17 @@ let (check_core :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Admit.fst"
-                                                                    (Prims.of_int (62))
+                                                                    (Prims.of_int (63))
                                                                     (Prims.of_int (32))
-                                                                    (Prims.of_int (62))
+                                                                    (Prims.of_int (63))
                                                                     (Prims.of_int (50)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Admit.fst"
-                                                                    (Prims.of_int (61))
+                                                                    (Prims.of_int (62))
                                                                     (Prims.of_int (70))
-                                                                    (Prims.of_int (67))
+                                                                    (Prims.of_int (68))
                                                                     (Prims.of_int (47)))))
                                                                     (Obj.magic
                                                                     (Pulse_Checker_Pure.check_universe
@@ -210,17 +239,17 @@ let (check_core :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Admit.fst"
-                                                                    (Prims.of_int (63))
+                                                                    (Prims.of_int (64))
                                                                     (Prims.of_int (26))
-                                                                    (Prims.of_int (63))
+                                                                    (Prims.of_int (64))
                                                                     (Prims.of_int (46)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Admit.fst"
-                                                                    (Prims.of_int (63))
+                                                                    (Prims.of_int (64))
                                                                     (Prims.of_int (49))
-                                                                    (Prims.of_int (67))
+                                                                    (Prims.of_int (68))
                                                                     (Prims.of_int (47)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -238,17 +267,17 @@ let (check_core :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Admit.fst"
-                                                                    (Prims.of_int (65))
+                                                                    (Prims.of_int (66))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (65))
+                                                                    (Prims.of_int (66))
                                                                     (Prims.of_int (77)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Admit.fst"
-                                                                    (Prims.of_int (63))
+                                                                    (Prims.of_int (64))
                                                                     (Prims.of_int (49))
-                                                                    (Prims.of_int (67))
+                                                                    (Prims.of_int (68))
                                                                     (Prims.of_int (47)))))
                                                                     (Obj.magic
                                                                     (Pulse_Checker_Pure.check_tot_term
@@ -278,7 +307,8 @@ let (check_core :
                                                                     uu___4)))
                                                                     uu___3)))
                                                                     uu___3))
-                                                                 | (uu___2,
+                                                                    | 
+                                                                    (uu___2,
                                                                     FStar_Pervasives_Native.Some
                                                                     post1) ->
                                                                     Obj.magic
@@ -287,17 +317,17 @@ let (check_core :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Admit.fst"
-                                                                    (Prims.of_int (70))
+                                                                    (Prims.of_int (71))
                                                                     (Prims.of_int (33))
-                                                                    (Prims.of_int (70))
+                                                                    (Prims.of_int (71))
                                                                     (Prims.of_int (37)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Admit.fst"
-                                                                    (Prims.of_int (71))
+                                                                    (Prims.of_int (72))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (78))
+                                                                    (Prims.of_int (79))
                                                                     (Prims.of_int (9)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -333,9 +363,9 @@ let (check_core :
                                                                     post2.Pulse_Typing.post
                                                                     px), ())))))
                                                                     uu___3)))
-                                                                (fun uu___2
-                                                                   ->
-                                                                   (fun res
+                                                                    (fun
+                                                                    uu___2 ->
+                                                                    (fun res
                                                                     ->
                                                                     Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -343,17 +373,17 @@ let (check_core :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Admit.fst"
-                                                                    (Prims.of_int (80))
+                                                                    (Prims.of_int (81))
                                                                     (Prims.of_int (55))
-                                                                    (Prims.of_int (80))
+                                                                    (Prims.of_int (81))
                                                                     (Prims.of_int (58)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Admit.fst"
-                                                                    (Prims.of_int (79))
+                                                                    (Prims.of_int (80))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (86))
+                                                                    (Prims.of_int (99))
                                                                     (Prims.of_int (117)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -378,17 +408,17 @@ let (check_core :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Admit.fst"
-                                                                    (Prims.of_int (81))
+                                                                    (Prims.of_int (82))
                                                                     (Prims.of_int (13))
-                                                                    (Prims.of_int (81))
+                                                                    (Prims.of_int (82))
                                                                     (Prims.of_int (37)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Admit.fst"
-                                                                    (Prims.of_int (81))
-                                                                    (Prims.of_int (40))
-                                                                    (Prims.of_int (86))
+                                                                    (Prims.of_int (83))
+                                                                    (Prims.of_int (65))
+                                                                    (Prims.of_int (99))
                                                                     (Prims.of_int (117)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -406,64 +436,123 @@ let (check_core :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Admit.fst"
-                                                                    (Prims.of_int (82))
-                                                                    (Prims.of_int (21))
-                                                                    (Prims.of_int (82))
-                                                                    (Prims.of_int (37)))))
+                                                                    (Prims.of_int (85))
+                                                                    (Prims.of_int (53))
+                                                                    (Prims.of_int (96))
+                                                                    (Prims.of_int (15)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Admit.fst"
-                                                                    (Prims.of_int (84))
+                                                                    (Prims.of_int (83))
                                                                     (Prims.of_int (65))
-                                                                    (Prims.of_int (86))
+                                                                    (Prims.of_int (99))
                                                                     (Prims.of_int (117)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
                                                                     uu___3 ->
+                                                                    match 
+                                                                    if
+                                                                    has_annotated_post
+                                                                    then
+                                                                    Prims.Mkdtuple2
+                                                                    (Pulse_Syntax_Base.tm_emp,
+                                                                    ())
+                                                                    else
+                                                                    Prims.Mkdtuple2
+                                                                    (pre, ())
+                                                                    with
+                                                                    | 
+                                                                    Prims.Mkdtuple2
+                                                                    (pre1,
+                                                                    pre_typing1)
+                                                                    ->
+                                                                    Prims.Mkdtuple2
+                                                                    ({
+                                                                    Pulse_Syntax_Base.u
+                                                                    = u;
+                                                                    Pulse_Syntax_Base.res
+                                                                    = t2;
+                                                                    Pulse_Syntax_Base.pre
+                                                                    = pre1;
+                                                                    Pulse_Syntax_Base.post
+                                                                    = post1
+                                                                    },
+                                                                    (Pulse_Typing.STC
+                                                                    (g1,
                                                                     {
                                                                     Pulse_Syntax_Base.u
                                                                     = u;
                                                                     Pulse_Syntax_Base.res
                                                                     = t2;
                                                                     Pulse_Syntax_Base.pre
-                                                                    = pre;
+                                                                    = pre1;
                                                                     Pulse_Syntax_Base.post
                                                                     = post1
-                                                                    }))
+                                                                    }, x, (),
+                                                                    (), ())))))
                                                                     (fun
                                                                     uu___3 ->
-                                                                    (fun s ->
+                                                                    (fun
+                                                                    uu___3 ->
+                                                                    match uu___3
+                                                                    with
+                                                                    | 
+                                                                    Prims.Mkdtuple2
+                                                                    (_s, ds)
+                                                                    ->
                                                                     Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Admit.fst"
-                                                                    (Prims.of_int (85))
-                                                                    (Prims.of_int (10))
-                                                                    (Prims.of_int (85))
-                                                                    (Prims.of_int (67)))))
+                                                                    (Prims.of_int (96))
+                                                                    (Prims.of_int (18))
+                                                                    (Prims.of_int (99))
+                                                                    (Prims.of_int (117)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Admit.fst"
-                                                                    (Prims.of_int (86))
-                                                                    (Prims.of_int (2))
-                                                                    (Prims.of_int (86))
+                                                                    (Prims.of_int (96))
+                                                                    (Prims.of_int (18))
+                                                                    (Prims.of_int (99))
                                                                     (Prims.of_int (117)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
-                                                                    uu___3 ->
-                                                                    Pulse_Typing.T_Admit
-                                                                    (g1, s,
-                                                                    c,
-                                                                    (Pulse_Typing.STC
-                                                                    (g1, s,
-                                                                    x, (),
-                                                                    (), ())))))
+                                                                    uu___4 ->
+                                                                    uu___3))
                                                                     (fun
-                                                                    uu___3 ->
+                                                                    uu___4 ->
+                                                                    (fun
+                                                                    uu___4 ->
+                                                                    Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Admit.fst"
+                                                                    (Prims.of_int (98))
+                                                                    (Prims.of_int (10))
+                                                                    (Prims.of_int (98))
+                                                                    (Prims.of_int (26)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Admit.fst"
+                                                                    (Prims.of_int (99))
+                                                                    (Prims.of_int (2))
+                                                                    (Prims.of_int (99))
+                                                                    (Prims.of_int (117)))))
+                                                                    (FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___5 ->
+                                                                    Pulse_Typing.T_Admit
+                                                                    (g1, _s,
+                                                                    c, ds)))
+                                                                    (fun
+                                                                    uu___5 ->
                                                                     (fun d ->
                                                                     Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -471,17 +560,17 @@ let (check_core :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Admit.fst"
-                                                                    (Prims.of_int (86))
+                                                                    (Prims.of_int (99))
                                                                     (Prims.of_int (18))
-                                                                    (Prims.of_int (86))
+                                                                    (Prims.of_int (99))
                                                                     (Prims.of_int (99)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Admit.fst"
-                                                                    (Prims.of_int (86))
+                                                                    (Prims.of_int (99))
                                                                     (Prims.of_int (2))
-                                                                    (Prims.of_int (86))
+                                                                    (Prims.of_int (99))
                                                                     (Prims.of_int (117)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -489,17 +578,17 @@ let (check_core :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Admit.fst"
-                                                                    (Prims.of_int (86))
+                                                                    (Prims.of_int (99))
                                                                     (Prims.of_int (44))
-                                                                    (Prims.of_int (86))
+                                                                    (Prims.of_int (99))
                                                                     (Prims.of_int (87)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Admit.fst"
-                                                                    (Prims.of_int (86))
+                                                                    (Prims.of_int (99))
                                                                     (Prims.of_int (18))
-                                                                    (Prims.of_int (86))
+                                                                    (Prims.of_int (99))
                                                                     (Prims.of_int (99)))))
                                                                     (Obj.magic
                                                                     (Pulse_Checker_Base.match_comp_res_with_post_hint
@@ -513,41 +602,43 @@ let (check_core :
                                                                     = c;
                                                                     Pulse_Syntax_Base.u1
                                                                     =
-                                                                    (s.Pulse_Syntax_Base.u);
+                                                                    (_s.Pulse_Syntax_Base.u);
                                                                     Pulse_Syntax_Base.typ
                                                                     =
-                                                                    (s.Pulse_Syntax_Base.res);
+                                                                    (_s.Pulse_Syntax_Base.res);
                                                                     Pulse_Syntax_Base.post3
                                                                     =
                                                                     FStar_Pervasives_Native.None
                                                                     }))
                                                                     (Pulse_Typing.comp_admit
-                                                                    c s) d
+                                                                    c _s) d
                                                                     post_hint))
                                                                     (fun
-                                                                    uu___3 ->
+                                                                    uu___5 ->
                                                                     (fun
-                                                                    uu___3 ->
+                                                                    uu___5 ->
                                                                     Obj.magic
                                                                     (Pulse_Checker_Prover.try_frame_pre
                                                                     g pre ()
-                                                                    uu___3
+                                                                    uu___5
                                                                     res_ppname))
-                                                                    uu___3)))
+                                                                    uu___5)))
                                                                     (fun
-                                                                    uu___3 ->
+                                                                    uu___5 ->
                                                                     (fun
-                                                                    uu___3 ->
+                                                                    uu___5 ->
                                                                     Obj.magic
                                                                     (Pulse_Checker_Prover.prove_post_hint
                                                                     g pre
-                                                                    uu___3
+                                                                    uu___5
                                                                     post_hint
                                                                     t2.Pulse_Syntax_Base.range1))
+                                                                    uu___5)))
+                                                                    uu___5)))
+                                                                    uu___4)))
                                                                     uu___3)))
                                                                     uu___3)))
-                                                                    uu___3)))
-                                                                    uu___3)))
+                                                                    uu___2)))
                                                                     uu___2)))
                                                                     uu___2)))
                                                           uu___2))) uu___2)))
@@ -572,13 +663,13 @@ let (check :
                 (FStar_Sealed.seal
                    (Obj.magic
                       (FStar_Range.mk_range "Pulse.Checker.Admit.fst"
-                         (Prims.of_int (97)) (Prims.of_int (21))
-                         (Prims.of_int (97)) (Prims.of_int (27)))))
+                         (Prims.of_int (110)) (Prims.of_int (21))
+                         (Prims.of_int (110)) (Prims.of_int (27)))))
                 (FStar_Sealed.seal
                    (Obj.magic
                       (FStar_Range.mk_range "Pulse.Checker.Admit.fst"
-                         (Prims.of_int (97)) (Prims.of_int (3))
-                         (Prims.of_int (102)) (Prims.of_int (56)))))
+                         (Prims.of_int (110)) (Prims.of_int (3))
+                         (Prims.of_int (115)) (Prims.of_int (56)))))
                 (FStar_Tactics_Effect.lift_div_tac
                    (fun uu___ -> t.Pulse_Syntax_Base.term1))
                 (fun uu___ ->

--- a/src/ocaml/plugin/generated/Pulse_Checker_Admit.ml
+++ b/src/ocaml/plugin/generated/Pulse_Checker_Admit.ml
@@ -1,5 +1,4 @@
 open Prims
-type ('p, 'x, 't, 'u, 'post) post_hint_compatible = Obj.t
 let (check_core :
   Pulse_Typing_Env.env ->
     Pulse_Syntax_Base.term ->
@@ -20,13 +19,13 @@ let (check_core :
                 (FStar_Sealed.seal
                    (Obj.magic
                       (FStar_Range.mk_range "Pulse.Checker.Admit.fst"
-                         (Prims.of_int (47)) (Prims.of_int (10))
-                         (Prims.of_int (47)) (Prims.of_int (63)))))
+                         (Prims.of_int (40)) (Prims.of_int (10))
+                         (Prims.of_int (40)) (Prims.of_int (63)))))
                 (FStar_Sealed.seal
                    (Obj.magic
                       (FStar_Range.mk_range "Pulse.Checker.Admit.fst"
-                         (Prims.of_int (47)) (Prims.of_int (66))
-                         (Prims.of_int (94)) (Prims.of_int (117)))))
+                         (Prims.of_int (40)) (Prims.of_int (66))
+                         (Prims.of_int (86)) (Prims.of_int (117)))))
                 (FStar_Tactics_Effect.lift_div_tac
                    (fun uu___ ->
                       Pulse_Typing_Env.push_context g "check_admit"
@@ -39,14 +38,14 @@ let (check_core :
                               (Obj.magic
                                  (FStar_Range.mk_range
                                     "Pulse.Checker.Admit.fst"
-                                    (Prims.of_int (49)) (Prims.of_int (43))
-                                    (Prims.of_int (49)) (Prims.of_int (49)))))
+                                    (Prims.of_int (42)) (Prims.of_int (43))
+                                    (Prims.of_int (42)) (Prims.of_int (49)))))
                            (FStar_Sealed.seal
                               (Obj.magic
                                  (FStar_Range.mk_range
                                     "Pulse.Checker.Admit.fst"
-                                    (Prims.of_int (47)) (Prims.of_int (66))
-                                    (Prims.of_int (94)) (Prims.of_int (117)))))
+                                    (Prims.of_int (40)) (Prims.of_int (66))
+                                    (Prims.of_int (86)) (Prims.of_int (117)))))
                            (FStar_Tactics_Effect.lift_div_tac
                               (fun uu___ -> t.Pulse_Syntax_Base.term1))
                            (fun uu___ ->
@@ -64,17 +63,17 @@ let (check_core :
                                              (Obj.magic
                                                 (FStar_Range.mk_range
                                                    "Pulse.Checker.Admit.fst"
-                                                   (Prims.of_int (51))
+                                                   (Prims.of_int (44))
                                                    (Prims.of_int (10))
-                                                   (Prims.of_int (51))
+                                                   (Prims.of_int (44))
                                                    (Prims.of_int (17)))))
                                           (FStar_Sealed.seal
                                              (Obj.magic
                                                 (FStar_Range.mk_range
                                                    "Pulse.Checker.Admit.fst"
-                                                   (Prims.of_int (51))
+                                                   (Prims.of_int (44))
                                                    (Prims.of_int (20))
-                                                   (Prims.of_int (94))
+                                                   (Prims.of_int (86))
                                                    (Prims.of_int (117)))))
                                           (FStar_Tactics_Effect.lift_div_tac
                                              (fun uu___2 ->
@@ -87,17 +86,17 @@ let (check_core :
                                                         (Obj.magic
                                                            (FStar_Range.mk_range
                                                               "Pulse.Checker.Admit.fst"
-                                                              (Prims.of_int (52))
+                                                              (Prims.of_int (45))
                                                               (Prims.of_int (11))
-                                                              (Prims.of_int (52))
+                                                              (Prims.of_int (45))
                                                               (Prims.of_int (20)))))
                                                      (FStar_Sealed.seal
                                                         (Obj.magic
                                                            (FStar_Range.mk_range
                                                               "Pulse.Checker.Admit.fst"
-                                                              (Prims.of_int (52))
+                                                              (Prims.of_int (45))
                                                               (Prims.of_int (23))
-                                                              (Prims.of_int (94))
+                                                              (Prims.of_int (86))
                                                               (Prims.of_int (117)))))
                                                      (FStar_Tactics_Effect.lift_div_tac
                                                         (fun uu___2 ->
@@ -111,17 +110,17 @@ let (check_core :
                                                                    (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Admit.fst"
-                                                                    (Prims.of_int (59))
+                                                                    (Prims.of_int (52))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (86))
+                                                                    (Prims.of_int (78))
                                                                     (Prims.of_int (9)))))
                                                                 (FStar_Sealed.seal
                                                                    (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Admit.fst"
-                                                                    (Prims.of_int (87))
+                                                                    (Prims.of_int (79))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (94))
+                                                                    (Prims.of_int (86))
                                                                     (Prims.of_int (117)))))
                                                                 (match 
                                                                    (post,
@@ -137,125 +136,6 @@ let (check_core :
                                                                     "could not find a post annotation on admit, please add one")
                                                                  | (FStar_Pervasives_Native.Some
                                                                     post1,
-                                                                    FStar_Pervasives_Native.Some
-                                                                    post2) ->
-                                                                    Obj.magic
-                                                                    (FStar_Tactics_Effect.tac_bind
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Admit.fst"
-                                                                    (Prims.of_int (65))
-                                                                    (Prims.of_int (10))
-                                                                    (Prims.of_int (67))
-                                                                    (Prims.of_int (43)))))
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Admit.fst"
-                                                                    (Prims.of_int (64))
-                                                                    (Prims.of_int (8))
-                                                                    (Prims.of_int (67))
-                                                                    (Prims.of_int (43)))))
-                                                                    (Obj.magic
-                                                                    (FStar_Tactics_Effect.tac_bind
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Admit.fst"
-                                                                    (Prims.of_int (67))
-                                                                    (Prims.of_int (13))
-                                                                    (Prims.of_int (67))
-                                                                    (Prims.of_int (42)))))
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Admit.fst"
-                                                                    (Prims.of_int (65))
-                                                                    (Prims.of_int (10))
-                                                                    (Prims.of_int (67))
-                                                                    (Prims.of_int (43)))))
-                                                                    (Obj.magic
-                                                                    (Pulse_Syntax_Printer.term_to_string
-                                                                    post2.Pulse_Typing.post))
-                                                                    (fun
-                                                                    uu___2 ->
-                                                                    (fun
-                                                                    uu___2 ->
-                                                                    Obj.magic
-                                                                    (FStar_Tactics_Effect.tac_bind
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Admit.fst"
-                                                                    (Prims.of_int (65))
-                                                                    (Prims.of_int (10))
-                                                                    (Prims.of_int (67))
-                                                                    (Prims.of_int (43)))))
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Admit.fst"
-                                                                    (Prims.of_int (65))
-                                                                    (Prims.of_int (10))
-                                                                    (Prims.of_int (67))
-                                                                    (Prims.of_int (43)))))
-                                                                    (Obj.magic
-                                                                    (FStar_Tactics_Effect.tac_bind
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Admit.fst"
-                                                                    (Prims.of_int (66))
-                                                                    (Prims.of_int (13))
-                                                                    (Prims.of_int (66))
-                                                                    (Prims.of_int (37)))))
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "FStar.Printf.fst"
-                                                                    (Prims.of_int (122))
-                                                                    (Prims.of_int (8))
-                                                                    (Prims.of_int (124))
-                                                                    (Prims.of_int (44)))))
-                                                                    (Obj.magic
-                                                                    (Pulse_Syntax_Printer.term_to_string
-                                                                    post1))
-                                                                    (fun
-                                                                    uu___3 ->
-                                                                    FStar_Tactics_Effect.lift_div_tac
-                                                                    (fun
-                                                                    uu___4 ->
-                                                                    fun x1 ->
-                                                                    Prims.strcat
-                                                                    (Prims.strcat
-                                                                    "found two post annotations on admit: "
-                                                                    (Prims.strcat
-                                                                    uu___3
-                                                                    " and "))
-                                                                    (Prims.strcat
-                                                                    x1
-                                                                    ", please remove one")))))
-                                                                    (fun
-                                                                    uu___3 ->
-                                                                    FStar_Tactics_Effect.lift_div_tac
-                                                                    (fun
-                                                                    uu___4 ->
-                                                                    uu___3
-                                                                    uu___2))))
-                                                                    uu___2)))
-                                                                    (fun
-                                                                    uu___2 ->
-                                                                    (fun
-                                                                    uu___2 ->
-                                                                    Obj.magic
-                                                                    (Pulse_Typing_Env.fail
-                                                                    g1
-                                                                    FStar_Pervasives_Native.None
-                                                                    uu___2))
-                                                                    uu___2))
-                                                                 | (FStar_Pervasives_Native.Some
-                                                                    post1,
                                                                     uu___2)
                                                                     ->
                                                                     Obj.magic
@@ -264,21 +144,55 @@ let (check_core :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Admit.fst"
+                                                                    (Prims.of_int (61))
+                                                                    (Prims.of_int (25))
+                                                                    (Prims.of_int (61))
+                                                                    (Prims.of_int (65)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Admit.fst"
+                                                                    (Prims.of_int (61))
                                                                     (Prims.of_int (70))
+                                                                    (Prims.of_int (67))
+                                                                    (Prims.of_int (47)))))
+                                                                    (FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___3 ->
+                                                                    {
+                                                                    Pulse_Syntax_Base.t
+                                                                    =
+                                                                    (Pulse_Syntax_Base.Tm_FStar
+                                                                    Pulse_Reflection_Util.unit_tm);
+                                                                    Pulse_Syntax_Base.range1
+                                                                    =
+                                                                    (t1.Pulse_Syntax_Base.range1)
+                                                                    }))
+                                                                    (fun
+                                                                    uu___3 ->
+                                                                    (fun t2
+                                                                    ->
+                                                                    Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Admit.fst"
+                                                                    (Prims.of_int (62))
                                                                     (Prims.of_int (32))
-                                                                    (Prims.of_int (70))
+                                                                    (Prims.of_int (62))
                                                                     (Prims.of_int (50)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Admit.fst"
-                                                                    (Prims.of_int (69))
-                                                                    (Prims.of_int (23))
-                                                                    (Prims.of_int (75))
+                                                                    (Prims.of_int (61))
+                                                                    (Prims.of_int (70))
+                                                                    (Prims.of_int (67))
                                                                     (Prims.of_int (47)))))
                                                                     (Obj.magic
                                                                     (Pulse_Checker_Pure.check_universe
-                                                                    g1 t1))
+                                                                    g1 t2))
                                                                     (fun
                                                                     uu___3 ->
                                                                     (fun
@@ -296,17 +210,17 @@ let (check_core :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Admit.fst"
-                                                                    (Prims.of_int (71))
+                                                                    (Prims.of_int (63))
                                                                     (Prims.of_int (26))
-                                                                    (Prims.of_int (71))
+                                                                    (Prims.of_int (63))
                                                                     (Prims.of_int (46)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Admit.fst"
-                                                                    (Prims.of_int (71))
+                                                                    (Prims.of_int (63))
                                                                     (Prims.of_int (49))
-                                                                    (Prims.of_int (75))
+                                                                    (Prims.of_int (67))
                                                                     (Prims.of_int (47)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -324,24 +238,24 @@ let (check_core :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Admit.fst"
-                                                                    (Prims.of_int (73))
+                                                                    (Prims.of_int (65))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (73))
+                                                                    (Prims.of_int (65))
                                                                     (Prims.of_int (77)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Admit.fst"
-                                                                    (Prims.of_int (71))
+                                                                    (Prims.of_int (63))
                                                                     (Prims.of_int (49))
-                                                                    (Prims.of_int (75))
+                                                                    (Prims.of_int (67))
                                                                     (Prims.of_int (47)))))
                                                                     (Obj.magic
                                                                     (Pulse_Checker_Pure.check_tot_term
                                                                     (Pulse_Typing_Env.push_binding
                                                                     g1 x
                                                                     (FStar_Pervasives_Native.fst
-                                                                    px) t1)
+                                                                    px) t2)
                                                                     post_opened
                                                                     Pulse_Syntax_Base.tm_vprop))
                                                                     (fun
@@ -357,11 +271,12 @@ let (check_core :
                                                                     post_typing)
                                                                     ->
                                                                     FStar_Pervasives.Mkdtuple5
-                                                                    (t1, u,
+                                                                    (t2, u,
                                                                     (),
                                                                     post2,
                                                                     ())))))
                                                                     uu___4)))
+                                                                    uu___3)))
                                                                     uu___3))
                                                                  | (uu___2,
                                                                     FStar_Pervasives_Native.Some
@@ -372,17 +287,17 @@ let (check_core :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Admit.fst"
-                                                                    (Prims.of_int (78))
+                                                                    (Prims.of_int (70))
                                                                     (Prims.of_int (33))
-                                                                    (Prims.of_int (78))
+                                                                    (Prims.of_int (70))
                                                                     (Prims.of_int (37)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Admit.fst"
-                                                                    (Prims.of_int (79))
+                                                                    (Prims.of_int (71))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (86))
+                                                                    (Prims.of_int (78))
                                                                     (Prims.of_int (9)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -428,17 +343,17 @@ let (check_core :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Admit.fst"
-                                                                    (Prims.of_int (88))
+                                                                    (Prims.of_int (80))
                                                                     (Prims.of_int (55))
-                                                                    (Prims.of_int (88))
+                                                                    (Prims.of_int (80))
                                                                     (Prims.of_int (58)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Admit.fst"
-                                                                    (Prims.of_int (87))
+                                                                    (Prims.of_int (79))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (94))
+                                                                    (Prims.of_int (86))
                                                                     (Prims.of_int (117)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -463,17 +378,17 @@ let (check_core :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Admit.fst"
-                                                                    (Prims.of_int (89))
+                                                                    (Prims.of_int (81))
                                                                     (Prims.of_int (13))
-                                                                    (Prims.of_int (89))
+                                                                    (Prims.of_int (81))
                                                                     (Prims.of_int (37)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Admit.fst"
-                                                                    (Prims.of_int (89))
+                                                                    (Prims.of_int (81))
                                                                     (Prims.of_int (40))
-                                                                    (Prims.of_int (94))
+                                                                    (Prims.of_int (86))
                                                                     (Prims.of_int (117)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -491,17 +406,17 @@ let (check_core :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Admit.fst"
-                                                                    (Prims.of_int (90))
+                                                                    (Prims.of_int (82))
                                                                     (Prims.of_int (21))
-                                                                    (Prims.of_int (90))
+                                                                    (Prims.of_int (82))
                                                                     (Prims.of_int (37)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Admit.fst"
-                                                                    (Prims.of_int (92))
+                                                                    (Prims.of_int (84))
                                                                     (Prims.of_int (65))
-                                                                    (Prims.of_int (94))
+                                                                    (Prims.of_int (86))
                                                                     (Prims.of_int (117)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -525,17 +440,17 @@ let (check_core :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Admit.fst"
-                                                                    (Prims.of_int (93))
+                                                                    (Prims.of_int (85))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (93))
+                                                                    (Prims.of_int (85))
                                                                     (Prims.of_int (67)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Admit.fst"
-                                                                    (Prims.of_int (94))
+                                                                    (Prims.of_int (86))
                                                                     (Prims.of_int (2))
-                                                                    (Prims.of_int (94))
+                                                                    (Prims.of_int (86))
                                                                     (Prims.of_int (117)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -556,17 +471,17 @@ let (check_core :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Admit.fst"
-                                                                    (Prims.of_int (94))
+                                                                    (Prims.of_int (86))
                                                                     (Prims.of_int (18))
-                                                                    (Prims.of_int (94))
+                                                                    (Prims.of_int (86))
                                                                     (Prims.of_int (99)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Admit.fst"
-                                                                    (Prims.of_int (94))
+                                                                    (Prims.of_int (86))
                                                                     (Prims.of_int (2))
-                                                                    (Prims.of_int (94))
+                                                                    (Prims.of_int (86))
                                                                     (Prims.of_int (117)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -574,17 +489,17 @@ let (check_core :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Admit.fst"
-                                                                    (Prims.of_int (94))
+                                                                    (Prims.of_int (86))
                                                                     (Prims.of_int (44))
-                                                                    (Prims.of_int (94))
+                                                                    (Prims.of_int (86))
                                                                     (Prims.of_int (87)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Admit.fst"
-                                                                    (Prims.of_int (94))
+                                                                    (Prims.of_int (86))
                                                                     (Prims.of_int (18))
-                                                                    (Prims.of_int (94))
+                                                                    (Prims.of_int (86))
                                                                     (Prims.of_int (99)))))
                                                                     (Obj.magic
                                                                     (Pulse_Checker_Base.match_comp_res_with_post_hint
@@ -657,13 +572,13 @@ let (check :
                 (FStar_Sealed.seal
                    (Obj.magic
                       (FStar_Range.mk_range "Pulse.Checker.Admit.fst"
-                         (Prims.of_int (105)) (Prims.of_int (21))
-                         (Prims.of_int (105)) (Prims.of_int (27)))))
+                         (Prims.of_int (97)) (Prims.of_int (21))
+                         (Prims.of_int (97)) (Prims.of_int (27)))))
                 (FStar_Sealed.seal
                    (Obj.magic
                       (FStar_Range.mk_range "Pulse.Checker.Admit.fst"
-                         (Prims.of_int (105)) (Prims.of_int (3))
-                         (Prims.of_int (110)) (Prims.of_int (56)))))
+                         (Prims.of_int (97)) (Prims.of_int (3))
+                         (Prims.of_int (102)) (Prims.of_int (56)))))
                 (FStar_Tactics_Effect.lift_div_tac
                    (fun uu___ -> t.Pulse_Syntax_Base.term1))
                 (fun uu___ ->

--- a/src/ocaml/plugin/generated/Pulse_Checker_Bind.ml
+++ b/src/ocaml/plugin/generated/Pulse_Checker_Bind.ml
@@ -423,7 +423,7 @@ let (check_bind :
                      (Obj.magic
                         (FStar_Range.mk_range "Pulse.Checker.Bind.fst"
                            (Prims.of_int (79)) (Prims.of_int (2))
-                           (Prims.of_int (126)) (Prims.of_int (3)))))
+                           (Prims.of_int (135)) (Prims.of_int (3)))))
                   (FStar_Tactics_Effect.lift_div_tac
                      (fun uu___ ->
                         Pulse_Typing_Env.push_context g "check_bind"
@@ -443,7 +443,7 @@ let (check_bind :
                                    (FStar_Range.mk_range
                                       "Pulse.Checker.Bind.fst"
                                       (Prims.of_int (82)) (Prims.of_int (2))
-                                      (Prims.of_int (126)) (Prims.of_int (3)))))
+                                      (Prims.of_int (135)) (Prims.of_int (3)))))
                              (Obj.magic
                                 (Pulse_Checker_Prover_Util.debug_prover g1
                                    (fun uu___ ->
@@ -491,7 +491,7 @@ let (check_bind :
                                                  "Pulse.Checker.Bind.fst"
                                                  (Prims.of_int (83))
                                                  (Prims.of_int (90))
-                                                 (Prims.of_int (126))
+                                                 (Prims.of_int (135))
                                                  (Prims.of_int (3)))))
                                         (if
                                            FStar_Pervasives_Native.uu___is_None
@@ -526,7 +526,7 @@ let (check_bind :
                                                             "Pulse.Checker.Bind.fst"
                                                             (Prims.of_int (83))
                                                             (Prims.of_int (90))
-                                                            (Prims.of_int (126))
+                                                            (Prims.of_int (135))
                                                             (Prims.of_int (3)))))
                                                    (FStar_Tactics_Effect.lift_div_tac
                                                       (fun uu___2 ->
@@ -543,46 +543,90 @@ let (check_bind :
                                                                Pulse_Syntax_Base.body1
                                                                  = e2;_}
                                                              ->
-                                                             if
-                                                               Pulse_Syntax_Base.uu___is_Tm_Admit
-                                                                 e1.Pulse_Syntax_Base.term1
-                                                             then
-                                                               Obj.magic
-                                                                 (check g1
+                                                             Obj.magic
+                                                               (FStar_Tactics_Effect.tac_bind
+                                                                  (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Bind.fst"
+                                                                    (Prims.of_int (87))
+                                                                    (Prims.of_int (4))
+                                                                    (Prims.of_int (94))
+                                                                    (Prims.of_int (16)))))
+                                                                  (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Bind.fst"
+                                                                    (Prims.of_int (95))
+                                                                    (Prims.of_int (2))
+                                                                    (Prims.of_int (135))
+                                                                    (Prims.of_int (3)))))
+                                                                  (FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___3 ->
+                                                                    match 
+                                                                    e1.Pulse_Syntax_Base.term1
+                                                                    with
+                                                                    | 
+                                                                    Pulse_Syntax_Base.Tm_Admit
+                                                                    {
+                                                                    Pulse_Syntax_Base.ctag1
+                                                                    = uu___4;
+                                                                    Pulse_Syntax_Base.u1
+                                                                    = uu___5;
+                                                                    Pulse_Syntax_Base.typ
+                                                                    = uu___6;
+                                                                    Pulse_Syntax_Base.post3
+                                                                    =
+                                                                    FStar_Pervasives_Native.None;_}
+                                                                    -> true
+                                                                    | 
+                                                                    uu___4 ->
+                                                                    false))
+                                                                  (fun uu___3
+                                                                    ->
+                                                                    (fun
+                                                                    discard_continuation
+                                                                    ->
+                                                                    if
+                                                                    discard_continuation
+                                                                    then
+                                                                    Obj.magic
+                                                                    (check g1
                                                                     ctxt ()
                                                                     post_hint
                                                                     res_ppname
                                                                     e1)
-                                                             else
-                                                               if
-                                                                 Pulse_Syntax_Base.uu___is_Tm_Abs
-                                                                   e1.Pulse_Syntax_Base.term1
-                                                               then
-                                                                 Obj.magic
-                                                                   (check_bind_fn
+                                                                    else
+                                                                    if
+                                                                    Pulse_Syntax_Base.uu___is_Tm_Abs
+                                                                    e1.Pulse_Syntax_Base.term1
+                                                                    then
+                                                                    Obj.magic
+                                                                    (check_bind_fn
                                                                     g1 ctxt
                                                                     ()
                                                                     post_hint
                                                                     res_ppname
                                                                     t check)
-                                                               else
-                                                                 Obj.magic
-                                                                   (FStar_Tactics_Effect.tac_bind
+                                                                    else
+                                                                    Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (95))
+                                                                    (Prims.of_int (104))
                                                                     (Prims.of_int (55))
-                                                                    (Prims.of_int (116))
+                                                                    (Prims.of_int (125))
                                                                     (Prims.of_int (7)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (94))
+                                                                    (Prims.of_int (103))
                                                                     (Prims.of_int (7))
-                                                                    (Prims.of_int (126))
+                                                                    (Prims.of_int (135))
                                                                     (Prims.of_int (3)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -590,17 +634,17 @@ let (check_bind :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (96))
+                                                                    (Prims.of_int (105))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (96))
+                                                                    (Prims.of_int (105))
                                                                     (Prims.of_int (67)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (96))
+                                                                    (Prims.of_int (105))
                                                                     (Prims.of_int (70))
-                                                                    (Prims.of_int (116))
+                                                                    (Prims.of_int (125))
                                                                     (Prims.of_int (7)))))
                                                                     (Obj.magic
                                                                     (check g1
@@ -617,17 +661,17 @@ let (check_bind :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (98))
+                                                                    (Prims.of_int (107))
                                                                     (Prims.of_int (15))
-                                                                    (Prims.of_int (98))
+                                                                    (Prims.of_int (107))
                                                                     (Prims.of_int (31)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (99))
+                                                                    (Prims.of_int (108))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (116))
+                                                                    (Prims.of_int (125))
                                                                     (Prims.of_int (7)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -643,17 +687,17 @@ let (check_bind :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (99))
+                                                                    (Prims.of_int (108))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (114))
+                                                                    (Prims.of_int (123))
                                                                     (Prims.of_int (108)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (96))
+                                                                    (Prims.of_int (105))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (96))
+                                                                    (Prims.of_int (105))
                                                                     (Prims.of_int (11)))))
                                                                     (match 
                                                                     ty.Pulse_Syntax_Base.t
@@ -676,17 +720,17 @@ let (check_bind :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (102))
+                                                                    (Prims.of_int (111))
                                                                     (Prims.of_int (29))
-                                                                    (Prims.of_int (102))
+                                                                    (Prims.of_int (111))
                                                                     (Prims.of_int (55)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (101))
+                                                                    (Prims.of_int (110))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (114))
+                                                                    (Prims.of_int (123))
                                                                     (Prims.of_int (108)))))
                                                                     (Obj.magic
                                                                     (Pulse_Checker_Pure.compute_tot_term_type
@@ -709,17 +753,17 @@ let (check_bind :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (103))
+                                                                    (Prims.of_int (112))
                                                                     (Prims.of_int (46))
-                                                                    (Prims.of_int (103))
+                                                                    (Prims.of_int (112))
                                                                     (Prims.of_int (47)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (102))
+                                                                    (Prims.of_int (111))
                                                                     (Prims.of_int (58))
-                                                                    (Prims.of_int (114))
+                                                                    (Prims.of_int (123))
                                                                     (Prims.of_int (108)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -754,17 +798,17 @@ let (check_bind :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (114))
+                                                                    (Prims.of_int (123))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (114))
+                                                                    (Prims.of_int (123))
                                                                     (Prims.of_int (108)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (113))
+                                                                    (Prims.of_int (122))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (114))
+                                                                    (Prims.of_int (123))
                                                                     (Prims.of_int (108)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -772,17 +816,17 @@ let (check_bind :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (114))
+                                                                    (Prims.of_int (123))
                                                                     (Prims.of_int (87))
-                                                                    (Prims.of_int (114))
+                                                                    (Prims.of_int (123))
                                                                     (Prims.of_int (107)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (114))
+                                                                    (Prims.of_int (123))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (114))
+                                                                    (Prims.of_int (123))
                                                                     (Prims.of_int (108)))))
                                                                     (Obj.magic
                                                                     (Pulse_Syntax_Printer.term_to_string
@@ -799,17 +843,17 @@ let (check_bind :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (114))
+                                                                    (Prims.of_int (123))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (114))
+                                                                    (Prims.of_int (123))
                                                                     (Prims.of_int (108)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (114))
+                                                                    (Prims.of_int (123))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (114))
+                                                                    (Prims.of_int (123))
                                                                     (Prims.of_int (108)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -817,9 +861,9 @@ let (check_bind :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (114))
+                                                                    (Prims.of_int (123))
                                                                     (Prims.of_int (65))
-                                                                    (Prims.of_int (114))
+                                                                    (Prims.of_int (123))
                                                                     (Prims.of_int (86)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -908,17 +952,17 @@ let (check_bind :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (118))
+                                                                    (Prims.of_int (127))
                                                                     (Prims.of_int (50))
-                                                                    (Prims.of_int (122))
+                                                                    (Prims.of_int (131))
                                                                     (Prims.of_int (66)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (122))
+                                                                    (Prims.of_int (131))
                                                                     (Prims.of_int (69))
-                                                                    (Prims.of_int (125))
+                                                                    (Prims.of_int (134))
                                                                     (Prims.of_int (45)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -926,17 +970,17 @@ let (check_bind :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (119))
+                                                                    (Prims.of_int (128))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (119))
+                                                                    (Prims.of_int (128))
                                                                     (Prims.of_int (47)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (119))
+                                                                    (Prims.of_int (128))
                                                                     (Prims.of_int (50))
-                                                                    (Prims.of_int (122))
+                                                                    (Prims.of_int (131))
                                                                     (Prims.of_int (66)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -953,17 +997,17 @@ let (check_bind :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (121))
+                                                                    (Prims.of_int (130))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (121))
+                                                                    (Prims.of_int (130))
                                                                     (Prims.of_int (99)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (122))
+                                                                    (Prims.of_int (131))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (122))
+                                                                    (Prims.of_int (131))
                                                                     (Prims.of_int (66)))))
                                                                     (Obj.magic
                                                                     (check
@@ -995,17 +1039,17 @@ let (check_bind :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (123))
+                                                                    (Prims.of_int (132))
                                                                     (Prims.of_int (49))
-                                                                    (Prims.of_int (123))
+                                                                    (Prims.of_int (132))
                                                                     (Prims.of_int (63)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (125))
+                                                                    (Prims.of_int (134))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (125))
+                                                                    (Prims.of_int (134))
                                                                     (Prims.of_int (45)))))
                                                                     (Obj.magic
                                                                     (k1
@@ -1024,6 +1068,7 @@ let (check_bind :
                                                                     uu___7)))
                                                                     uu___7)))
                                                                     uu___5)))
+                                                                    uu___3)))
                                                         uu___2))) uu___1)))
                                   uu___))) uu___)
 let (check_tot_bind :
@@ -1048,13 +1093,13 @@ let (check_tot_bind :
                   (FStar_Sealed.seal
                      (Obj.magic
                         (FStar_Range.mk_range "Pulse.Checker.Bind.fst"
-                           (Prims.of_int (139)) (Prims.of_int (10))
-                           (Prims.of_int (139)) (Prims.of_int (66)))))
+                           (Prims.of_int (148)) (Prims.of_int (10))
+                           (Prims.of_int (148)) (Prims.of_int (66)))))
                   (FStar_Sealed.seal
                      (Obj.magic
                         (FStar_Range.mk_range "Pulse.Checker.Bind.fst"
-                           (Prims.of_int (141)) (Prims.of_int (2))
-                           (Prims.of_int (194)) (Prims.of_int (3)))))
+                           (Prims.of_int (150)) (Prims.of_int (2))
+                           (Prims.of_int (203)) (Prims.of_int (3)))))
                   (FStar_Tactics_Effect.lift_div_tac
                      (fun uu___ ->
                         Pulse_Typing_Env.push_context g "check_tot_bind"
@@ -1067,16 +1112,16 @@ let (check_tot_bind :
                                 (Obj.magic
                                    (FStar_Range.mk_range
                                       "Pulse.Checker.Bind.fst"
-                                      (Prims.of_int (141)) (Prims.of_int (2))
-                                      (Prims.of_int (142))
+                                      (Prims.of_int (150)) (Prims.of_int (2))
+                                      (Prims.of_int (151))
                                       (Prims.of_int (93)))))
                              (FStar_Sealed.seal
                                 (Obj.magic
                                    (FStar_Range.mk_range
                                       "Pulse.Checker.Bind.fst"
-                                      (Prims.of_int (142))
+                                      (Prims.of_int (151))
                                       (Prims.of_int (94))
-                                      (Prims.of_int (194)) (Prims.of_int (3)))))
+                                      (Prims.of_int (203)) (Prims.of_int (3)))))
                              (if
                                 FStar_Pervasives_Native.uu___is_None
                                   post_hint
@@ -1100,17 +1145,17 @@ let (check_tot_bind :
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.Checker.Bind.fst"
-                                                 (Prims.of_int (145))
+                                                 (Prims.of_int (154))
                                                  (Prims.of_int (50))
-                                                 (Prims.of_int (145))
+                                                 (Prims.of_int (154))
                                                  (Prims.of_int (56)))))
                                         (FStar_Sealed.seal
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.Checker.Bind.fst"
-                                                 (Prims.of_int (142))
+                                                 (Prims.of_int (151))
                                                  (Prims.of_int (94))
-                                                 (Prims.of_int (194))
+                                                 (Prims.of_int (203))
                                                  (Prims.of_int (3)))))
                                         (FStar_Tactics_Effect.lift_div_tac
                                            (fun uu___1 ->
@@ -1133,17 +1178,17 @@ let (check_tot_bind :
                                                           (Obj.magic
                                                              (FStar_Range.mk_range
                                                                 "Pulse.Checker.Bind.fst"
-                                                                (Prims.of_int (146))
+                                                                (Prims.of_int (155))
                                                                 (Prims.of_int (8))
-                                                                (Prims.of_int (146))
+                                                                (Prims.of_int (155))
                                                                 (Prims.of_int (55)))))
                                                        (FStar_Sealed.seal
                                                           (Obj.magic
                                                              (FStar_Range.mk_range
                                                                 "Pulse.Checker.Bind.fst"
-                                                                (Prims.of_int (146))
+                                                                (Prims.of_int (155))
                                                                 (Prims.of_int (2))
-                                                                (Prims.of_int (194))
+                                                                (Prims.of_int (203))
                                                                 (Prims.of_int (3)))))
                                                        (Obj.magic
                                                           (Pulse_Checker_Base.is_stateful_application
@@ -1160,17 +1205,17 @@ let (check_tot_bind :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (148))
+                                                                    (Prims.of_int (157))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (148))
+                                                                    (Prims.of_int (157))
                                                                     (Prims.of_int (70)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (149))
+                                                                    (Prims.of_int (158))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (149))
+                                                                    (Prims.of_int (158))
                                                                     (Prims.of_int (60)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -1213,17 +1258,17 @@ let (check_tot_bind :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (153))
+                                                                    (Prims.of_int (162))
                                                                     (Prims.of_int (62))
-                                                                    (Prims.of_int (167))
+                                                                    (Prims.of_int (176))
                                                                     (Prims.of_int (108)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (152))
+                                                                    (Prims.of_int (161))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (194))
+                                                                    (Prims.of_int (203))
                                                                     (Prims.of_int (3)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1231,17 +1276,17 @@ let (check_tot_bind :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (156))
+                                                                    (Prims.of_int (165))
                                                                     (Prims.of_int (15))
-                                                                    (Prims.of_int (156))
+                                                                    (Prims.of_int (165))
                                                                     (Prims.of_int (26)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (157))
+                                                                    (Prims.of_int (166))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (167))
+                                                                    (Prims.of_int (176))
                                                                     (Prims.of_int (108)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -1268,17 +1313,17 @@ let (check_tot_bind :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (161))
+                                                                    (Prims.of_int (170))
                                                                     (Prims.of_int (29))
-                                                                    (Prims.of_int (161))
+                                                                    (Prims.of_int (170))
                                                                     (Prims.of_int (55)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (160))
+                                                                    (Prims.of_int (169))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (167))
+                                                                    (Prims.of_int (176))
                                                                     (Prims.of_int (108)))))
                                                                     (Obj.magic
                                                                     (Pulse_Checker_Pure.compute_tot_term_type
@@ -1301,17 +1346,17 @@ let (check_tot_bind :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (162))
+                                                                    (Prims.of_int (171))
                                                                     (Prims.of_int (34))
-                                                                    (Prims.of_int (162))
+                                                                    (Prims.of_int (171))
                                                                     (Prims.of_int (53)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (161))
+                                                                    (Prims.of_int (170))
                                                                     (Prims.of_int (58))
-                                                                    (Prims.of_int (167))
+                                                                    (Prims.of_int (176))
                                                                     (Prims.of_int (108)))))
                                                                     (Obj.magic
                                                                     (Pulse_Checker_Pure.check_universe
@@ -1333,17 +1378,17 @@ let (check_tot_bind :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (163))
+                                                                    (Prims.of_int (172))
                                                                     (Prims.of_int (40))
-                                                                    (Prims.of_int (163))
+                                                                    (Prims.of_int (172))
                                                                     (Prims.of_int (66)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (162))
+                                                                    (Prims.of_int (171))
                                                                     (Prims.of_int (56))
-                                                                    (Prims.of_int (167))
+                                                                    (Prims.of_int (176))
                                                                     (Prims.of_int (108)))))
                                                                     (Obj.magic
                                                                     (Pulse_Checker_Pure.check_term_at_type
@@ -1392,17 +1437,17 @@ let (check_tot_bind :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (170))
+                                                                    (Prims.of_int (179))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (173))
+                                                                    (Prims.of_int (182))
                                                                     (Prims.of_int (23)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (173))
+                                                                    (Prims.of_int (182))
                                                                     (Prims.of_int (26))
-                                                                    (Prims.of_int (193))
+                                                                    (Prims.of_int (202))
                                                                     (Prims.of_int (45)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -1430,17 +1475,17 @@ let (check_tot_bind :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (177))
+                                                                    (Prims.of_int (186))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (177))
+                                                                    (Prims.of_int (186))
                                                                     (Prims.of_int (29)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (173))
+                                                                    (Prims.of_int (182))
                                                                     (Prims.of_int (26))
-                                                                    (Prims.of_int (193))
+                                                                    (Prims.of_int (202))
                                                                     (Prims.of_int (45)))))
                                                                     (Obj.magic
                                                                     (Pulse_Checker_Pure.check_term
@@ -1463,17 +1508,17 @@ let (check_tot_bind :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (179))
+                                                                    (Prims.of_int (188))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (179))
+                                                                    (Prims.of_int (188))
                                                                     (Prims.of_int (19)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (179))
+                                                                    (Prims.of_int (188))
                                                                     (Prims.of_int (22))
-                                                                    (Prims.of_int (193))
+                                                                    (Prims.of_int (202))
                                                                     (Prims.of_int (45)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -1489,17 +1534,17 @@ let (check_tot_bind :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (181))
+                                                                    (Prims.of_int (190))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (181))
+                                                                    (Prims.of_int (190))
                                                                     (Prims.of_int (35)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (181))
+                                                                    (Prims.of_int (190))
                                                                     (Prims.of_int (40))
-                                                                    (Prims.of_int (193))
+                                                                    (Prims.of_int (202))
                                                                     (Prims.of_int (45)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -1521,17 +1566,17 @@ let (check_tot_bind :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (182))
+                                                                    (Prims.of_int (191))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (182))
+                                                                    (Prims.of_int (191))
                                                                     (Prims.of_int (87)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (182))
+                                                                    (Prims.of_int (191))
                                                                     (Prims.of_int (90))
-                                                                    (Prims.of_int (193))
+                                                                    (Prims.of_int (202))
                                                                     (Prims.of_int (45)))))
                                                                     (Obj.magic
                                                                     (Pulse_Checker_Base.continuation_elaborator_with_let
@@ -1549,17 +1594,17 @@ let (check_tot_bind :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (184))
+                                                                    (Prims.of_int (193))
                                                                     (Prims.of_int (13))
-                                                                    (Prims.of_int (184))
+                                                                    (Prims.of_int (193))
                                                                     (Prims.of_int (31)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (184))
-                                                                    (Prims.of_int (34))
                                                                     (Prims.of_int (193))
+                                                                    (Prims.of_int (34))
+                                                                    (Prims.of_int (202))
                                                                     (Prims.of_int (45)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -1576,17 +1621,17 @@ let (check_tot_bind :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (185))
+                                                                    (Prims.of_int (194))
                                                                     (Prims.of_int (13))
-                                                                    (Prims.of_int (185))
+                                                                    (Prims.of_int (194))
                                                                     (Prims.of_int (41)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (185))
+                                                                    (Prims.of_int (194))
                                                                     (Prims.of_int (44))
-                                                                    (Prims.of_int (193))
+                                                                    (Prims.of_int (202))
                                                                     (Prims.of_int (45)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -1605,17 +1650,17 @@ let (check_tot_bind :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (187))
+                                                                    (Prims.of_int (196))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (187))
+                                                                    (Prims.of_int (196))
                                                                     (Prims.of_int (60)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (187))
+                                                                    (Prims.of_int (196))
                                                                     (Prims.of_int (63))
-                                                                    (Prims.of_int (193))
+                                                                    (Prims.of_int (202))
                                                                     (Prims.of_int (45)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -1632,17 +1677,17 @@ let (check_tot_bind :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (188))
+                                                                    (Prims.of_int (197))
                                                                     (Prims.of_int (11))
-                                                                    (Prims.of_int (191))
+                                                                    (Prims.of_int (200))
                                                                     (Prims.of_int (64)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (191))
+                                                                    (Prims.of_int (200))
                                                                     (Prims.of_int (67))
-                                                                    (Prims.of_int (193))
+                                                                    (Prims.of_int (202))
                                                                     (Prims.of_int (45)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1650,17 +1695,17 @@ let (check_tot_bind :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (189))
+                                                                    (Prims.of_int (198))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (189))
+                                                                    (Prims.of_int (198))
                                                                     (Prims.of_int (48)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (189))
+                                                                    (Prims.of_int (198))
                                                                     (Prims.of_int (51))
-                                                                    (Prims.of_int (191))
+                                                                    (Prims.of_int (200))
                                                                     (Prims.of_int (64)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -1677,17 +1722,17 @@ let (check_tot_bind :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (190))
+                                                                    (Prims.of_int (199))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (190))
+                                                                    (Prims.of_int (199))
                                                                     (Prims.of_int (79)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (191))
+                                                                    (Prims.of_int (200))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (191))
+                                                                    (Prims.of_int (200))
                                                                     (Prims.of_int (64)))))
                                                                     (Obj.magic
                                                                     (check g'
@@ -1716,17 +1761,17 @@ let (check_tot_bind :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (192))
+                                                                    (Prims.of_int (201))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (192))
+                                                                    (Prims.of_int (201))
                                                                     (Prims.of_int (25)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (193))
+                                                                    (Prims.of_int (202))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (193))
+                                                                    (Prims.of_int (202))
                                                                     (Prims.of_int (45)))))
                                                                     (Obj.magic
                                                                     (k

--- a/src/syntax_extension/PulseSyntaxExtension.Desugar.fst
+++ b/src/syntax_extension/PulseSyntaxExtension.Desugar.fst
@@ -140,9 +140,15 @@ let admit_or_return (env:env_t) (s:S.term)
   = let r = s.pos in
     let head, args = U.head_and_args_full s in
     match head.n, args with
-    | S.Tm_fvar fv, [_] -> (
+    | S.Tm_fvar fv, [e, _] -> (
       if S.fv_eq_lid fv admit_lid
-      then STTerm (SW.tm_admit r)
+      then begin
+        let post =
+          match S.(e.n) with
+          | S.Tm_constant (FStar.Const.Const_unit) -> None
+          | _ -> Some (as_term e) in
+        STTerm (SW.tm_admit post r)
+      end
       else if S.fv_eq_lid fv unreachable_lid
       then STTerm (SW.tm_unreachable r) 
       else Return s

--- a/src/syntax_extension/PulseSyntaxExtension.SyntaxWrapper.fsti
+++ b/src/syntax_extension/PulseSyntaxExtension.SyntaxWrapper.fsti
@@ -102,7 +102,7 @@ val tm_protect (s:st_term) : st_term
 val tm_par (p1:term) (p2:term) (q1:term) (q2:term) (b1:st_term) (b2:st_term) (_:range) : st_term
 val tm_rewrite (p1:term) (p2:term) (_:range) : st_term
 val tm_rename (pairs:list (term & term)) (_:range) : st_term
-val tm_admit (_:range) : st_term
+val tm_admit (post:option term) (_:range) : st_term
 val tm_unreachable (_:range) : st_term
 val tm_proof_hint_with_binders (_:hint_type) (_:list binder) (body:st_term) (_:range) : st_term
 val tm_with_inv (iname:term) (body:st_term) (returns_:option (binder & term)) (_:range) : st_term


### PR DESCRIPTION
For example:

```
fn test ()
  requires emp
  ensures p ** q
{
  admit p
}
```
will fail with a `cannot prove q` error.

While `admit ()` consumes the pre from the context, takes the post hint from the context, and drops the continuation, `admit p` has `emp` pre, only provides `p` as post, has the return type `unit`, and does not drop the continuation.

Some examples: https://github.com/FStarLang/steel/pull/158/files#diff-b1b081beaa2d28ad436aceaca4108b35ab0b1adeb2c0d6f2c57961184fe73b72.

May be `admit p` should be `assume p` in the syntax (and in the checker we use `Tm_Admit` itself as in the PR).