### PR TITLE
mk: Fix --already_cached '*', which fails in Windows

### DIFF
--- a/mk/plugin.mk
+++ b/mk/plugin.mk
@@ -43,7 +43,7 @@ FSTAR = $(FSTAR_EXE) $(SIL) $(FSTAR_OPTIONS)
 %$(EXTENSION): FF=$(notdir $(subst $(EXTENSION),,$@))
 %$(EXTENSION):
 	$(call msg, "CHECK", $(FF))
-	$(FSTAR) --already_cached '*' $<
+	$(FSTAR) --already_cached ',*' $<
 	@touch -c $@  ## SHOULD NOT BE NEEDED
 
 %.ml: FF=$(notdir $(subst $(EXTENSION),,$<))
@@ -54,7 +54,7 @@ FSTAR = $(FSTAR_EXE) $(SIL) $(FSTAR_OPTIONS)
 # is relying on F* looking in its include path.
 %.ml:
 	$(call msg, "EXTRACT", $(LBL))
-	$(FSTAR) $(FF) --already_cached '*' --codegen $(CODEGEN) --extract_module $(MM)
+	$(FSTAR) $(FF) --already_cached ',*' --codegen $(CODEGEN) --extract_module $(MM)
 	@touch -c $@  ## SHOULD NOT BE NEEDED
 
 $(CACHE_DIR)/.depend$(TAG):


### PR DESCRIPTION
See https://github.com/FStarLang/FStar/pull/3640