### PR TITLE
fixing missing packages in opam CI

### DIFF
--- a/src/ci/opam.Dockerfile
+++ b/src/ci/opam.Dockerfile
@@ -9,7 +9,7 @@ ADD --chown=opam:opam ./ steel/
 
 # FIXME: the `opam depext` command should be unnecessary with opam 2.1
 RUN sudo apt-get update && \
-    sudo apt-get install --yes --no-install-recommends jq && \
+    sudo apt-get install --yes --no-install-recommends jq pkg-config libgmp-dev && \
     opam depext conf-gmp z3.4.8.5-1 conf-m4 && \
     git clone --branch $(jq -c -r '.RepoVersions.fstar' steel/src/ci/config.json || echo master) https://github.com/FStarLang/FStar FStar && \
     opam install -j $opamthreads -v -v -v FStar/fstar.opam && \


### PR DESCRIPTION
I think this should fix the OPAM CI, but it fails with something seemingly unrelated:
```
2024-08-26T00:09:42.6558328Z /home/opam/steel_tools/karamel/krmllib/dist/minimal/FStar_UInt128_Verified.h:10:10: fatal error: WindowsWorkaroundSigh.h: No such file or directory
2024-08-26T00:09:42.6560682Z    10 | #include "WindowsWorkaroundSigh.h"
2024-08-26T00:09:42.6561608Z       |          ^~~~~~~~~~~~~~~~~~~~~~~~~
```