### PR TITLE
Revert "Steel.Effect.Atomic: disambiguate type in equality"

### DIFF
--- a/lib/steel/Steel.Effect.Atomic.fsti
+++ b/lib/steel/Steel.Effect.Atomic.fsti
@@ -763,7 +763,7 @@ val intro_vrefine (#opened:inames)
   (v: vprop) (p: (normal (t_of v) -> Tot prop))
 : SteelGhost unit opened v (fun _ -> vrefine v p)
   (requires fun h -> p (h v))
-  (ensures fun h _ h' -> (h' (vrefine v p) <: t_of v) == h v)
+  (ensures fun h _ h' -> h' (vrefine v p) == h v)
 
 /// We can transform back vprop [v] refined with predicate [p] to the underlying [v],
 /// where [p] holds on the selector of [v]


### PR DESCRIPTION
This is not actually needed. It did fail while I was working on F* PR https://github.com/FStarLang/FStar/pull/3841, but after a few changes, the original code behaves as before.

The equality is indeed between two different types, but they are refinements of the same base type. The unifier should just join the refinements.

This reverts commit fc35ec46065f46aa701145a2a312dc2a76002bf8.