### PR TITLE
Bump rlimit and tweak fuel/ifuel

### DIFF
--- a/lib/steel/Steel.Heap.fst
+++ b/lib/steel/Steel.Heap.fst
@@ -508,6 +508,7 @@ let pts_to_compatible_fwd (#a:Type u#a)
               pts_to_cell pcm v1 c1 /\
               c == join_cells c0 c1)
 
+#push-options "--z3rlimit_factor 12"
 let pts_to_compatible_bk (#a:Type u#a)
                           (#pcm:_)
                           (x:ref a pcm)
@@ -561,6 +562,7 @@ let pts_to_compatible_bk (#a:Type u#a)
         assert (disjoint m0 m1) //fire the existential
     in
     ()
+#pop-options
 
 let pts_to_compatible (#a:Type u#a)
                       (#pcm:_)

--- a/lib/steel/Steel.ST.GenArraySwap.fst
+++ b/lib/steel/Steel.ST.GenArraySwap.fst
@@ -4,6 +4,8 @@ open Steel.ST.GenElim
 module Prf = Steel.ST.GenArraySwap.Proof
 module R = Steel.ST.Reference
 
+#push-options "--fuel 1 --ifuel 1"
+
 let gcd_inv_prop
   (n0: nat)
   (l0: nat)
@@ -394,7 +396,8 @@ let impl_jump
   else idx `SZ.add` l
 
 #restart-solver
-#push-options "--z3rlimit 24 --split_queries always" // This proof is really brittle.
+
+#push-options "--z3rlimit 100 --split_queries always" // This proof is really brittle.
 inline_for_extraction
 let array_swap_outer_body
   (#t: Type)
@@ -459,8 +462,10 @@ let array_swap_outer_body
     intro_array_swap_outer_invariant pts_to n l bz s0 pi (i' `SZ.lt` d) _ _;
     noop ()
   ))
+#pop-options
 
 #restart-solver
+
 inline_for_extraction
 let array_swap_aux
   (#t: Type)


### PR DESCRIPTION
These two proofs otherwise fail with Z3 4.13.3 locally (x86_64).
Interestingly, way fewer proofs fail since context pruning has been enabled: more proofs did fail back in December when I first tried to upgrade this repo to Z3 4.13.3.