### PR TITLE
Steel.Effect.Common: update after changes to TacticFailure exception

### DIFF
--- a/lib/steel/Steel.Effect.Common.fsti
+++ b/lib/steel/Steel.Effect.Common.fsti
@@ -1873,7 +1873,7 @@ let canon_l_r (use_smt:bool)
     try
       let res = equivalent_lists use_smt (flatten r1_raw) (flatten r2_raw) am in
       raise (Result res) with
-    | TacticFailure m -> fail_doc m
+    | TacticFailure (m, rng_opt) -> fail_doc_at m rng_opt
     | Result res -> res
     | _ -> fail "uncaught exception in equivalent_lists"
   in
@@ -2063,9 +2063,9 @@ let canon_l_r (use_smt:bool)
         unify_pr_with_true pr; // MUST be done AFTER identity_left/reflexivity, which can unify other uvars
         apply_lemma (`solve_implies_true)
       with
-      | TacticFailure msg ->
+      | TacticFailure (msg, rng_opt) ->
         let open FStar.Stubs.Pprint in
-        fail_doc ([doc_of_string "Cannot unify pr with true"] @ msg)
+        fail_doc_at ([doc_of_string "Cannot unify pr with true"] @ msg) rng_opt
       | e -> raise e
     )
   | l ->
@@ -2568,11 +2568,11 @@ let rec solve_can_be_split_forall_dep (args:list argv) : Tac bool =
        with
        | Postpone msg ->
          false
-       | TacticFailure msg ->
+       | TacticFailure (msg, rng_opt) ->
          let opened = try_open_existentials_forall_dep () in
          if opened
          then solve_can_be_split_forall_dep args // we only need args for their number of uvars, which has not changed
-         else fail_doc msg
+         else fail_doc_at msg rng_opt
        | _ -> fail "Unexpected exception in framing tactic"
       ) else false
 

--- a/src/ocaml/plugin/generated/Steel_Effect_Common.ml
+++ b/src/ocaml/plugin/generated/Steel_Effect_Common.ml
@@ -5888,10 +5888,13 @@ let (canon_l_r :
                                                                     with
                                                                     | 
                                                                     FStar_Tactics_Common.TacticFailure
-                                                                    m1 ->
+                                                                    (m1,
+                                                                    rng_opt)
+                                                                    ->
                                                                     Obj.magic
-                                                                    (FStar_Tactics_V2_Derived.fail_doc
-                                                                    m1)
+                                                                    (FStar_Tactics_V2_Derived.fail_doc_at
+                                                                    m1
+                                                                    rng_opt)
                                                                     | 
                                                                     Result
                                                                     res ->
@@ -7624,14 +7627,17 @@ let (canon_l_r :
                                                                     with
                                                                     | 
                                                                     FStar_Tactics_Common.TacticFailure
-                                                                    msg ->
+                                                                    (msg,
+                                                                    rng_opt)
+                                                                    ->
                                                                     Obj.magic
-                                                                    (FStar_Tactics_V2_Derived.fail_doc
+                                                                    (FStar_Tactics_V2_Derived.fail_doc_at
                                                                     (FStar_List_Tot_Base.append
                                                                     [
                                                                     FStar_Pprint.doc_of_string
                                                                     "Cannot unify pr with true"]
-                                                                    msg))
+                                                                    msg)
+                                                                    rng_opt)
                                                                     | 
                                                                     e ->
                                                                     Obj.magic
@@ -12146,7 +12152,9 @@ let rec (solve_can_be_split_forall_dep :
                                                                     uu___6 ->
                                                                     false)))
                                                                | FStar_Tactics_Common.TacticFailure
-                                                                   msg ->
+                                                                   (msg,
+                                                                    rng_opt)
+                                                                   ->
                                                                    Obj.magic
                                                                     (Obj.repr
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -12165,7 +12173,7 @@ let rec (solve_can_be_split_forall_dep :
                                                                     (Prims.of_int (2573))
                                                                     (Prims.of_int (9))
                                                                     (Prims.of_int (2575))
-                                                                    (Prims.of_int (26)))))
+                                                                    (Prims.of_int (37)))))
                                                                     (Obj.magic
                                                                     (try_open_existentials_forall_dep
                                                                     ()))
@@ -12182,8 +12190,9 @@ let rec (solve_can_be_split_forall_dep :
                                                                     else
                                                                     Obj.magic
                                                                     (Obj.repr
-                                                                    (FStar_Tactics_V2_Derived.fail_doc
-                                                                    msg)))
+                                                                    (FStar_Tactics_V2_Derived.fail_doc_at
+                                                                    msg
+                                                                    rng_opt)))
                                                                     uu___6)))
                                                                | uu___6 ->
                                                                    Obj.magic


### PR DESCRIPTION
This should also preserve error ranges better.

--

This fixes the build after https://github.com/FStarLang/FStar/pull/3370. Sorry for not noticing earlier. It also makes re-raised exceptions preserve the original range, so I wonder if it improves error locations noticeably in Steel code.