### PR TITLE
FractionalPermission: Fixes for new F* real interface

### DIFF
--- a/lib/steel/Steel.FractionalAnchoredPreorder.fst
+++ b/lib/steel/Steel.FractionalAnchoredPreorder.fst
@@ -135,18 +135,14 @@ type knowledge (#v:Type) (#p:preorder v) (anchors:anchor_rel p) =
   | Owns     : avalue anchors -> knowledge anchors
   | Nothing  : knowledge anchors
 
-let b2p (b:bool)
-  : prop
-  = b == true
-
 /// Fractional permissions are composable when their sum <= 1.0
 let perm_opt_composable (p0 p1:option perm)
   : prop
   = match p0, p1 with
     | None, None -> True
     | Some p, None
-    | None, Some p -> b2p (p `lesser_equal_perm` full_perm)
-    | Some p0, Some p1 -> b2p (sum_perm p0 p1 `lesser_equal_perm` full_perm)
+    | None, Some p -> p `lesser_equal_perm` full_perm
+    | Some p0, Some p1 -> sum_perm p0 p1 `lesser_equal_perm` full_perm
 
 /// Composing them sums the permissions
 let compose_perm_opt (p0 p1:option perm) =

--- a/lib/steel/Steel.FractionalPermission.fst
+++ b/lib/steel/Steel.FractionalPermission.fst
@@ -29,8 +29,8 @@ noeq type perm : Type0 =
   | MkPerm: v:real{ v >. zero } -> perm
 
 /// A reference is only safely writeable if we have full permission
-let writeable (p: perm) : GTot bool =
-  MkPerm?.v p = one
+let writeable (p: perm) : prop =
+  MkPerm?.v p == one
 
 /// Helper around splitting a permission in half
 let half_perm (p: perm) : Tot perm =
@@ -41,10 +41,10 @@ let sum_perm (p1 p2: perm) : Tot perm =
   MkPerm (MkPerm?.v p1 +.  MkPerm?.v p2)
 
 /// Helper to compare two permissions
-let lesser_equal_perm (p1 p2:perm) : GTot bool =
+let lesser_equal_perm (p1 p2:perm) : prop =
   MkPerm?.v p1 <=.  MkPerm?.v p2
 
-let lesser_perm (p1 p2:perm) : GTot bool =
+let lesser_perm (p1 p2:perm) : prop =
   MkPerm?.v p1 <.  MkPerm?.v p2
 
 /// Wrapper around the full permission value

--- a/lib/steel/Steel.HigherReference.fst
+++ b/lib/steel/Steel.HigherReference.fst
@@ -31,7 +31,7 @@ module Mem = Steel.Memory
 let ref a = Mem.ref (fractional a) pcm_frac
 let null #a = Mem.null #(fractional a) #pcm_frac
 let is_null #a r = Mem.is_null #(fractional a) #pcm_frac r
-let perm_ok p : prop = (p.v <=. one == true) /\ True
+let perm_ok p : prop = p.v <=. one
 let pts_to_raw_sl (#a:Type) (r:ref a) (p:perm) (v:erased a) : slprop =
   Mem.pts_to r (Some (Ghost.reveal v, p))
 let pts_to_raw (#a:Type) (r:ref a) (p:perm) (v:erased a) : vprop =


### PR DESCRIPTION
See https://github.com/FStarLang/FStar/pull/3242

---

Hi! We're planning to change the interface of `FStar.Real` to only provide a logical axiomatization of real numbers, instead of the current seemingly-computable interface which does not make a lot of sense (or will not when we extend `FStar.Real` to make it more interesting).

This requires a few patches to make Steel work, hence this PR. Wondering if this seems sensible to you and there are any serious breakages outside this repo.

Thanks!