### PR TITLE
Remove uses of term_eq_old and make sure to use new lax_term_eq

### DIFF
--- a/lib/steel/Steel.Effect.Common.fsti
+++ b/lib/steel/Steel.Effect.Common.fsti
@@ -798,7 +798,7 @@ let rec get_candidates (t:term) (l:list term) : Tac (list term) =
   | [] -> []
   | hd::tl ->
       let n, _ = collect_app hd in
-      if term_eq_old n name then (
+      if lax_term_eq n name then (
         hd::(get_candidates t tl)
       ) else get_candidates t tl
 
@@ -1603,12 +1603,12 @@ let equivalent_sorted (#a:Type) (eq:CE.equiv a) (m:CE.cm a eq) (am:amap a) (l1 l
 #pop-options
 
 /// Finds the position of first occurrence of x in xs.
-/// This is now specialized to terms and their funny term_eq_old.
+/// This is now specialized to terms and their funny lax_term_eq.
 let rec where_aux (n:nat) (x:term) (xs:list term) :
     Tac (option nat) (decreases xs) =
   match xs with
   | [] -> None
-  | x'::xs' -> if term_eq_old x x' then Some n else where_aux (n+1) x xs'
+  | x'::xs' -> if lax_term_eq x x' then Some n else where_aux (n+1) x xs'
 let where = where_aux 0
 
 let fatom (t:term) (ts:list term) (am:amap term) : Tac (exp * list term * amap term) =
@@ -1628,13 +1628,13 @@ let rec reification_aux (ts:list term) (am:amap term)
   let hd, tl = collect_app_ref t in
   match inspect_unascribe hd, List.Tot.Base.list_unref tl with
   | Tv_FVar fv, [(t1, Q_Explicit) ; (t2, Q_Explicit)] ->
-    if term_eq_old (pack (Tv_FVar fv)) mult
+    if lax_term_eq (pack (Tv_FVar fv)) mult
     then (let (e1, ts, am) = reification_aux ts am mult unit t1 in
           let (e2, ts, am) = reification_aux ts am mult unit t2 in
           (Mult e1 e2, ts, am))
     else fatom t ts am
   | _, _ ->
-    if term_eq_old t unit
+    if lax_term_eq t unit
     then (Unit, ts, am)
     else fatom t ts am
 
@@ -2200,7 +2200,7 @@ let rec term_mem (te: term) (l: list term) : Tac bool =
   match l with
   | [] -> false
   | t' :: q ->
-    if te `term_eq_old` t' then true else term_mem te q
+    if te `lax_term_eq` t' then true else term_mem te q
 
 let rec lookup_by_term_attr' (attr: term) (e: env) (found: list fv) (l: list fv) : Tac (list fv)
 =
@@ -2778,7 +2778,7 @@ let rec term_dict_assoc
   | [] -> []
   | (k, v) :: q ->
     let q' = term_dict_assoc key q in
-    if k `term_eq_old` key
+    if k `lax_term_eq` key
     then (v :: q')
     else q'
 

--- a/lib/steel/Steel.ST.GenElim.Base.fsti
+++ b/lib/steel/Steel.ST.GenElim.Base.fsti
@@ -1,7 +1,7 @@
 module Steel.ST.GenElim.Base
 include Steel.ST.Util
 
-module T = FStar.Tactics
+module T = FStar.Tactics.V2
 
 let is_fvar     = Reflection.is_fvar
 let is_any_fvar = Reflection.is_any_fvar
@@ -307,7 +307,7 @@ let rec term_has_head
   (head: T.term)
 : T.Tac bool
 = let (hd, tl) = T.collect_app t in
-  if hd `T.term_eq_old` head
+  if hd `T.lax_term_eq` head
   then true
   else if is_star_or_vstar hd
   then
@@ -501,7 +501,7 @@ let rec solve_gen_elim_nondep' (fuel: nat) (rev_types_and_binders: list (T.term 
         try
           let env = cur_env () in
           let ty = tc env type_list in
-          ty `term_eq_old` (`(list Type0))
+          ty `lax_term_eq` (`(list Type0))
         with _ -> false
       in
       if not type_list_typechecks
@@ -573,7 +573,7 @@ let solve_gen_elim_prop
     then T.fail "not a gen_elim_prop goal";
     begin match List.Tot.filter (fun (_, x) -> T.Q_Explicit? x) tl1 with
     | [(enable_nondep_opt_tm, _); (p, _); (a, _); (q, _); (post, _)] ->
-      let enable_nondep_opt = enable_nondep_opt_tm `T.term_eq_old` (`true) in
+      let enable_nondep_opt = enable_nondep_opt_tm `T.lax_term_eq` (`true) in
       let i' = solve_gen_elim p in
       let norm () = T.norm [delta_attr [(`%gen_elim_reduce)]; zeta; iota] in
       begin match solve_gen_elim_nondep0 enable_nondep_opt i' with
@@ -624,7 +624,7 @@ let solve_gen_elim_prop_placeholder
       let post_is_uvar = T.Tv_Uvar? (T.inspect post) in
       if not (a_is_uvar && q_is_uvar && post_is_uvar)
       then T.fail "gen_elim_prop_placeholder is already solved";
-      let enable_nondep_opt = enable_nondep_opt_tm `T.term_eq_old` (`true) in
+      let enable_nondep_opt = enable_nondep_opt_tm `T.lax_term_eq` (`true) in
       let i' = solve_gen_elim p in
       let j' = solve_gen_elim_nondep enable_nondep_opt i' in
       let norm_term = T.norm_term [delta_attr [(`%gen_elim_reduce)]; zeta; iota] in

--- a/lib/steel/Steel.ST.GenElim1.Base.fsti
+++ b/lib/steel/Steel.ST.GenElim1.Base.fsti
@@ -1,7 +1,8 @@
 module Steel.ST.GenElim1.Base
 include Steel.ST.Util
 
-module T = FStar.Tactics
+module T = FStar.Tactics.V2
+module R = FStar.Reflection.V2
 
 let is_fvar     = Reflection.is_fvar
 let is_any_fvar = Reflection.is_any_fvar
@@ -339,7 +340,7 @@ let rec term_has_head
   (head: T.term)
 : T.Tac bool
 = let (hd, tl) = T.collect_app t in
-  if hd `T.term_eq_old` head
+  if hd `T.lax_term_eq` head
   then true
   else if is_star_or_vstar hd
   then
@@ -399,7 +400,7 @@ let rec solve_gen_elim
         if hd `is_fvar` (`%exists_)
         then
           let universe = match T.inspect_ln_unascribe hd with
-          | T.Tv_UInst _ (u :: _) -> get_universe u
+          | R.Tv_UInst _ (u :: _) -> get_universe u
           | _ -> T.fail "ill-formed exists_: no universe found"
           in
           let (ty, body) =
@@ -560,7 +561,7 @@ let rec solve_gen_elim_nondep' (fuel: nat) (rev_types_and_binders: list (T.term 
         try
           let env = cur_env () in
           let ty = tc env type_list in
-          ty `term_eq_old` (`(list (Type u#1)))
+          ty `lax_term_eq` (`(list (Type u#1)))
         with _ -> false
       in
       if not type_list_typechecks
@@ -639,7 +640,7 @@ let solve_gen_elim_prop
     then T.fail "not a gen_elim_prop goal";
     begin match List.Tot.filter (fun (_, x) -> T.Q_Explicit? x) tl1 with
     | [(enable_nondep_opt_tm, _); (p, _); (a, _); (q, _); (post, _)] ->
-      let enable_nondep_opt = enable_nondep_opt_tm `T.term_eq_old` (`true) in
+      let enable_nondep_opt = enable_nondep_opt_tm `T.lax_term_eq` (`true) in
       let i' = solve_gen_elim p in
       let norm () = T.norm [delta_attr [(`%gen_elim_reduce)]; zeta; iota] in
       begin match solve_gen_elim_nondep0 enable_nondep_opt i' with
@@ -690,7 +691,7 @@ let solve_gen_elim_prop_placeholder
       let post_is_uvar = T.Tv_Uvar? (T.inspect post) in
       if not (a_is_uvar && q_is_uvar && post_is_uvar)
       then T.fail "gen_elim_prop_placeholder is already solved";
-      let enable_nondep_opt = enable_nondep_opt_tm `T.term_eq_old` (`true) in
+      let enable_nondep_opt = enable_nondep_opt_tm `T.lax_term_eq` (`true) in
       let i' = solve_gen_elim p in
       let j' = solve_gen_elim_nondep enable_nondep_opt i' in
       let norm_term = T.norm_term [delta_attr [(`%gen_elim_reduce)]; zeta; iota] in


### PR DESCRIPTION
This function has been deprecated for a while and should be removed. The old builtin term_eq had an interesting behavior of ignoring universe annotations and ascriptions, which Steel seem to rely on. F* added a new laxer term_eq function (https://github.com/FStarLang/FStar/pull/3936) that mimics this old behavior, but is completely implemented in userspace.