### PR TITLE
Fixing extraction

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,6 @@ endif
 export STEEL_HOME := $(CURDIR)
 
 include $(STEEL_HOME)/mk/common.mk
-.DEFAULT_GOAL := all
 
 FSTAR_EXE ?= fstar.exe
 

--- a/include/steel/steel_full.h
+++ b/include/steel/steel_full.h
@@ -1,0 +1,10 @@
+/* Copyright (c) INRIA and Microsoft Corporation. All rights reserved.
+   Licensed under the Apache 2.0 License. */
+
+#ifndef __KRML_STEEL_FULL_H
+#define __KRML_STEEL_FULL_H
+
+#include "steel_base.h"
+#include "Steel_SpinLock.h"
+
+#endif

--- a/mk/boot.mk
+++ b/mk/boot.mk
@@ -1,6 +1,7 @@
+default: ocaml
+
 include $(STEEL_HOME)/mk/common.mk
 
-.DEFAULT_GOAL := ocaml
 $(call need_dir_mk, CACHE_DIR, directory for checked files)
 $(call need_dir_mk, OUTPUT_DIR, directory for extracted OCaml files)
 $(call need, CODEGEN, backend (OCaml / Plugin))

--- a/mk/common.mk
+++ b/mk/common.mk
@@ -44,11 +44,6 @@ endif
 # In other words, make `make` less insane.
 .DELETE_ON_ERROR:
 
-.DEFAULT_GOAL:=__undef
-.PHONY: __undef
-__undef:
-	$(error "This makefile does not have a default goal")
-
 # Check that a variable is defined. If not, abort with an (optional) error message.
 need =												\
   $(if $(value $(strip $1)),,									\

--- a/share/steel/Makefile.include
+++ b/share/steel/Makefile.include
@@ -2,7 +2,6 @@ ifeq (,$(STEEL_HOME))
 	$(error STEEL_HOME should be defined in the enclosing Makefile as the prefix directory where Steel was installed, or the root directory of its source repository)
 endif
 include $(STEEL_HOME)/mk/common.mk
-.DEFAULT_GOAL := verify
 
 FSTAR_EXE ?= fstar.exe
 

--- a/share/steel/Makefile.include
+++ b/share/steel/Makefile.include
@@ -11,6 +11,7 @@ ifeq ($(OS),Windows_NT)
 else
   OCAMLPATH := $(STEEL_HOME)/lib:$(OCAMLPATH)
 endif
+export OCAMLPATH
 
 FSTAR_FILES += $(filter-out $(EXCLUDE_FILES),$(wildcard *.fst *.fsti))
 ADDITIONAL_INCLUDES ?= 

--- a/share/steel/examples/steel/OWGCounter/OWGCounterTest.ml
+++ b/share/steel/examples/steel/OWGCounter/OWGCounterTest.ml
@@ -8,4 +8,4 @@ let main =
   let r = Steel_Reference.alloc_pt (Z.of_int 0) in
   OWGCounter.incr_main () r;
   let v = Steel_Reference.read_pt () () r in
-  FStar_IO.print_string (Prims.string_of_int v)
+  FStar_IO.print_string (Prims.string_of_int v ^ "\n");

--- a/share/steel/tests/krml/Makefile
+++ b/share/steel/tests/krml/Makefile
@@ -110,8 +110,8 @@ $(OUTPUT_DIR)/%.exe: $(ALL_KRML_FILES) $(KRML_BIN)
 
 # Various flags to be passed to some targets...
 $(OUTPUT_DIR)/SteelArrayArith.exe: EXTRA=-static-header Steel.ArrayArith -no-prefix Steel.ArrayArith
-$(OUTPUT_DIR)/SteelLock.exe: EXTRA=-bundle Steel.* -add-include 'Steel:"steel_types.h"'
 $(OUTPUT_DIR)/SizeT.exe: EXTRA=-ccopt -std=c2x
+$(OUTPUT_DIR)/SteelLock.exe: EXTRA=-bundle Steel.* -add-include '"steel_full.h"' # uses spinlock
 
 # A pseudo-target for WASM compilation that does not match any specific file.
 # All WASM targets get the -wasm flag; some specific targets may override

--- a/src/extraction/ExtractSteel.Krml.fst
+++ b/src/extraction/ExtractSteel.Krml.fst
@@ -1,22 +1,15 @@
 module ExtractSteel.Krml
 friend FStarC.Extraction.Krml
 
-(* IMPORTANT: these `open` directives come from FStarC.Extraction.Krml.
-   Without them, spurious dependencies on F* ulib will be introduced *)
 open FStarC
 open FStarC.Effect
-open FStarC.List
-open FStarC
-open FStarC.Util
 open FStarC.Extraction
 open FStarC.Extraction.ML
 open FStarC.Extraction.ML.Syntax
 open FStarC.Const
-open FStarC.BaseTypes
+open FStarC.Extraction.Krml
 
 module BU = FStarC.Util
-
-open FStarC.Extraction.Krml
 
 let steel_translate_type_without_decay : translate_type_without_decay_t = fun env t ->
   match t with

--- a/src/extraction/ExtractSteel.Krml.fst
+++ b/src/extraction/ExtractSteel.Krml.fst
@@ -1,4 +1,4 @@
-module ExtractSteel
+module ExtractSteel.Krml
 friend FStarC.Extraction.Krml
 
 (* IMPORTANT: these `open` directives come from FStarC.Extraction.Krml.

--- a/src/extraction/ExtractSteel.Krml.fsti
+++ b/src/extraction/ExtractSteel.Krml.fsti
@@ -1,0 +1,5 @@
+module ExtractSteel.Krml
+
+(* This file defines extraction for SteelC, in the ML -> Krml pass. *)
+
+(* The interface is necessary due to friending. *)

--- a/src/extraction/ExtractSteel.ML.fst
+++ b/src/extraction/ExtractSteel.ML.fst
@@ -1,0 +1,69 @@
+module ExtractSteel.ML
+
+open FStarC
+open FStarC.Effect
+open FStarC.Extraction.ML.Syntax
+open FStarC.Syntax.Syntax
+open FStarC.Extraction.ML.UEnv
+open FStarC.Extraction.ML.Term
+
+open FStarC.Class.Show
+open FStarC.Syntax.Print {} // instances
+
+module BU = FStarC.Util
+module SS = FStarC.Syntax.Subst
+module S = FStarC.Syntax.Syntax
+module U = FStarC.Syntax.Util
+module Ident = FStarC.Ident
+
+let dbg = Debug.get_toggle "steel_extraction"
+
+let steel_memory_inv_lid = Ident.lid_of_str "Steel.Memory.inv"
+
+let steel_new_invariant_lid = Ident.lid_of_str "Steel.Effect.Atomic.new_invariant"
+let steel_st_new_invariant_lid = Ident.lid_of_str "Steel.ST.Util.new_invariant"
+
+let steel_with_invariant_g_lid = Ident.lid_of_str "Steel.Effect.Atomic.with_invariant_g"
+let steel_st_with_invariant_g_lid = Ident.lid_of_str "Steel.ST.Util.with_invariant_g"
+
+let steel_with_invariant_lid = Ident.lid_of_str "Steel.Effect.Atomic.with_invariant"
+let steel_st_with_invariant_lid = Ident.lid_of_str "Steel.ST.Util.with_invariant"
+
+let hua (t:term) : option (S.fv & list S.universe & S.args) =
+  let t = U.unmeta t in
+  let hd, args = U.head_and_args_full t in
+  let hd = U.unmeta hd in
+  match (SS.compress hd).n with
+  | Tm_fvar fv -> Some (fv, [], args)
+  | Tm_uinst ({ n = Tm_fvar fv }, us) -> Some (fv, us, args)
+  | _ -> None
+
+let tr_expr (g:uenv) (t:term) : mlexpr & e_tag & mlty =
+  let cb = FStarC.Extraction.ML.Term.term_as_mlexpr in
+  let hua = hua t in
+  if None? hua then
+    raise NotSupportedByExtension;
+  let Some (fv, us, args) = hua in
+  if !dbg then
+    BU.print1 "ExtractSteel.ML.tr_expr (%s)\n" (show hua);
+  match fv, us, args with
+  | fv, _, [_a; _fp; _fp'; _o; _p; _i; _body]
+      when S.fv_eq_lid fv steel_with_invariant_g_lid
+        || S.fv_eq_lid fv steel_st_with_invariant_g_lid ->
+      ml_unit, E_PURE, MLTY_Erased
+
+  | fv, _, [_a; _fp; _fp'; _o; _obs; _p; _i; (body, None)]
+      when S.fv_eq_lid fv steel_with_invariant_lid
+        || S.fv_eq_lid fv steel_st_with_invariant_lid ->
+    let tm = S.mk_Tm_app body [as_arg unit_const] body.pos in
+    cb g tm
+
+  | fv, _, [_o; _p]
+      when S.fv_eq_lid fv steel_new_invariant_lid
+        || S.fv_eq_lid fv steel_st_new_invariant_lid ->
+    ml_unit, E_PURE, ml_unit_ty
+
+  | _ ->
+    raise NotSupportedByExtension
+
+let _ = register_pre_translate tr_expr

--- a/src/extraction/ExtractSteel.ML.fsti
+++ b/src/extraction/ExtractSteel.ML.fsti
@@ -1,0 +1,5 @@
+module ExtractSteel.ML
+
+(* This file defines extraction for Steel, in the F* -> ML pass. *)
+
+(* The interface is necessary due to friending. *)

--- a/src/extraction/ExtractSteel.fsti
+++ b/src/extraction/ExtractSteel.fsti
@@ -1,3 +1,0 @@
-module ExtractSteel
-
-// this fsti is necessary because we are `friend`ing FStarC.Extraction.Krml

--- a/src/extraction/ExtractSteelC.Krml.fst
+++ b/src/extraction/ExtractSteelC.Krml.fst
@@ -1,4 +1,4 @@
-module ExtractSteelC
+module ExtractSteelC.Krml
 
 friend FStarC.Extraction.Krml
 open FStarC

--- a/src/extraction/ExtractSteelC.Krml.fst
+++ b/src/extraction/ExtractSteelC.Krml.fst
@@ -1,15 +1,13 @@
 module ExtractSteelC.Krml
-
 friend FStarC.Extraction.Krml
+
 open FStarC
 open FStarC.Effect
-open FStarC.List
 open FStarC.Util
 open FStarC.Extraction
 open FStarC.Extraction.ML
 open FStarC.Extraction.ML.Syntax
-open FStarC.Const
-open FStarC.BaseTypes
+open FStar.Char
 open FStarC.Extraction.Krml
 module BU = FStarC.Util
 

--- a/src/extraction/ExtractSteelC.Krml.fsti
+++ b/src/extraction/ExtractSteelC.Krml.fsti
@@ -1,0 +1,5 @@
+module ExtractSteelC.Krml
+
+(* This file defines extraction for SteelC, in the ML -> Krml pass. *)
+
+(* The interface is necessary due to friending. *)

--- a/src/extraction/ExtractSteelC.fsti
+++ b/src/extraction/ExtractSteelC.fsti
@@ -1,2 +1,0 @@
-module ExtractSteelC
-(* this interface is necessary because ExtractSteelC `friend`s FStarC.Extraction.Krml *)

--- a/src/extraction/Extraction.fst.config.json
+++ b/src/extraction/Extraction.fst.config.json
@@ -4,8 +4,7 @@
     "--lax",
     "--MLish",
     "--with_fstarc",
-    "--MLish_effect", "FStarC.Effect",
-    "--cache_dir"
+    "--MLish_effect", "FStarC.Effect"
   ],
   "include_dirs": [
   ]

--- a/src/extraction/Makefile
+++ b/src/extraction/Makefile
@@ -7,7 +7,7 @@ FSTAR_EXE ?= fstar.exe
 OUTPUT_DIRECTORY = $(CURDIR)/../ocaml/plugin/generated
 FSTAR_C=$(RUNLIM) $(FSTAR_EXE) $(SIL) $(FSTAR_BOOT_OPTIONS)
 
-EXTRACT_FILES=ExtractSteel_Krml.ml ExtractSteelC_Krml.ml
+EXTRACT_FILES := ExtractSteel_ML.ml ExtractSteel_Krml.ml ExtractSteelC_Krml.ml
 extract: $(addprefix $(OUTPUT_DIRECTORY)/,$(EXTRACT_FILES))
 
 $(OUTPUT_DIRECTORY)/%.ml: %.fst

--- a/src/extraction/Makefile
+++ b/src/extraction/Makefile
@@ -7,7 +7,7 @@ FSTAR_EXE ?= fstar.exe
 OUTPUT_DIRECTORY = $(CURDIR)/../ocaml/plugin/generated
 FSTAR_C=$(RUNLIM) $(FSTAR_EXE) $(SIL) $(FSTAR_BOOT_OPTIONS)
 
-EXTRACT_FILES=ExtractSteel.ml ExtractSteelC.ml
+EXTRACT_FILES=ExtractSteel_Krml.ml ExtractSteelC_Krml.ml
 extract: $(addprefix $(OUTPUT_DIRECTORY)/,$(EXTRACT_FILES))
 
 $(OUTPUT_DIRECTORY)/%.ml: %.fst

--- a/src/proofs/steelc/Makefile
+++ b/src/proofs/steelc/Makefile
@@ -3,7 +3,6 @@ all: steelc
 # assuming src/proofs/steelc
 STEEL_HOME=../../..
 include $(STEEL_HOME)/mk/common.mk
-.DEFAULT_GOAL := all
 
 FSTAR_EXE ?= fstar.exe
 


### PR DESCRIPTION
Follow up to #199. The F*->ML rules taking care of erasing invariants were mistakenly dropped by FStarLang/FStar#3557. This PR adds them back to the Steel plugin, in a standalone file. There is also a bit of cleanup for the ML->Krml extraction rules, which are now in better-named files.

Many thanks to @cmovcc for the report and investigation here.